### PR TITLE
fix(generator): move version checks after __all__ in __init__.py temlate

### DIFF
--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -60,9 +60,6 @@ from .types.{{ proto.module_name }} import {{ enum.name }}
 {% endfor %}
 {% endfor %}
 
-api_core.check_python_version("{{package_path}}")
-api_core.check_dependency_versions("{{package_path}}")
-
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over
     them again.
@@ -90,4 +87,8 @@ __all__ = (
     {% endfor -%}
     {% endfilter %}
 )
+
+api_core.check_python_version("{{package_path}}")
+api_core.check_dependency_versions("{{package_path}}")
+
 {% endblock %}

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -118,9 +118,6 @@ from .types.assets import TemporalAsset
 from .types.assets import TimeWindow
 from .types.assets import VersionedResource
 
-api_core.check_python_version("google.cloud.asset_v1")
-api_core.check_dependency_versions("google.cloud.asset_v1")
-
 __all__ = (
     'AssetServiceAsyncClient',
 'AnalyzeIamPolicyLongrunningMetadata',
@@ -206,3 +203,6 @@ __all__ = (
 'UpdateSavedQueryRequest',
 'VersionedResource',
 )
+
+api_core.check_python_version("google.cloud.asset_v1")
+api_core.check_dependency_versions("google.cloud.asset_v1")

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -44,9 +44,6 @@ from .types.common import SignBlobResponse
 from .types.common import SignJwtRequest
 from .types.common import SignJwtResponse
 
-api_core.check_python_version("google.iam.credentials_v1")
-api_core.check_dependency_versions("google.iam.credentials_v1")
-
 __all__ = (
     'IAMCredentialsAsyncClient',
 'GenerateAccessTokenRequest',
@@ -59,3 +56,6 @@ __all__ = (
 'SignJwtRequest',
 'SignJwtResponse',
 )
+
+api_core.check_python_version("google.iam.credentials_v1")
+api_core.check_dependency_versions("google.iam.credentials_v1")

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -116,9 +116,6 @@ from .types.trigger import StateCondition
 from .types.trigger import Transport
 from .types.trigger import Trigger
 
-api_core.check_python_version("google.cloud.eventarc_v1")
-api_core.check_dependency_versions("google.cloud.eventarc_v1")
-
 __all__ = (
     'EventarcAsyncClient',
 'Channel',
@@ -193,3 +190,6 @@ __all__ = (
 'UpdatePipelineRequest',
 'UpdateTriggerRequest',
 )
+
+api_core.check_python_version("google.cloud.eventarc_v1")
+api_core.check_dependency_versions("google.cloud.eventarc_v1")

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -120,9 +120,6 @@ from .types.logging_metrics import ListLogMetricsResponse
 from .types.logging_metrics import LogMetric
 from .types.logging_metrics import UpdateLogMetricRequest
 
-api_core.check_python_version("google.cloud.logging_v2")
-api_core.check_dependency_versions("google.cloud.logging_v2")
-
 __all__ = (
     'ConfigServiceV2AsyncClient',
     'LoggingServiceV2AsyncClient',
@@ -207,3 +204,6 @@ __all__ = (
 'WriteLogEntriesRequest',
 'WriteLogEntriesResponse',
 )
+
+api_core.check_python_version("google.cloud.logging_v2")
+api_core.check_dependency_versions("google.cloud.logging_v2")

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -120,9 +120,6 @@ from .types.logging_metrics import ListLogMetricsResponse
 from .types.logging_metrics import LogMetric
 from .types.logging_metrics import UpdateLogMetricRequest
 
-api_core.check_python_version("google.cloud.logging_v2")
-api_core.check_dependency_versions("google.cloud.logging_v2")
-
 __all__ = (
     'BaseConfigServiceV2AsyncClient',
     'BaseMetricsServiceV2AsyncClient',
@@ -207,3 +204,6 @@ __all__ = (
 'WriteLogEntriesRequest',
 'WriteLogEntriesResponse',
 )
+
+api_core.check_python_version("google.cloud.logging_v2")
+api_core.check_dependency_versions("google.cloud.logging_v2")

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -62,9 +62,6 @@ from .types.cloud_redis import UpgradeInstanceRequest
 from .types.cloud_redis import WeeklyMaintenanceWindow
 from .types.cloud_redis import ZoneMetadata
 
-api_core.check_python_version("google.cloud.redis_v1")
-api_core.check_dependency_versions("google.cloud.redis_v1")
-
 __all__ = (
     'CloudRedisAsyncClient',
 'CloudRedisClient',
@@ -96,3 +93,6 @@ __all__ = (
 'WeeklyMaintenanceWindow',
 'ZoneMetadata',
 )
+
+api_core.check_python_version("google.cloud.redis_v1")
+api_core.check_dependency_versions("google.cloud.redis_v1")

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -55,9 +55,6 @@ from .types.cloud_redis import UpdateInstanceRequest
 from .types.cloud_redis import WeeklyMaintenanceWindow
 from .types.cloud_redis import ZoneMetadata
 
-api_core.check_python_version("google.cloud.redis_v1")
-api_core.check_dependency_versions("google.cloud.redis_v1")
-
 __all__ = (
     'CloudRedisAsyncClient',
 'CloudRedisClient',
@@ -82,3 +79,6 @@ __all__ = (
 'WeeklyMaintenanceWindow',
 'ZoneMetadata',
 )
+
+api_core.check_python_version("google.cloud.redis_v1")
+api_core.check_dependency_versions("google.cloud.redis_v1")

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
@@ -64,9 +64,6 @@ from .types.storage_batch_operations_types import PutObjectHold
 from .types.storage_batch_operations_types import RewriteObject
 from .types.storage_batch_operations_types import UpdateObjectCustomContext
 
-api_core.check_python_version("google.cloud.storagebatchoperations_v1")
-api_core.check_dependency_versions("google.cloud.storagebatchoperations_v1")
-
 __all__ = (
     'StorageBatchOperationsAsyncClient',
 'BucketList',
@@ -99,3 +96,6 @@ __all__ = (
 'StorageBatchOperationsClient',
 'UpdateObjectCustomContext',
 )
+
+api_core.check_python_version("google.cloud.storagebatchoperations_v1")
+api_core.check_dependency_versions("google.cloud.storagebatchoperations_v1")


### PR DESCRIPTION
This PR updates the `__init__.py.j2` template to place runtime checks (`api_core.check_python_version()` and `api_core.check_dependency_versions()`) at the very end of the file after `__all__`.

In `gapic-generator 1.38.0`, runtime version and dependency checks were placed immediately before `__all__`. This created an execution boundary in the middle of the module:
* When post-processing scripts or handwritten extensions (such as `SpeechHelpers` in `google-cloud-speech` or `VisionHelpers` in `google-cloud-vision`) inject helper imports or wrap client classes prior to `__all__`, linters (Flake8 and Ruff) flag `E402: Module level import not at top of file`.
* Moving the checks to after `__all__` ensures all module imports remain contiguous at the top of the file, complying with PEP 8 import ordering and eliminating the need for `# noqa: E402` annotations in post-processing.
* Module import semantics remain identical: Python executes the file top-to-bottom, so environment checks still run immediately upon import and abort if incompatible versions are detected.