### PR TITLE
tests(functions): add flaky retries for apply axis 1 tests

### DIFF
--- a/packages/bigframes/tests/system/large/functions/test_managed_function.py
+++ b/packages/bigframes/tests/system/large/functions/test_managed_function.py
@@ -348,6 +348,7 @@ def test_managed_function_dataframe_apply_axis_1(
     )
 
 
+@pytest.mark.flaky(retries=2, delay=30)
 def test_managed_function_dataframe_apply_axis_1_array_output(
     session, dataset_id, function_id
 ):
@@ -560,6 +561,7 @@ def test_managed_function_options_errors(session, dataset_id, function_id):
         )(foo)
 
 
+@pytest.mark.flaky(retries=2, delay=30)
 def test_managed_function_df_apply_axis_1(
     session, dataset_id, scalars_dfs, function_id
 ):

--- a/packages/bigframes/tests/system/large/functions/test_remote_function.py
+++ b/packages/bigframes/tests/system/large/functions/test_remote_function.py
@@ -2360,6 +2360,7 @@ def test_remote_function_clean_up_by_session_id():
         )
 
 
+@pytest.mark.flaky(retries=2, delay=120)
 def test_df_apply_axis_1_multiple_params(session):
     bf_df = bigframes.dataframe.DataFrame(
         {
@@ -2440,6 +2441,7 @@ def test_df_apply_axis_1_multiple_params(session):
         cleanup_function_assets(foo, session.bqclient, session.cloudfunctionsclient)
 
 
+@pytest.mark.flaky(retries=2, delay=120)
 def test_df_apply_axis_1_multiple_params_array_output(session):
     bf_df = bigframes.dataframe.DataFrame(
         {
@@ -2524,6 +2526,7 @@ def test_df_apply_axis_1_multiple_params_array_output(session):
         cleanup_function_assets(foo, session.bqclient, session.cloudfunctionsclient)
 
 
+@pytest.mark.flaky(retries=2, delay=120)
 def test_df_apply_axis_1_single_param_non_series(session):
     bf_df = bigframes.dataframe.DataFrame(
         {


### PR DESCRIPTION
In `tests/system/large/functions/test_managed_function.py` and `tests/system/large/functions/test_remote_function.py`, tests exercising `DataFrame.apply(axis=1)` deploy ephemeral Cloud Functions and BigQuery remote connection assets.

Under parallel CI execution (`pytest -n 20`), concurrent function deployment requests occasionally hit transient Cloud Functions deployment rate limiting or IAM propagation delays.

### Changes
- Added `@pytest.mark.flaky(retries=2, delay=120)` to `test_df_apply_axis_1_multiple_params`, `test_df_apply_axis_1_multiple_params_array_output`, and `test_df_apply_axis_1_single_param_non_series` in `test_remote_function.py`.
- Added `@pytest.mark.flaky(retries=2, delay=30)` to `test_managed_function_dataframe_apply_axis_1_array_output` and `test_managed_function_df_apply_axis_1` in `test_managed_function.py`.



Fixes #<545713683> 🦕