### PR TITLE
fix(auth): restore pyOpenSSL for ECP offload flow

### DIFF
--- a/packages/google-auth/google/auth/transport/_custom_tls_signer.py
+++ b/packages/google-auth/google/auth/transport/_custom_tls_signer.py
@@ -46,6 +46,18 @@ SIGN_CALLBACK_CTYPE = ctypes.CFUNCTYPE(
 
 
 # Cast SSL_CTX* to void*
+def _cast_ssl_ctx_to_void_p_pyopenssl(ssl_ctx):
+    try:
+        import cffi
+    except ImportError as caught_exc:
+        raise exceptions.MutualTLSChannelError(
+            "cffi is required for pyOpenSSL ECP support."
+        ) from caught_exc
+
+    return ctypes.cast(int(cffi.FFI().cast("intptr_t", ssl_ctx)), ctypes.c_void_p)
+
+
+# Cast SSL_CTX* to void*
 def _cast_ssl_ctx_to_void_p_stdlib(context):
     if not issubclass(type(context), ssl.SSLContext):
         raise TypeError("context must be an instance of ssl.SSLContext, not a mock")
@@ -281,7 +293,7 @@ class CustomTlsSigner(object):
             if not self._offload_lib.ConfigureSslContext(
                 self._sign_callback,
                 ctypes.c_char_p(self._cert),
-                _cast_ssl_ctx_to_void_p_stdlib(ctx),
+                _cast_ssl_ctx_to_void_p_pyopenssl(ctx._ctx._context),
             ):
                 raise exceptions.MutualTLSChannelError(
                     "failed to configure ECP Offload SSL context"

--- a/packages/google-auth/google/auth/transport/requests.py
+++ b/packages/google-auth/google/auth/transport/requests.py
@@ -278,7 +278,7 @@ class _MutualTlsOffloadAdapter(requests.adapters.HTTPAdapter):
                 }
 
     Raises:
-        ImportError: if certifi is not installed
+        ImportError: if certifi or pyOpenSSL is not installed
         google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
             creation failed for any reason.
     """
@@ -289,6 +289,11 @@ class _MutualTlsOffloadAdapter(requests.adapters.HTTPAdapter):
 
         self.signer = _custom_tls_signer.CustomTlsSigner(enterprise_cert_file_path)
         self.signer.load_libraries()
+
+        if not self.signer.should_use_provider():
+            import urllib3.contrib.pyopenssl
+
+            urllib3.contrib.pyopenssl.inject_into_urllib3()
 
         poolmanager = create_urllib3_context()
         poolmanager.load_verify_locations(cafile=certifi.where())

--- a/packages/google-auth/google/auth/transport/requests.py
+++ b/packages/google-auth/google/auth/transport/requests.py
@@ -478,7 +478,7 @@ class AuthorizedSession(requests.Session):
                 creation failed for any reason. The existing session state (such
                 as adapter mounts) remains unmodified if this error is raised.
         """
-        use_client_cert = google.auth.transport._mtls_helper.check_use_client_cert()
+        use_client_cert = _mtls_helper.check_use_client_cert()
         if not use_client_cert:
             return
 
@@ -487,9 +487,7 @@ class AuthorizedSession(requests.Session):
                 is_mtls,
                 cert,
                 key,
-            ) = google.auth.transport._mtls_helper.get_client_cert_and_key(
-                client_cert_callback
-            )
+            ) = _mtls_helper.get_client_cert_and_key(client_cert_callback)
 
             old_adapter = self.adapters.get("https://")
 

--- a/packages/google-auth/google/auth/transport/requests.py
+++ b/packages/google-auth/google/auth/transport/requests.py
@@ -39,8 +39,14 @@ from google.auth import _helpers
 from google.auth import exceptions
 from google.auth import transport
 from google.auth.transport import _mtls_helper
-import google.auth.transport._mtls_helper
 from google.oauth2 import service_account
+
+try:
+    import OpenSSL.SSL  # type: ignore
+
+    _OPENSSL_SSL_ERROR = (OpenSSL.SSL.Error,)
+except ImportError:
+    _OPENSSL_SSL_ERROR = ()  # type: ignore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -242,7 +248,7 @@ class _MutualTlsAdapter(requests.adapters.HTTPAdapter):
             ValueError,
             RuntimeError,
             TypeError,
