### PR TITLE
feat(auth): add deprecation warning for grpcio < 1.83.0 (PQC support)

### DIFF
--- a/packages/google-auth/google/auth/transport/grpc.py
+++ b/packages/google-auth/google/auth/transport/grpc.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import logging
+import warnings
 
 from google.auth import exceptions
 from google.auth.transport import _mtls_helper
@@ -29,6 +30,26 @@ except ImportError as caught_exc:  # pragma: NO COVER
     raise ImportError(
         "gRPC is not installed from please install the grpcio package to use the gRPC transport."
     ) from caught_exc
+
+
+_grpc_ver_str = getattr(grpc, "__version__", None)
+if isinstance(_grpc_ver_str, str):
+    _parts = []
+    for _part in _grpc_ver_str.split("."):
+        try:
+            _parts.append(int(_part))
+        except ValueError:
+            break
+    if _parts and tuple(_parts) < (1, 83, 0):
+        warnings.warn(
+            "grpcio < 1.83.0 does not support Post-Quantum Cryptography (PQC). "
+            "Support for non-PQC environments is deprecated. In October 2026, "
+            "google-auth will raise its minimum requirements "
+            "to enforce grpcio >= 1.83.0. "
+            "For more details on Google Cloud's post-quantum security migration, visit: "
+            "https://cloud.google.com/security/resources/post-quantum-cryptography",
+            FutureWarning,
+        )
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/packages/google-auth/tests/transport/test_grpc.py
+++ b/packages/google-auth/tests/transport/test_grpc.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import datetime
+import importlib
 import os
 import time
 from unittest import mock
+import warnings
 
 import pytest  # type: ignore
 
@@ -678,3 +680,25 @@ class TestSslCredentials(object):
         mock_ssl_channel_credentials.assert_called_once_with(
             certificate_chain=PUBLIC_CERT_BYTES, private_key=PRIVATE_KEY_BYTES
         )
+
+
+def test_grpc_version_warning_for_older_version(monkeypatch):
+    monkeypatch.setattr(grpc, "__version__", "1.80.0")
+    with pytest.warns(
+        FutureWarning, match="does not support Post-Quantum Cryptography"
+    ):
+        importlib.reload(google.auth.transport.grpc)
+
+
+def test_grpc_version_warning_not_emitted_for_supported_version(monkeypatch):
+    monkeypatch.setattr(grpc, "__version__", "1.83.0")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        importlib.reload(google.auth.transport.grpc)
+
+
+def test_grpc_version_warning_not_emitted_when_no_version(monkeypatch):
+    monkeypatch.delattr(grpc, "__version__", raising=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        importlib.reload(google.auth.transport.grpc)


### PR DESCRIPTION
Emits a deprecation `FutureWarning` when `google.auth.transport.grpc` is imported with `grpcio < 1.83.0`.
In October 2026, Google Cloud client libraries (including `google-auth`) will raise minimum requirements to enforce `grpcio >= 1.83.0` for Post-Quantum Cryptography (PQC) support.

Towards: b/537446703