### PR TITLE
feat: add PendingDeprecationWarning for from_dataframe methods

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/client.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/client.py
@@ -163,6 +163,16 @@ _LIST_ROWS_FROM_QUERY_RESULTS_FIELDS = "jobReference,totalRows,pageToken,rows"
 # https://github.com/googleapis/python-bigquery/issues/438
 _MIN_GET_QUERY_RESULTS_TIMEOUT = 120
 
+_LOAD_TABLE_FROM_DATAFRAME_DEPRECATED = (
+    "Loading DataFrames via google-cloud-bigquery is deprecated. "
+    "For direct, optimized loading, please call 'pandas_gbq.to_gbq()' directly."
+)
+
+_INSERT_ROWS_FROM_DATAFRAME_DEPRECATED = (
+    "Inserting rows from DataFrames via google-cloud-bigquery is deprecated. "
+    "For direct, optimized access, please call 'pandas_gbq.to_gbq()' directly."
+)
+
 TIMEOUT_HEADER = "X-Server-Timeout"
 
 
@@ -2830,6 +2840,12 @@ class Client(ClientWithProject):
                 If ``job_config`` is not an instance of
                 :class:`~google.cloud.bigquery.job.LoadJobConfig` class.
         """
+        warnings.warn(
+            _LOAD_TABLE_FROM_DATAFRAME_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
         job_id = _make_job_id(job_id, job_id_prefix)
 
         if job_config is not None:
@@ -3900,6 +3916,12 @@ class Client(ClientWithProject):
         Raises:
             ValueError: if table's schema is not set
         """
+        warnings.warn(
+            _INSERT_ROWS_FROM_DATAFRAME_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
         insert_results = []
 
         chunk_count = int(math.ceil(len(dataframe) / chunk_size))

--- a/packages/google-cloud-bigquery/tests/unit/test_client.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_client.py
@@ -6563,21 +6563,25 @@ class TestClient(unittest.TestCase):
         self.assertEqual(len(error_info), 1)
         assert error_info[0] == []  # no chunk errors
 
-        EXPECTED_SENT_DATA = {
-            "rows": [
-                {"insertId": None, "json": {"name": "Little One", "adult": "false"}},
-                {"insertId": None, "json": {"name": "Young Gun", "adult": "true"}},
-            ]
-        }
+    def test_insert_rows_from_dataframe_emits_pending_deprecation_warning(self):
+        pandas = pytest.importorskip("pandas")
+        from google.cloud.bigquery.schema import SchemaField
+        from google.cloud.bigquery.table import Table
 
-        actual_calls = conn.api_request.call_args_list
-        assert len(actual_calls) == 1
-        assert actual_calls[0] == mock.call(
-            method="POST",
-            path=API_PATH,
-            data=EXPECTED_SENT_DATA,
-            timeout=DEFAULT_TIMEOUT,
-        )
+        creds = _make_credentials()
+        http = object()
+        client = self._make_one(project=self.PROJECT, credentials=creds, _http=http)
+        client._connection = make_connection({}, {})
+
+        schema = [SchemaField("name", "STRING", mode="REQUIRED")]
+        table = Table(self.TABLE_REF, schema=schema)
+        dataframe = pandas.DataFrame([{"name": "Alice"}])
+
+        with pytest.warns(
+            PendingDeprecationWarning,
+            match="Inserting rows from DataFrames via google-cloud-bigquery is deprecated",
+        ):
+            client.insert_rows_from_dataframe(table, dataframe)
 
     def test_insert_rows_json_default_behavior(self):
         from google.cloud.bigquery.dataset import DatasetReference
@@ -6841,10 +6845,10 @@ class TestClient(unittest.TestCase):
             client.insert_rows_json(table, ROW)
 
     def test_insert_rows_json_w_ssl_error(self):
+        import requests.exceptions
         from google.cloud.bigquery.dataset import DatasetReference
         from google.cloud.bigquery.schema import SchemaField
         from google.cloud.bigquery.table import Table
-        import requests.exceptions
 
         PROJECT = "PROJECT"
         DS_ID = "DS_ID"
@@ -9389,6 +9393,29 @@ class TestClientUpload(object):
         assert tuple(sent_config.schema) == (
             SchemaField("x", "BIGNUMERIC", "NULLABLE", None),
         )
+
+    def test_load_table_from_dataframe_emits_pending_deprecation_warning(self):
+        pandas = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+
+        client = self._make_client()
+        dataframe = pandas.DataFrame({"x": [1, 2, 3]})
+
+        load_patch = mock.patch(
+            "google.cloud.bigquery.client.Client.load_table_from_file", autospec=True
+        )
+        get_table_patch = mock.patch(
+            "google.cloud.bigquery.client.Client.get_table", autospec=True
+        )
+        with (
+            load_patch,
+            get_table_patch,
+            pytest.warns(
+                PendingDeprecationWarning,
+                match="Loading DataFrames via google-cloud-bigquery is deprecated",
+            ),
+        ):
+            client.load_table_from_dataframe(dataframe, self.TABLE_REF)
 
     # With autodetect specified, we pass the value as is. For more info, see
     # https://github.com/googleapis/python-bigquery/issues/1228#issuecomment-1910946297


### PR DESCRIPTION
Adds `PendingDeprecationWarning` to `Client.load_table_from_dataframe()` and `Client.insert_rows_from_dataframe()`.

Guides developers toward direct `pandas_gbq.to_gbq()` APIs as part of the `pandas-gbq` backend consolidation.



Fixes #<526614511>🦕