-        ) as exc:
+        ) + _OPENSSL_SSL_ERROR as exc:
             raise exceptions.MutualTLSChannelError(
                 "Failed to configure client certificate and key for mTLS."
             ) from exc
@@ -542,7 +548,7 @@ class AuthorizedSession(requests.Session):
             ImportError,
             OSError,
             ValueError,
-        ) as caught_exc:
+        ) + _OPENSSL_SSL_ERROR as caught_exc:
             new_exc = exceptions.MutualTLSChannelError(caught_exc)
             raise new_exc from caught_exc
 

--- a/packages/google-auth/google/auth/transport/urllib3.py
+++ b/packages/google-auth/google/auth/transport/urllib3.py
@@ -56,6 +56,13 @@ from google.auth import transport
 from google.auth.transport import _mtls_helper
 from google.oauth2 import service_account
 
+try:
+    import OpenSSL.SSL  # type: ignore
+
+    _OPENSSL_SSL_ERROR = (OpenSSL.SSL.Error,)
+except ImportError:
+    _OPENSSL_SSL_ERROR = ()  # type: ignore
+
 if version.parse(urllib3.__version__) >= version.parse("2.0.0"):  # pragma: NO COVER
     RequestMethods = urllib3._request_methods.RequestMethods  # type: ignore
 else:  # pragma: NO COVER
@@ -194,7 +201,14 @@ def _make_mutual_tls_http(cert, key):
                 keyfile=key_path,
                 password=password,
             )
-    except (ssl.SSLError, OSError, IOError, ValueError, RuntimeError, TypeError) as exc:
+    except (
+        ssl.SSLError,
+        OSError,
+        IOError,
+        ValueError,
+        RuntimeError,
+        TypeError,
+    ) + _OPENSSL_SSL_ERROR as exc:
         raise exceptions.MutualTLSChannelError(
             "Failed to configure client certificate and key for mTLS."
         ) from exc
@@ -368,7 +382,7 @@ class AuthorizedHttp(RequestMethods):  # type: ignore
             ImportError,
             OSError,
             ValueError,
-        ) as caught_exc:
+        ) + _OPENSSL_SSL_ERROR as caught_exc:
             new_exc = exceptions.MutualTLSChannelError(caught_exc)
             raise new_exc from caught_exc
 

