### PR TITLE
fix(automl): remove unused libcst extra and constraints

### DIFF
--- a/.librarian/generator-input/client-post-processing/integrate-isolated-handwritten-code.yaml
+++ b/.librarian/generator-input/client-post-processing/integrate-isolated-handwritten-code.yaml
@@ -198,7 +198,6 @@ replacements:
     before: extras = \{\}
     after: |
       extras = {
-          "libcst": "libcst >= 0.2.5",
           "pandas": ["pandas>=1.3.4"],
           "storage": [
             "google-cloud-storage >=2.14.0, <4.0.0",
@@ -215,7 +214,6 @@ replacements:
     after: |
       google-api-core==2.25.0
       google-cloud-storage==2.14.0
-      libcst==0.2.5
       pandas==1.3.4
       # numpy is a dependency of pandas
       numpy==1.21.3

--- a/packages/google-cloud-automl/setup.py
+++ b/packages/google-cloud-automl/setup.py
@@ -52,7 +52,6 @@ dependencies = [
     "protobuf >= 6.33.5, < 8.0.0",
 ]
 extras = {
-    "libcst": "libcst >= 0.2.5",
     "pandas": ["pandas>=1.3.4"],
     "storage": [
         "google-cloud-storage >=2.14.0, <4.0.0",

--- a/packages/google-cloud-automl/testing/constraints-3.10.txt
+++ b/packages/google-cloud-automl/testing/constraints-3.10.txt
@@ -6,7 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.25.0
 google-cloud-storage==2.14.0
-libcst==0.2.5
 pandas==1.3.4
 # numpy is a dependency of pandas
 numpy==1.21.3


### PR DESCRIPTION
`libcst` was historically included in `google-cloud-automl` extras and testing constraints, but is not imported or used anywhere in the package or test suite.
During pre-release / core dependencies testing on newer Python versions, `pip` attempts to build `libcst` from source, which fails due to the missing Rust toolchain in CI build environments.

Googlers, see: https://fusion2.corp.google.com/ci;prev=s/kokoro/prod:cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fgoogle-cloud-python%2Fcontinuous%2Fcore_deps/activity/5b360144-9a17-4e4a-844b-deba86b165f7/log?q=google-cloud-python&s=p