### PR TITLE
chore(librarian): add protoc version to librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -21,6 +21,7 @@ sources:
 tools:
   protoc:
     version: "33.5"
+    sha256: 24e58fb231d50306ee28491f33a170301e99540f7e29ca461e0e80fd1239f8d1
   pip:
     - name: black
       version: 23.7.0

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -19,6 +19,8 @@ sources:
     commit: 240b58fe7058f6fff77cba02f51d600170b6c421
     sha256: ca03f2c93b8f1e92fd75c87b2568992c96a2ecc37fde750c5bf83129fa17b407
 tools:
+  protoc:
+    version: "33.5"
   pip:
     - name: black
       version: 23.7.0

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -19,9 +19,6 @@ sources:
     commit: 240b58fe7058f6fff77cba02f51d600170b6c421
     sha256: ca03f2c93b8f1e92fd75c87b2568992c96a2ecc37fde750c5bf83129fa17b407
 tools:
-  protoc:
-    version: "33.5"
-    sha256: 24e58fb231d50306ee28491f33a170301e99540f7e29ca461e0e80fd1239f8d1
   pip:
     - name: black
       version: 23.7.0
@@ -37,6 +34,9 @@ tools:
     - name: synthtool
       version: e643ce8e20f8fe237a31a1754524ba987de72875
       package: gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875
+  protoc:
+    version: "33.5"
+    sha256: 24e58fb231d50306ee28491f33a170301e99540f7e29ca461e0e80fd1239f8d1
 default:
   output: packages
   tag_format: '{name}-v{version}'


### PR DESCRIPTION
Adds `tools.protoc` configuration (version 33.5 with SHA256 checksum) to `librarian.yaml`.

This allows Librarian to download and use the pinned protoc binary during Python client generation, completing the migration away from embedded tool defaults.

For: https://github.com/googleapis/librarian/issues/6508