### PR TITLE
feat: check python and dependency versions in bigquery and ndb

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/__init__.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/__init__.py
@@ -30,6 +30,8 @@ The main concepts with this API are:
 import sys
 import warnings
 
+import google.api_core as api_core
+
 from google.cloud.bigquery import version as bigquery_version
 
 __version__ = bigquery_version.__version__
@@ -131,6 +133,9 @@ if sys.version_info < (3, 10):  # pragma: NO COVER
         "more details, see: [Google Cloud Client Libraries Supported Python Versions policy](https://cloud.google.com/python/docs/supported-python-versions)",
         FutureWarning,
     )
+
+api_core.check_python_version(__name__)
+api_core.check_dependency_versions(__name__)
 
 __all__ = [
     "__version__",

--- a/packages/google-cloud-ndb/google/cloud/ndb/__init__.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/__init__.py
@@ -21,6 +21,8 @@ version of the ``db`` API (hence ``ndb``).
 .. autodata:: __all__
 """
 
+import google.api_core as api_core
+
 from google.cloud.ndb import version
 
 __version__: str = version.__version__
@@ -134,6 +136,9 @@ from google.cloud.ndb.tasklets import (
     wait_all,
     wait_any,
 )
+
+api_core.check_python_version(__name__)
+api_core.check_dependency_versions(__name__)
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Adds `check_python_version(__name__)` and `check_dependency_versions(__name__)` to `google.cloud.bigquery` and `google.cloud.ndb` at package import time.
This establishes parity with the standard GAPIC-generated packages across the repository and ensures deprecation notices (such as Python version deprecations and upcoming `grpcio >= 1.83.0` PQC requirements) are consistently emitted when these packages are imported.

Towards: b/537446703