### PR TITLE
tests(session): improve session table deletion polling and add flaky retries

### DIFF
--- a/packages/bigframes/tests/system/small/test_bq_sessions.py
+++ b/packages/bigframes/tests/system/small/test_bq_sessions.py
@@ -44,7 +44,7 @@ def session_resource_manager(
     )
 
 
-@pytest.mark.flaky(retries=2, delay=10)
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
 def test_bq_session_create_temp_table_clustered(bigquery_client: bigquery.Client):
     session_resource_manager = bigquery_session.SessionResourceManager(
         bigquery_client, "US", publisher=bigframes.core.events.Publisher()

--- a/packages/bigframes/tests/system/small/test_bq_sessions.py
+++ b/packages/bigframes/tests/system/small/test_bq_sessions.py
@@ -75,7 +75,7 @@ def test_bq_session_create_temp_table_clustered(bigquery_client: bigquery.Client
     )
 
 
-@pytest.mark.flaky(retries=2, delay=10)
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
 def test_bq_session_create_multi_temp_tables(bigquery_client: bigquery.Client):
     session_resource_manager = bigquery_session.SessionResourceManager(
         bigquery_client, "US", publisher=bigframes.core.events.Publisher()

--- a/packages/bigframes/tests/system/small/test_bq_sessions.py
+++ b/packages/bigframes/tests/system/small/test_bq_sessions.py
@@ -44,6 +44,7 @@ def session_resource_manager(
     )
 
 
+@pytest.mark.flaky(retries=2, delay=10)
 def test_bq_session_create_temp_table_clustered(bigquery_client: bigquery.Client):
     session_resource_manager = bigquery_session.SessionResourceManager(
         bigquery_client, "US", publisher=bigframes.core.events.Publisher()
@@ -60,14 +61,21 @@ def test_bq_session_create_temp_table_clustered(bigquery_client: bigquery.Client
     assert result_table.clustering_fields == cluster_cols
 
     session_resource_manager.close()
-    with pytest.raises(google.api_core.exceptions.NotFound):
-        # It may take time for the underlying tables to get cleaned up after
-        # closing the session, so wait at least 1 minute to check.
-        for _ in range(6):
+    # BigQuery cleans up temporary session tables asynchronously after closing the session.
+    table_deleted = False
+    for _ in range(24):
+        try:
             bigquery_client.get_table(session_table_ref)
-            time.sleep(10)
+            time.sleep(5)
+        except google.api_core.exceptions.NotFound:
+            table_deleted = True
+            break
+    assert table_deleted, (
+        f"Session table {session_table_ref} was not deleted after closing session."
+    )
 
 
+@pytest.mark.flaky(retries=2, delay=10)
 def test_bq_session_create_multi_temp_tables(bigquery_client: bigquery.Client):
     session_resource_manager = bigquery_session.SessionResourceManager(
         bigquery_client, "US", publisher=bigframes.core.events.Publisher()


### PR DESCRIPTION
In `tests/system/small/test_bq_sessions.py`:
1. `test_bq_session_create_temp_table_clustered` tests that session temporary tables are deleted after closing the session. Because BigQuery cleans up `_SESSION` dataset resources asynchronously, during high CI load this can take longer than 60 seconds, causing `pytest.raises(NotFound)` to fail prematurely.
2. `test_bq_session_create_multi_temp_tables` creates 10 concurrent tables across threads and can encounter transient DDL rate limiting or network latency under parallel test execution (`pytest-xdist`).

### Changes
- Updated `test_bq_session_create_temp_table_clustered` to poll for table deletion for up to 120s with 5s intervals and assert `table_deleted`.
- Added `@pytest.mark.flaky(retries=2, delay=10)` to both session tests to prevent transient CI test flakes.


Fixes #<545778300> 🦕