### PR TITLE
chore(bigtable): update post-processing rules for setup.py

### DIFF
--- a/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
@@ -190,6 +190,7 @@ replacements:
           "libcst": "libcst >= 0.2.5",
       }
     count: 1
+  # Note: Updated following https://github.com/googleapis/google-cloud-python/pull/16760
   - paths: [
       packages/google-cloud-bigtable/setup.py,
     ]
@@ -198,9 +199,12 @@ replacements:
       \]
     after: |
       "protobuf >= 6.33.5, < 8.0.0",
+          "google-cloud-monitoring >= 2.0.0, <3.0.0dev",
           "google-cloud-core >= 2.0.0, <3.0.0",
           "grpc-google-iam-v1 >= 0.14.2, <1.0.0",
-          "google-crc32c>=1.6.0, < 2.0.0",
+          "google-crc32c>=1.6.0, <2.0.0",
+          "opentelemetry-api >= 1.0.0, <2.0.0dev",
+          "opentelemetry-sdk >= 1.0.0, <2.0.0dev",
       ]
     count: 1
   - paths: [
@@ -410,6 +414,7 @@ replacements:
       ]
       SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = [
           "pytest-asyncio==0.21.2",
+          "pytest-order==1.3.0",
           RUFF_VERSION,
           "pyyaml==6.0.2",
       ]

--- a/packages/google-cloud-bigtable/setup.py
+++ b/packages/google-cloud-bigtable/setup.py
@@ -43,7 +43,6 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 2.25.0, <3.0.0",
-    "google-cloud-monitoring >= 2.0.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
@@ -51,6 +50,7 @@ dependencies = [
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.26.1, <2.0.0",
     "protobuf >= 6.33.5, < 8.0.0",
+    "google-cloud-monitoring >= 2.0.0, <3.0.0dev",
     "google-cloud-core >= 2.0.0, <3.0.0",
     "grpc-google-iam-v1 >= 0.14.2, <1.0.0",
     "google-crc32c>=1.6.0, <2.0.0",


### PR DESCRIPTION
Updates the client post-processing configuration for `google-cloud-bigtable` in `.librarian/generator-input/client-post-processing/bigtable-integration.yaml` to ensure code generation produces zero diff.

Required as a result of the change in https://github.com/googleapis/google-cloud-python/pull/16760