### PR TITLE
fix(ci): preserve target branch history for import profiler baseline generation

### DIFF
--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -55,9 +55,9 @@ elif [[ ${BUILD_TYPE} == "presubmit" ]]; then
     # common commit in the target branch.
     if [ -n "${TARGET_BRANCH}" ]; then
         if [[ "${TEST_TYPE}" == "import_profile" ]]; then
-            git fetch origin "${TARGET_BRANCH}" || true
+            git fetch upstream "${TARGET_BRANCH}" 2>/dev/null || git fetch origin "${TARGET_BRANCH}" || true
         else
-            git fetch origin "${TARGET_BRANCH}" --depth=200 || true
+            git fetch upstream "${TARGET_BRANCH}" --depth=200 2>/dev/null || git fetch origin "${TARGET_BRANCH}" --depth=200 || true
         fi
     fi
     GIT_DIFF_ARG="origin/${TARGET_BRANCH}..."

--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -55,9 +55,9 @@ elif [[ ${BUILD_TYPE} == "presubmit" ]]; then
     # common commit in the target branch.
     if [ -n "${TARGET_BRANCH}" ]; then
         if [[ "${TEST_TYPE}" == "import_profile" ]]; then
-            git fetch upstream "${TARGET_BRANCH}" 2>/dev/null || git fetch origin "${TARGET_BRANCH}" || true
+            git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" || true
         else
-            git fetch upstream "${TARGET_BRANCH}" --depth=200 2>/dev/null || git fetch origin "${TARGET_BRANCH}" --depth=200 || true
+            git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --depth=200 || true
         fi
     fi
     GIT_DIFF_ARG="origin/${TARGET_BRANCH}..."

--- a/ci/run_conditional_tests.sh
+++ b/ci/run_conditional_tests.sh
@@ -54,7 +54,11 @@ elif [[ ${BUILD_TYPE} == "presubmit" ]]; then
     # For presubmit build, we want to know the difference from the
     # common commit in the target branch.
     if [ -n "${TARGET_BRANCH}" ]; then
-        git fetch origin "${TARGET_BRANCH}" --depth=200 || true
+        if [[ "${TEST_TYPE}" == "import_profile" ]]; then
+            git fetch origin "${TARGET_BRANCH}" || true
+        else
+            git fetch origin "${TARGET_BRANCH}" --depth=200 || true
+        fi
     fi
     GIT_DIFF_ARG="origin/${TARGET_BRANCH}..."
 

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -140,15 +140,12 @@ case ${TEST_TYPE} in
             if [ -n "${TARGET_BRANCH}" ]; then
                 # Fetch history for the target branch without --depth=1 in case it was shallowly fetched
                 if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
-                    git fetch upstream "${TARGET_BRANCH}" --unshallow 2>/dev/null || \
-                    git fetch origin "${TARGET_BRANCH}" --unshallow 2>/dev/null || \
-                    git fetch upstream "${TARGET_BRANCH}" 2>/dev/null || \
-                    git fetch origin "${TARGET_BRANCH}" 2>/dev/null || true
+                    git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --unshallow 2>/dev/null || \
+                    git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" 2>/dev/null || true
                 fi
-                # Try upstream first (for forks), then origin
-                BASELINE_COMMIT=$(git merge-base HEAD "upstream/${TARGET_BRANCH}" 2>/dev/null || \
-                                 git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || \
-                                 git merge-base HEAD "${TARGET_BRANCH}" 2>/dev/null || true)
+                # Try origin first, then fallback to HEAD if everything else fails
+                BASELINE_COMMIT=$(git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || \
+                                 git rev-parse HEAD)
                 if [ -n "${BASELINE_COMMIT}" ]; then
                     echo "Checking out baseline commit ${BASELINE_COMMIT} in a temporary worktree..."
                     REPO_PREFIX=$(git rev-parse --show-prefix)

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -138,9 +138,12 @@ case ${TEST_TYPE} in
             BASELINE_CSV="${PROFILER_TEMP_DIR}/baseline_${PACKAGE_NAME}.csv"
             
             if [ -n "${TARGET_BRANCH}" ]; then
-                # Fetch history for origin/${TARGET_BRANCH} without --depth=1 in case it was shallowly fetched
+                # Fetch history for the target branch without --depth=1 in case it was shallowly fetched
                 if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
-                    git fetch origin "${TARGET_BRANCH}" --unshallow 2>/dev/null || git fetch origin "${TARGET_BRANCH}" 2>/dev/null || true
+                    git fetch upstream "${TARGET_BRANCH}" --unshallow 2>/dev/null || \
+                    git fetch origin "${TARGET_BRANCH}" --unshallow 2>/dev/null || \
+                    git fetch upstream "${TARGET_BRANCH}" 2>/dev/null || \
+                    git fetch origin "${TARGET_BRANCH}" 2>/dev/null || true
                 fi
                 # Try upstream first (for forks), then origin
                 BASELINE_COMMIT=$(git merge-base HEAD "upstream/${TARGET_BRANCH}" 2>/dev/null || \

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -138,6 +138,10 @@ case ${TEST_TYPE} in
             BASELINE_CSV="${PROFILER_TEMP_DIR}/baseline_${PACKAGE_NAME}.csv"
             
             if [ -n "${TARGET_BRANCH}" ]; then
+                # Fetch history for origin/${TARGET_BRANCH} without --depth=1 in case it was shallowly fetched
+                if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+                    git fetch origin "${TARGET_BRANCH}" --unshallow 2>/dev/null || git fetch origin "${TARGET_BRANCH}" 2>/dev/null || true
+                fi
                 # Try upstream first (for forks), then origin
                 BASELINE_COMMIT=$(git merge-base HEAD "upstream/${TARGET_BRANCH}" 2>/dev/null || \
                                  git merge-base HEAD "origin/${TARGET_BRANCH}" 2>/dev/null || \


### PR DESCRIPTION
Avoid shallow-fetching `origin/${TARGET_BRANCH}` when `TEST_TYPE` is import_profile so git merge-base can successfully find baseline commits for baseline profiling comparison.