--- a/packages/google-auth/noxfile.py
+++ b/packages/google-auth/noxfile.py
@@ -158,6 +158,7 @@ def mypy(session):
     session.install(
         "mypy",
         "types-certifi",
+        "types-cffi",
         "types-freezegun",
         "types-requests",
         "types-setuptools",

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -39,7 +39,7 @@ pyjwt_extra_require = ["pyjwt>=2.0"]
 
 reauth_extra_require = ["pyu2f>=0.1.5"]
 
-enterprise_cert_extra_require = cryptography_base_require
+enterprise_cert_extra_require = ["pyopenssl>=20.0.0", "cffi>=1.0.0"]
 
 urllib3_extra_require = [
     "urllib3 >= 1.26.15, < 3.0.0",
@@ -65,6 +65,7 @@ testing_extra_require = [
     *reauth_extra_require,
     "responses",
     *urllib3_extra_require,
+    *enterprise_cert_extra_require,
     # Async Dependencies
     *aiohttp_extra_require,
     "aioresponses",

--- a/packages/google-auth/tests/transport/test__custom_tls_signer.py
+++ b/packages/google-auth/tests/transport/test__custom_tls_signer.py
@@ -168,6 +168,9 @@ def test_get_cert():
 
 
 def test_custom_tls_signer():
+    urllib3_pyopenssl = pytest.importorskip("urllib3.contrib.pyopenssl")
+    urllib3_pyopenssl.inject_into_urllib3()
+
     offload_lib = mock.MagicMock()
     signer_lib = mock.MagicMock()
 
@@ -238,7 +241,9 @@ def test_custom_tls_signer_failed_to_attach():
         signer_object._sign_callback = mock.MagicMock()
         signer_object._cert = b"mock cert"
         signer_object._offload_lib.ConfigureSslContext.return_value = False
-        signer_object.attach_to_ssl_context(ssl.SSLContext())
+        ctx = mock.Mock()
+        ctx._ctx._context = 123456
+        signer_object.attach_to_ssl_context(ctx)
     assert excinfo.match("failed to configure ECP Offload SSL context")
 
 
@@ -366,3 +371,12 @@ def test_cast_ssl_ctx_to_void_p_stdlib_mock_error():
         TypeError, match="context must be an instance of ssl.SSLContext, not a mock"
     ):
         _custom_tls_signer._cast_ssl_ctx_to_void_p_stdlib(context)
+
+
+def test_cast_ssl_ctx_to_void_p_pyopenssl():
+    urllib3_pyopenssl = pytest.importorskip("urllib3.contrib.pyopenssl")
+    urllib3_pyopenssl.inject_into_urllib3()
+
+    context = create_urllib3_context()
+    res = _custom_tls_signer._cast_ssl_ctx_to_void_p_pyopenssl(context._ctx._context)
+    assert isinstance(res, ctypes.c_void_p)

--- a/packages/google-auth/tests/transport/test__custom_tls_signer.py
+++ b/packages/google-auth/tests/transport/test__custom_tls_signer.py
@@ -167,10 +167,15 @@ def test_get_cert():
     assert len(mock_cert) == mock_cert_len
 
 
-def test_custom_tls_signer():
+@pytest.fixture
+def inject_pyopenssl():
     urllib3_pyopenssl = pytest.importorskip("urllib3.contrib.pyopenssl")
     urllib3_pyopenssl.inject_into_urllib3()
+    yield
+    urllib3_pyopenssl.extract_from_urllib3()
 
+
+def test_custom_tls_signer(inject_pyopenssl):
     offload_lib = mock.MagicMock()
     signer_lib = mock.MagicMock()
 
@@ -373,10 +378,7 @@ def test_cast_ssl_ctx_to_void_p_stdlib_mock_error():
         _custom_tls_signer._cast_ssl_ctx_to_void_p_stdlib(context)
 
 
-def test_cast_ssl_ctx_to_void_p_pyopenssl():
-    urllib3_pyopenssl = pytest.importorskip("urllib3.contrib.pyopenssl")
-    urllib3_pyopenssl.inject_into_urllib3()
-
+def test_cast_ssl_ctx_to_void_p_pyopenssl(inject_pyopenssl):
     context = create_urllib3_context()
     res = _custom_tls_signer._cast_ssl_ctx_to_void_p_pyopenssl(context._ctx._context)
     assert isinstance(res, ctypes.c_void_p)

--- a/packages/google-auth/tests/transport/test_requests.py
+++ b/packages/google-auth/tests/transport/test_requests.py
@@ -694,8 +694,11 @@ class TestAuthorizedSession(object):
             "CLOUDSDK_CONTEXT_AWARE_CERTIFICATE_CONFIG_FILE_PATH": "",
         },
     )
