### PR TITLE
fix(generator): switch core_deps_from_source to DEFAULT_PYTHON_VERSION

### DIFF
--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -133,7 +133,7 @@ jobs:
           pip install nox
           cd packages/gapic-generator
           for pkg in credentials eventarc logging redis; do
-            nox -f tests/integration/goldens/$pkg/noxfile.py -s format lint unit-${LATEST_STABLE_PYTHON}
+            nox -f tests/integration/goldens/$pkg/noxfile.py -s format lint unit-${LATEST_STABLE_PYTHON} core_deps_from_source
           done
       # Run pylint (errors-only) over the goldens so generator regressions
       # like undefined names or import-time breakage that ruff/flake8 do
@@ -171,7 +171,7 @@ jobs:
           pip install nox
           cd packages/gapic-generator
           for pkg in credentials eventarc logging redis; do
-            nox -f tests/integration/goldens/$pkg/noxfile.py -s core_deps_from_source prerelease_deps
+            nox -f tests/integration/goldens/$pkg/noxfile.py -s prerelease_deps
           done
 
   fragment-snippet:

--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -154,10 +154,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Set up Python ${{ needs.python_config.outputs.prerelease_python }}
+      - name: Set up Python ${{ needs.python_config.outputs.latest_stable_python }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: ${{ needs.python_config.outputs.prerelease_python }}
+          python-version: ${{ needs.python_config.outputs.latest_stable_python }}
           allow-prereleases: true
           # Caches compiled wheels locally to prevent building heavy libraries 
           # such as grpcio, which we build from scratch on every run for Python 3.15+.

--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -154,10 +154,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Set up Python ${{ needs.python_config.outputs.latest_stable_python }}
+      - name: Set up Python ${{ needs.python_config.outputs.prerelease_python }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: ${{ needs.python_config.outputs.latest_stable_python }}
+          python-version: ${{ needs.python_config.outputs.prerelease_python }}
           allow-prereleases: true
           # Caches compiled wheels locally to prevent building heavy libraries 
           # such as grpcio, which we build from scratch on every run for Python 3.15+.

--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -457,7 +457,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -457,7 +457,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -572,7 +572,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python=PREVIEW_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -449,7 +449,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],
@@ -564,7 +564,7 @@ def prerelease_deps(session, protobuf_implementation):
     )
 
 
-@nox.session(python=PREVIEW_PYTHON_VERSION)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb"],


### PR DESCRIPTION
Update `core_deps_from_source` nox sessions in the noxfile template and integration test goldens to run on `DEFAULT_PYTHON_VERSION` instead of `PREVIEW_PYTHON_VERSION`. Running against unreleased preview Python versions causes CI failures due to missing prebuilt wheels on PyPI for third-party dependencies.