### PR TITLE
chore(bigquery-storage): update post-processing rules for setup.py

### DIFF
--- a/.librarian/generator-input/client-post-processing/bigquery-storage-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigquery-storage-integration.yaml
@@ -130,9 +130,13 @@ replacements:
       extras = \{\}
     after: |
       extras = {
-          "pandas": ["pandas>=1.1.3"],
-          "fastavro": ["fastavro>=1.1.0"],
-          "pyarrow": ["pyarrow>=3.0.0"],
+          "pandas": [
+              "pandas >= 1.1.3, < 3.0.0",
+              "pyarrow >= 3.0.0",
+              "pandas-gbq >= 0.35.1, < 2.0.0",
+          ],
+          "fastavro": ["fastavro >= 1.1.0, < 2.0.0"],
+          "pyarrow": ["pyarrow >= 3.0.0"],
       }
     count: 1
   - paths: [
@@ -177,7 +181,6 @@ replacements:
           "__version__",
           "types",
           "ArrowRecordBatch",
-    count: 1
     count: 1
   - paths: [
       packages/google-cloud-bigquery-storage/google/cloud/bigquery_storage/__init__.py,


### PR DESCRIPTION
Updates the client post-processing configuration for `google-cloud-bigquery-storage` in `.librarian/generator-input/client-post-processing/bigquery-storage-integration.yaml` to ensure code generation produces zero diff.