### PR TITLE
fix(ml): isolate temporary model names in LLM system tests

### DIFF
--- a/packages/bigframes/tests/system/large/ml/test_llm.py
+++ b/packages/bigframes/tests/system/large/ml/test_llm.py
@@ -43,11 +43,11 @@ def test_create_load_gemini_text_generator_model(
     assert gemini_text_generator_model._bqml_model is not None
 
     # save, load to ensure configuration was kept
-    sanitized_model_name = model_name.replace("-", "_").replace(".", "_").replace("@", "_")
-    target_model_name = f"{dataset_id}.temp_gemini_text_model_{sanitized_model_name}"
-    reloaded_model = gemini_text_generator_model.to_gbq(
-        target_model_name, replace=True
+    sanitized_model_name = (
+        model_name.replace("-", "_").replace(".", "_").replace("@", "_")
     )
+    target_model_name = f"{dataset_id}.temp_gemini_text_model_{sanitized_model_name}"
+    reloaded_model = gemini_text_generator_model.to_gbq(target_model_name, replace=True)
     assert target_model_name == reloaded_model._bqml_model.model_name
     assert reloaded_model.connection_name == bq_connection
     assert reloaded_model.model_name == model_name
@@ -237,10 +237,10 @@ def test_create_load_text_embedding_generator_model(
     assert text_embedding_model._bqml_model is not None
 
     # save, load to ensure configuration was kept
-    sanitized_model_name = model_name.replace("-", "_").replace(".", "_").replace("@", "_")
-    target_model_name = (
-        f"{dataset_id}.temp_text_embedding_model_{sanitized_model_name}"
+    sanitized_model_name = (
+        model_name.replace("-", "_").replace(".", "_").replace("@", "_")
     )
+    target_model_name = f"{dataset_id}.temp_text_embedding_model_{sanitized_model_name}"
     reloaded_model = text_embedding_model.to_gbq(target_model_name, replace=True)
     assert target_model_name == reloaded_model._bqml_model.model_name
     assert reloaded_model.connection_name == bq_connection

--- a/packages/bigframes/tests/system/large/ml/test_llm.py
+++ b/packages/bigframes/tests/system/large/ml/test_llm.py
@@ -43,7 +43,7 @@ def test_create_load_gemini_text_generator_model(
     assert gemini_text_generator_model._bqml_model is not None
 
     # save, load to ensure configuration was kept
-    sanitized_model_name = model_name.replace("-", "_").replace(".", "_")
+    sanitized_model_name = model_name.replace("-", "_").replace(".", "_").replace("@", "_")
     target_model_name = f"{dataset_id}.temp_gemini_text_model_{sanitized_model_name}"
     reloaded_model = gemini_text_generator_model.to_gbq(
         target_model_name, replace=True

--- a/packages/bigframes/tests/system/large/ml/test_llm.py
+++ b/packages/bigframes/tests/system/large/ml/test_llm.py
@@ -43,10 +43,12 @@ def test_create_load_gemini_text_generator_model(
     assert gemini_text_generator_model._bqml_model is not None
 
     # save, load to ensure configuration was kept
+    sanitized_model_name = model_name.replace("-", "_").replace(".", "_")
+    target_model_name = f"{dataset_id}.temp_gemini_text_model_{sanitized_model_name}"
     reloaded_model = gemini_text_generator_model.to_gbq(
-        f"{dataset_id}.temp_text_model", replace=True
+        target_model_name, replace=True
     )
-    assert f"{dataset_id}.temp_text_model" == reloaded_model._bqml_model.model_name
+    assert target_model_name == reloaded_model._bqml_model.model_name
     assert reloaded_model.connection_name == bq_connection
     assert reloaded_model.model_name == model_name
 
@@ -235,10 +237,12 @@ def test_create_load_text_embedding_generator_model(
     assert text_embedding_model._bqml_model is not None
 
     # save, load to ensure configuration was kept
-    reloaded_model = text_embedding_model.to_gbq(
-        f"{dataset_id}.temp_text_model", replace=True
+    sanitized_model_name = model_name.replace("-", "_").replace(".", "_")
+    target_model_name = (
+        f"{dataset_id}.temp_text_embedding_model_{sanitized_model_name}"
     )
-    assert f"{dataset_id}.temp_text_model" == reloaded_model._bqml_model.model_name
+    reloaded_model = text_embedding_model.to_gbq(target_model_name, replace=True)
+    assert target_model_name == reloaded_model._bqml_model.model_name
     assert reloaded_model.connection_name == bq_connection
     assert reloaded_model.model_name == model_name
 

--- a/packages/bigframes/tests/system/large/ml/test_llm.py
+++ b/packages/bigframes/tests/system/large/ml/test_llm.py
@@ -237,7 +237,7 @@ def test_create_load_text_embedding_generator_model(
     assert text_embedding_model._bqml_model is not None
 
     # save, load to ensure configuration was kept
-    sanitized_model_name = model_name.replace("-", "_").replace(".", "_")
+    sanitized_model_name = model_name.replace("-", "_").replace(".", "_").replace("@", "_")
     target_model_name = (
         f"{dataset_id}.temp_text_embedding_model_{sanitized_model_name}"
     )


### PR DESCRIPTION
In `tests/system/large/ml/test_llm.py`, parameterized test cases for `GeminiTextGenerator` and `TextEmbeddingGenerator` were saving models to BigQuery using the same hardcoded model name (`temp_text_model`).

When running system tests in parallel (`pytest-xdist`), concurrent workers overwrite each other's models in the shared dataset, resulting in race conditions and test failures.

### Changes
- Updated `test_create_load_gemini_text_generator_model` and `test_create_load_text_embedding_generator_model` to include the sanitized model name in the temporary BigQuery model ID.
- Ensures each parameterized test instance runs with an isolated model namespace.

Fixes #<545715319> 🦕