### PR TITLE
tests(google-cloud-compute): subtle fix to compute system test test_zero_values

### DIFF
--- a/packages/google-cloud-compute/tests/system/test_smoke.py
+++ b/packages/google-cloud-compute/tests/system/test_smoke.py
@@ -80,9 +80,7 @@ class TestComputeSmoke(TestBase):
             self.client.get(instance=self.name, zone=0)
         self.assertIn(
             (
-                "0 has type int, but expected one of: bytes, unicode"
-                if PROTOBUF_VERSION[0] == "3"
-                else "('bad argument type for built-in operation',)"
+                "bad argument type for built-in operation"
             ),
             str(ex.exception.args),
         )

--- a/packages/google-cloud-compute/tests/system/test_smoke.py
+++ b/packages/google-cloud-compute/tests/system/test_smoke.py
@@ -79,9 +79,7 @@ class TestComputeSmoke(TestBase):
         with self.assertRaises(expected_exception=TypeError) as ex:
             self.client.get(instance=self.name, zone=0)
         self.assertIn(
-            (
-                "bad argument type for built-in operation"
-            ),
+            ("bad argument type for built-in operation"),
             str(ex.exception.args),
         )
 


### PR DESCRIPTION
`test_zero_values` is failing in newer environments because `proto-plus` now wraps underlying `TypeErrors` in a more descriptive error message `(e.g., "Failed to set field...")` following #17682. This broke our rigid assertion which was looking for the exact raw tuple representation `('bad argument type for built-in operation',)`.

This PR updates the assertion to look for the core error substring instead, making the test robust to exception wrapping.