### PR TITLE
fix: use lowercase x-goog-api-client header

### DIFF
--- a/packages/google-cloud-core/google/cloud/_http/__init__.py
+++ b/packages/google-cloud-core/google/cloud/_http/__init__.py
@@ -34,7 +34,7 @@ API_BASE_URL = "https://www.googleapis.com"
 DEFAULT_USER_AGENT = "gcloud-python/{0}".format(version.__version__)
 """The user agent for google-cloud-python requests."""
 
-CLIENT_INFO_HEADER = "X-Goog-API-Client"
+CLIENT_INFO_HEADER = "x-goog-api-client"
 CLIENT_INFO_TEMPLATE = "gl-python/" + platform.python_version() + " gccl/{}"
 
 _USER_AGENT_ALL_CAPS_DEPRECATED = """\

--- a/packages/google-cloud-storage/google/cloud/storage/_helpers.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_helpers.py
@@ -767,7 +767,7 @@ def _get_default_headers(
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "User-Agent": user_agent,
-        "X-Goog-API-Client": x_goog_api_client,
+        "x-goog-api-client": x_goog_api_client,
         "content-type": content_type,
         "x-upload-content-type": x_upload_content_type or content_type,
     }

--- a/packages/google-cloud-storage/tests/unit/test_blob.py
+++ b/packages/google-cloud-storage/tests/unit/test_blob.py
@@ -2688,7 +2688,7 @@ class Test_Blob(unittest.TestCase):
                 **custom_headers,
             }
         self.assertEqual(
-            headers["X-Goog-API-Client"],
+            headers["x-goog-api-client"],
             f"{client._connection.user_agent} {GCCL_INVOCATION_TEST_CONST} gccl-gcs-cmd/{COMMAND}",
         )
         self.assertEqual(headers, expected_headers)

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -2169,8 +2169,8 @@ class TestClient(unittest.TestCase):
         client.download_blob_to_file(blob, file_obj)
 
         self.assertNotEqual(
-            blob._do_download.call_args_list[0][0][3]["X-Goog-API-Client"],
-            blob._do_download.call_args_list[1][0][3]["X-Goog-API-Client"],
+            blob._do_download.call_args_list[0][0][3]["x-goog-api-client"],
+            blob._do_download.call_args_list[1][0][3]["x-goog-api-client"],
         )
 
     def test_list_blobs_w_defaults_w_bucket_obj(self):

--- a/packages/google-cloud-storage/tests/unit/test_transfer_manager.py
+++ b/packages/google-cloud-storage/tests/unit/test_transfer_manager.py
@@ -1218,7 +1218,7 @@ def test_upload_chunks_concurrently_with_metadata_and_encryption():
             "Accept": "application/json",
             "Accept-Encoding": "gzip, deflate",
             "User-Agent": "agent",
-            "X-Goog-API-Client": f"agent gccl-invocation-id/{invocation_id} gccl-gcs-cmd/tm.upload_sharded",
+            "x-goog-api-client": f"agent gccl-invocation-id/{invocation_id} gccl-gcs-cmd/tm.upload_sharded",
             "content-type": FAKE_CONTENT_TYPE,
             "x-upload-content-type": FAKE_CONTENT_TYPE,
             "X-Goog-Encryption-Algorithm": "AES256",


### PR DESCRIPTION
Use lowercase 'x-goog-api-client' header key to ensure compatibility with google-auth library's metric tracking.

BUG=b/477154133
TAG=agy
CONV=2f25336d-e8f9-413f-8292-73b7a55c1d81