### PR TITLE
fix(pubsub): preserve publisher method type annotations

### DIFF
--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/async_client.py
@@ -17,6 +17,7 @@ import logging as std_logging
 import re
 from collections import OrderedDict
 from typing import (
+    Any,
     Callable,
     Dict,
     Mapping,
@@ -39,10 +40,7 @@ from google.oauth2 import service_account  # type: ignore
 
 from google.pubsub_v1 import gapic_version as package_version
 
-try:
-    OptionalRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
-except AttributeError:  # pragma: NO COVER
-    OptionalRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
+OptionalRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
 
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
@@ -552,7 +550,7 @@ class PublisherAsyncClient:
 
     async def publish(
         self,
-        request: Optional[Union[pubsub.PublishRequest, dict]] = None,
+        request: Optional[Union[pubsub.PublishRequest, Dict[str, Any]]] = None,
         *,
         topic: Optional[str] = None,
         messages: Optional[MutableSequence[pubsub.PubsubMessage]] = None,

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/client.py
@@ -22,6 +22,7 @@ import warnings
 from collections import OrderedDict
 from http import HTTPStatus
 from typing import (
+    Any,
     Callable,
     Dict,
     Mapping,
@@ -49,10 +50,7 @@ from google.oauth2 import service_account  # type: ignore
 
 from google.pubsub_v1 import gapic_version as package_version
 
-try:
-    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
-except AttributeError:  # pragma: NO COVER
-    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 
 try:
     from google.api_core import client_logging  # type: ignore
@@ -1062,7 +1060,7 @@ class PublisherClient(metaclass=PublisherClientMeta):
 
     def publish(
         self,
-        request: Optional[Union[pubsub.PublishRequest, dict]] = None,
+        request: Optional[Union[pubsub.PublishRequest, Dict[str, Any]]] = None,
         *,
         topic: Optional[str] = None,
         messages: Optional[MutableSequence[pubsub.PubsubMessage]] = None,

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/__init__.py
@@ -15,6 +15,8 @@
 #
 from typing import Union
 
+from google.api_core.timeout import ConstantTimeout, ExponentialTimeout
+
 from .pubsub import (
     AcknowledgeRequest,
     AIInference,
@@ -91,10 +93,9 @@ from .schema import (
 )
 
 TimeoutType = Union[
-    int,
     float,
-    "google.api_core.timeout.ConstantTimeout",
-    "google.api_core.timeout.ExponentialTimeout",
+    ConstantTimeout,
+    ExponentialTimeout,
 ]
 """The type of the timeout parameter of publisher client methods."""
 


### PR DESCRIPTION
### Overview

- Preserve concrete request, retry, and timeout annotations for Pub/Sub publishers.
