### PR TITLE
fix(storage): resume bidi reads after idle-stream aborts

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/async_multi_range_downloader.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/async_multi_range_downloader.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from google.api_core import exceptions
 from google.api_core.retry_async import AsyncRetry
-from google.rpc import status_pb2
 
 from google.cloud import _storage_v2
 from google.cloud.storage._helpers import generate_random_56_bit_integer
@@ -49,51 +48,34 @@ from google.cloud.storage.exceptions import DataCorruption
 from ._utils import raise_if_no_fast_crc32c
 
 _MAX_READ_RANGES_PER_BIDI_READ_REQUEST = 100
-_BIDI_READ_REDIRECTED_TYPE_URL = (
-    "type.googleapis.com/google.storage.v2.BidiReadObjectRedirectedError"
+_COMMON_READ_RETRYABLE_EXCEPTIONS = (
+    exceptions.InternalServerError,
+    exceptions.ServiceUnavailable,
+    exceptions.DeadlineExceeded,
+    exceptions.TooManyRequests,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def _is_read_retryable(exc):
-    """Predicate to determine if a read operation should be retried."""
-    if isinstance(
-        exc,
-        (
-            exceptions.InternalServerError,
-            exceptions.ServiceUnavailable,
-            exceptions.DeadlineExceeded,
-            exceptions.TooManyRequests,
-        ),
-    ):
+def _is_open_retryable(exc):
+    """Determine whether opening a read stream should be retried."""
+    if isinstance(exc, _COMMON_READ_RETRYABLE_EXCEPTIONS):
         return True
 
-    if not isinstance(exc, exceptions.Aborted) or not exc.errors:
+    if not isinstance(exc, exceptions.Aborted):
         return False
 
-    try:
-        grpc_error = exc.errors[0]
-        trailers = grpc_error.trailing_metadata()
-        if not trailers:
-            return False
+    routing_token, read_handle = _handle_redirect(exc)
+    return routing_token is not None or read_handle is not None
 
-        status_details_bin = next(
-            (v for k, v in trailers if k == "grpc-status-details-bin"), None
-        )
 
-        if not status_details_bin:
-            return False
-
-        status_proto = status_pb2.Status()
-        status_proto.ParseFromString(status_details_bin)
-        return any(
-            detail.type_url == _BIDI_READ_REDIRECTED_TYPE_URL
-            for detail in status_proto.details
-        )
-    except Exception as e:
-        logger.error(f"Error parsing status_details_bin: {e}")
-        return False
+def _is_read_retryable(exc):
+    """Determine whether an active read stream should be retried."""
+    return isinstance(
+        exc,
+        _COMMON_READ_RETRYABLE_EXCEPTIONS + (exceptions.Aborted,),
+    )
 
 
 class AsyncMultiRangeDownloader:
@@ -269,7 +251,7 @@ class AsyncMultiRangeDownloader:
                 self._on_open_error(exc)
 
             retry_policy = AsyncRetry(
-                predicate=_is_read_retryable, on_error=on_error_wrapper
+                predicate=_is_open_retryable, on_error=on_error_wrapper
             )
         else:
             original_on_error = retry_policy._on_error
@@ -281,7 +263,7 @@ class AsyncMultiRangeDownloader:
                     original_on_error(exc)
 
             retry_policy = AsyncRetry(
-                predicate=_is_read_retryable,
+                predicate=_is_open_retryable,
                 initial=retry_policy._initial,
                 maximum=retry_policy._maximum,
                 multiplier=retry_policy._multiplier,

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -20,6 +20,8 @@ from unittest.mock import AsyncMock
 import google_crc32c
 import pytest
 from google.api_core import exceptions
+from google.rpc import error_details_pb2
+from google.rpc import status_pb2
 
 from google.cloud import _storage_v2
 from google.cloud.storage.asyncio import async_read_object_stream
@@ -503,6 +505,48 @@ class TestAsyncMultiRangeDownloader:
         on_error(ValueError("test"))
         assert mrd._open_retries == 1
 
+    @mock.patch("google.cloud.storage.asyncio.async_multi_range_downloader.AsyncRetry")
+    @mock.patch(
+        "google.cloud.storage.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
+    )
+    @pytest.mark.asyncio
+    async def test_open_uses_redirect_aware_retry_predicate(
+        self, mock_cls_async_read_object_stream, mock_async_retry
+    ):
+        mock_policy = mock.MagicMock()
+        mock_policy.side_effect = lambda f: f
+        mock_async_retry.return_value = mock_policy
+
+        mock_client = mock.MagicMock()
+        mock_client.grpc_client = mock.AsyncMock()
+        mock_stream = mock_cls_async_read_object_stream.return_value
+        mock_stream.open = AsyncMock()
+
+        mrd = AsyncMultiRangeDownloader(
+            mock_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
+        )
+        await mrd.open()
+
+        predicate = mock_async_retry.call_args.kwargs["predicate"]
+        redirect = _storage_v2.BidiReadObjectRedirectedError(
+            routing_token="redirect-token"
+        )
+        status = status_pb2.Status()
+        detail = status.details.add()
+        detail.type_url = (
+            "type.googleapis.com/google.storage.v2.BidiReadObjectRedirectedError"
+        )
+        detail.value = _storage_v2.BidiReadObjectRedirectedError.serialize(redirect)
+        grpc_error = mock.MagicMock()
+        grpc_error.trailing_metadata.return_value = [
+            ("grpc-status-details-bin", status.SerializeToString())
+        ]
+
+        assert predicate(exceptions.ServiceUnavailable("unavailable")) is True
+        assert predicate(exceptions.Aborted("redirect", errors=[grpc_error])) is True
+        assert predicate(exceptions.Aborted("bare aborted")) is False
+        assert predicate(ConnectionResetError("connection reset")) is False
+
     @mock.patch("google.cloud.storage.asyncio.async_multi_range_downloader.logger")
     @pytest.mark.asyncio
     async def test_on_open_error_logs_warning(self, mock_logger):
@@ -707,3 +751,115 @@ class TestAsyncMultiRangeDownloader:
             await mrd.download_ranges([(0, 0, BytesIO())])
 
         mrd.close.assert_called_once()
+
+    @mock.patch(
+        "google.cloud.storage.asyncio.async_multi_range_downloader.generate_random_56_bit_integer"
+    )
+    @mock.patch(
+        "google.cloud.storage.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
+    )
+    @pytest.mark.asyncio
+    async def test_download_ranges_retries_on_aborted_idle_stream_from_recv(
+        self, mock_cls_async_read_object_stream, mock_random_int
+    ):
+        mock_client = mock.MagicMock()
+        mock_client.grpc_client = mock.AsyncMock()
+
+        initial_stream = mock.MagicMock()
+        initial_stream.open = AsyncMock()
+        initial_stream.close = AsyncMock()
+        initial_stream.send = AsyncMock()
+        initial_stream.generation_number = _TEST_GENERATION_NUMBER
+        initial_stream.persisted_size = _TEST_OBJECT_SIZE
+        initial_stream.read_handle = _TEST_READ_HANDLE
+        initial_stream.is_finalized = True
+        initial_stream.full_obj_server_crc32c = None
+        initial_stream.is_stream_open = True
+
+        replacement_stream = mock.MagicMock()
+        replacement_stream.open = AsyncMock()
+        replacement_stream.close = AsyncMock()
+        replacement_stream.send = AsyncMock()
+        replacement_stream.generation_number = _TEST_GENERATION_NUMBER
+        replacement_stream.persisted_size = _TEST_OBJECT_SIZE
+        replacement_stream.read_handle = _TEST_READ_HANDLE
+        replacement_stream.is_finalized = True
+        replacement_stream.full_obj_server_crc32c = None
+        replacement_stream.is_stream_open = True
+
+        mock_cls_async_read_object_stream.side_effect = [
+            initial_stream,
+            replacement_stream,
+        ]
+
+        error_info = error_details_pb2.ErrorInfo(
+            reason="GRPC_REQUEST_TIMEOUT",
+            domain="storage.googleapis.com",
+        )
+        initial_stream.recv = AsyncMock(
+            side_effect=exceptions.Aborted(
+                "Idle stream has been closed.",
+                details=[error_info],
+                error_info=error_info,
+            )
+        )
+
+        response = _storage_v2.BidiReadObjectResponse(
+            object_data_ranges=[
+                _storage_v2.ObjectRangeData(
+                    checksummed_data=_storage_v2.ChecksummedData(
+                        content=b"data", crc32c=google_crc32c.value(b"data")
+                    ),
+                    range_end=True,
+                    read_range=_storage_v2.ReadRange(
+                        read_offset=0, read_length=4, read_id=123
+                    ),
+                )
+            ]
+        )
+        replacement_stream.recv = AsyncMock(side_effect=[response])
+        mock_random_int.return_value = 123
+
+        mrd = await AsyncMultiRangeDownloader.create_mrd(
+            mock_client,
+            _TEST_BUCKET_NAME,
+            _TEST_OBJECT_NAME,
+            _TEST_GENERATION_NUMBER,
+            _TEST_READ_HANDLE,
+        )
+
+        buffer = BytesIO()
+        await mrd.download_ranges([(0, 4, buffer)])
+
+        assert buffer.getvalue() == b"data"
+        assert mock_cls_async_read_object_stream.call_count == 2
+        initial_stream.close.assert_awaited_once()
+        replacement_stream.open.assert_awaited_once()
+        replacement_stream.send.assert_awaited_once_with(
+            _storage_v2.BidiReadObjectRequest(
+                read_ranges=[
+                    _storage_v2.ReadRange(read_offset=0, read_length=4, read_id=123)
+                ]
+            )
+        )
+
+    def test_is_read_retryable_predicate(self):
+        """Tests that _is_read_retryable correctly classifies retryable read errors."""
+        from google.cloud.storage.asyncio.async_multi_range_downloader import (
+            _is_read_retryable,
+        )
+
+        # Retryable exceptions
+        assert _is_read_retryable(exceptions.Aborted("Idle stream closed")) is True
+        assert _is_read_retryable(exceptions.ServiceUnavailable("unavailable")) is True
+        assert _is_read_retryable(exceptions.InternalServerError("internal")) is True
+        assert _is_read_retryable(exceptions.DeadlineExceeded("timeout")) is True
+        assert _is_read_retryable(exceptions.TooManyRequests("quota")) is True
+        assert _is_read_retryable(ConnectionResetError("connection reset")) is False
+        assert _is_read_retryable(BrokenPipeError("broken pipe")) is False
+
+        # Non-retryable exceptions
+        assert _is_read_retryable(ValueError("invalid")) is False
+        assert _is_read_retryable(exceptions.NotFound("not found")) is False
+        assert _is_read_retryable(exceptions.PermissionDenied("denied")) is False
+        assert _is_read_retryable(exceptions.InvalidArgument("invalid")) is False


### PR DESCRIPTION
Retry ABORTED errors while resuming active multi-range reads, while keeping initial stream opens limited to transient and redirect errors. Do not retry local sink connection failures, and cover production redirect trailers and idle-stream recovery.

Fixes #<b/544515338> 🦕

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