### PR TITLE
feat: bump gapic-generator to v1.38.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -24,7 +24,7 @@ tools:
       version: 23.7.0
       package: black[jupyter]==23.7.0
     - name: gapic-generator
-      version: 1.37.1
+      version: 1.38.0
     - name: isort
       version: 5.11.0
     - name: nox


### PR DESCRIPTION
## Description
- Bumps `gapic-generator` version to `1.38.0` in `librarian.yaml`.

Regenerates all packages and preview-packages with `gapic-generator` v1.38.0 via `librarian generate --all`.

### Steps to Reproduce the Full Regeneration Diff

#### 1. Prerequisites & Environment Setup
Ensure Go, Python 3.11+, and `protoc` (`libprotoc 33.1` / `33.5`) are installed and available in your `$PATH`:

```bash
# Verify protoc version
protoc --version

# Create and activate a Python virtual environment
python3 -m venv .venv
source .venv/bin/activate

# Install synthtool in the environment
pip install synthtool
```

#### 2. Clean Locks, Synthtool Cache, & Export Template Directory
Synthtool caches templates locally under `~/.cache/synthtool/synthtool`. Clear any stale locks, ensure a clean template clone, and export the template path:

```bash
# Remove any stale git locks if present
rm -f .git/index.lock
rm -f "$HOME/.cache/synthtool/synthtool/.git/index.lock"

# Clean existing synthtool cache
rm -rf "$HOME/.cache/synthtool/synthtool"

# Clone the latest synthtool repository
git clone https://github.com/googleapis/synthtool.git "$HOME/.cache/synthtool/synthtool"

# Export the templates path required by synthtool
export SYNTHTOOL_TEMPLATES="$HOME/.cache/synthtool/synthtool/synthtool/gcp/templates"
```

#### 3. Clean Stale Workspace Artifacts
Remove any temporary build/staging directories left over from previous runs:

```bash
rm -rf packages/*/tmp preview-packages/*/tmp
```

#### 4. Install Dependencies via Librarian
Install the exact tool versions specified in `librarian.yaml` (including `gapic-generator 1.38.0`, formatters, and linters):

```bash
go run github.com/googleapis/librarian/cmd/librarian@v0.31.0 install
```

#### 5. Run Librarian Generation
Run librarian to regenerate all packages across the repository:

```bash
go run github.com/googleapis/librarian/cmd/librarian@v0.31.0 generate --all
```

#### 6. Post-Generation Cleanup
Remove temporary staging artifacts:

```bash
rm -rf packages/*/tmp preview-packages/*/tmp
```

*Note: updates to post-processing scripts in a separate PR stacked on top of this one.*