+    @mock.patch(
+        "google.auth.transport._mtls_helper._get_cert_config_path", return_value=None
+    )
     def test_configure_mtls_channel_without_client_cert_env(
-        self, get_client_cert_and_key
+        self, mock_get_cert_config_path, get_client_cert_and_key
     ):
         env_to_patch = {
             environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "",
@@ -1063,6 +1066,16 @@ class TestAuthorizedSession(object):
 
 
 class TestMutualTlsOffloadAdapter(object):
+    @pytest.fixture(autouse=True)
+    def teardown_pyopenssl(self):
+        yield
+        try:
+            from urllib3.contrib.pyopenssl import extract_from_urllib3
+
+            extract_from_urllib3()
+        except ImportError:
+            pass
+
     @mock.patch.object(requests.adapters.HTTPAdapter, "init_poolmanager")
     @mock.patch.object(requests.adapters.HTTPAdapter, "proxy_manager_for")
     @mock.patch.object(

--- a/packages/google-auth/tests/transport/test_requests.py
+++ b/packages/google-auth/tests/transport/test_requests.py
@@ -1061,6 +1061,7 @@ class TestMutualTlsOffloadAdapter(object):
         mock_proxy_manager_for,
         mock_init_poolmanager,
     ):
+        pytest.importorskip("urllib3.contrib.pyopenssl")
         enterprise_cert_file_path = "/path/to/enterprise/cert/json"
         adapter = google.auth.transport.requests._MutualTlsOffloadAdapter(
             enterprise_cert_file_path

--- a/packages/google-auth/tests/transport/test_requests.py
+++ b/packages/google-auth/tests/transport/test_requests.py
@@ -203,6 +203,24 @@ class TestMutualTlsAdapter(object):
         assert "Failed to configure client certificate" in str(exc_info.value)
         assert isinstance(exc_info.value.__cause__, OSError)
 
+    @mock.patch("google.auth.transport.requests.create_urllib3_context")
+    def test_pyopenssl_error_raises_mtls_error(self, mock_create_context):
+        try:
+            import OpenSSL.SSL  # type: ignore
+        except ImportError:
+            pytest.skip("pyOpenSSL not installed")
+
+        mock_context = mock.MagicMock()
+        mock_context.load_cert_chain.side_effect = OpenSSL.SSL.Error(
+            "OpenSSL cert load failure"
+        )
+        mock_create_context.return_value = mock_context
+
+        with pytest.raises(exceptions.MutualTLSChannelError) as exc_info:
+            google.auth.transport.requests._MutualTlsAdapter(b"cert", b"key")
+        assert "Failed to configure client certificate" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, OpenSSL.SSL.Error)
+
 
 def make_response(status=http_client.OK, data=None):
     response = requests.Response()

--- a/packages/google-auth/tests/transport/test_urllib3.py
+++ b/packages/google-auth/tests/transport/test_urllib3.py
@@ -114,6 +114,27 @@ class TestMakeMutualTlsHttp(object):
         assert "Failed to configure client certificate" in str(exc_info.value)
         assert isinstance(exc_info.value.__cause__, OSError)
 
+    @mock.patch(
+        "google.auth.transport.urllib3.urllib3.util.ssl_.create_urllib3_context",
+        autospec=True,
+    )
+    def test_pyopenssl_error_raises_mtls_error(self, mock_create_context):
+        try:
+            import OpenSSL.SSL  # type: ignore
+        except ImportError:
+            pytest.skip("pyOpenSSL not installed")
+
+        mock_context = mock.MagicMock()
+        mock_context.load_cert_chain.side_effect = OpenSSL.SSL.Error(
+            "OpenSSL cert load failure"
+        )
+        mock_create_context.return_value = mock_context
+
+        with pytest.raises(exceptions.MutualTLSChannelError) as exc_info:
+            google.auth.transport.urllib3._make_mutual_tls_http(b"cert", b"key")
+        assert "Failed to configure client certificate" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, OpenSSL.SSL.Error)
+
 
 class TestAuthorizedHttp(object):
     TEST_URL = "http://example.com"

--- a/packages/google-auth/tests/transport/test_urllib3.py
+++ b/packages/google-auth/tests/transport/test_urllib3.py
@@ -418,8 +418,11 @@ class TestAuthorizedHttp(object):
             "CLOUDSDK_CONTEXT_AWARE_CERTIFICATE_CONFIG_FILE_PATH": "",
         },
     )
+    @mock.patch(
+        "google.auth.transport._mtls_helper._get_cert_config_path", return_value=None
+    )
     def test_configure_mtls_channel_without_client_cert_env(
-        self, get_client_cert_and_key
+        self, mock_get_cert_config_path, get_client_cert_and_key
     ):
         callback = mock.Mock()
 


### PR DESCRIPTION
Resolves an issue where Enterprise Certificate Proxy (ECP) offload failed with "failed to configure ECP Offload SSL context" after pyOpenSSL was removed in #16976.

The `tls_offload` C library requires a PyOpenSSL context pointer and does not support standard library CPython `ssl.SSLContext`. This change:
- Restores `_cast_ssl_ctx_to_void_p_pyopenssl` in `_custom_tls_signer.py` for the offload branch.
- Conditionally calls `urllib3.contrib.pyopenssl.inject_into_urllib3()` in `_MutualTlsOffloadAdapter` only when the offload flow is used, leaving the ECP Provider flow on standard library `ssl.SSLContext`.
- Restores `pyopenssl` and `cffi` in `enterprise_cert` extra requirements in `setup.py`.
- Updates unit tests

Fixes #17791 