### PR TITLE
chore(automl): mock AutoMlClient in test_predicition_client_client_info

### DIFF
--- a/packages/google-cloud-automl/tests/unit/test_tables_client_v1beta1.py
+++ b/packages/google-cloud-automl/tests/unit/test_tables_client_v1beta1.py
@@ -1716,12 +1716,14 @@ class TestTablesClient(object):
     def test_prediction_client_client_info(self):
         credentials_mock = mock.Mock()
         client_info_mock = mock.Mock()
+        client_mock = mock.Mock()
         patch_prediction_client = mock.patch(
             "google.cloud.automl_v1beta1.services.tables.tables_client.PredictionServiceClient"
         )
         with patch_prediction_client as MockPredictionClient:
             automl_v1beta1.TablesClient(
                 credentials=credentials_mock,
+                client=client_mock,
                 client_info=client_info_mock,
             )
         _, prediction_client_kwargs = MockPredictionClient.call_args


### PR DESCRIPTION
Following https://github.com/googleapis/google-cloud-python/pull/17616, `google-api-core` extracts and deduplicates the `x-goog-api-client` metrics header during callable construction in `_GapicCallable.__init__` (`_extract_metrics_header`). Because `AutoMlClient` was not mocked in this test, passing `client_info=mock.Mock()` caused `AutoMlClient`'s transport wrapper to attempt unpacking the mock metadata into `(key, value)` pairs, resulting in:
```text
TypeError: cannot unpack non-iterable Mock object