### PR TITLE
fix(documentai-toolbox): enable autoescape in export_hocr_str

### DIFF
--- a/packages/google-cloud-documentai-toolbox/google/cloud/documentai_toolbox/wrappers/document.py
+++ b/packages/google-cloud-documentai-toolbox/google/cloud/documentai_toolbox/wrappers/document.py
@@ -943,7 +943,8 @@ class Document:
                 A string hOCR version of the Document
         """
         environment = Environment(
-            loader=PackageLoader("google.cloud.documentai_toolbox", "templates")
+            loader=PackageLoader("google.cloud.documentai_toolbox", "templates"),
+            autoescape=True,
         )
         template = environment.get_template("hocr_document_template.xml.j2")
         content = template.render(pages=self.pages, title=title)

--- a/packages/google-cloud-documentai-toolbox/tests/unit/test_document.py
+++ b/packages/google-cloud-documentai-toolbox/tests/unit/test_document.py
@@ -949,6 +949,23 @@ def test_export_hocr_str_with_escape_characters():
     assert actual_hocr == expected
 
 
+def test_export_hocr_str_escapes_title():
+    wrapped_document = document.Document.from_document_path(
+        document_path="tests/unit/resources/0/toolbox_invoice_test-0.json"
+    )
+
+    actual_hocr = wrapped_document.export_hocr_str(
+        title="</title><script>alert(1)</script>"
+    )
+
+    assert "<script>alert(1)</script>" not in actual_hocr
+
+    element = ElementTree.fromstring(actual_hocr)
+    assert element is not None
+    title_element = element.find(".//{http://www.w3.org/1999/xhtml}title")
+    assert title_element.text == "</title><script>alert(1)</script>"
+
+
 def test_document_to_merged_documentai_document(get_bytes_multiple_files_mock):
     wrapped_document = document.Document.from_gcs(
         gcs_bucket_name="test-directory", gcs_prefix="documentai/output/123456789/1/"


### PR DESCRIPTION
export_hocr_str builds its Jinja2 Environment without autoescape, so the title argument is written into the `<title>` element unescaped. A title such as `</title><script>alert(1)</script>` breaks out of the element and lands as raw script markup, producing invalid XML in an hOCR document that is meant to be valid XHTML rendered in a browser. The word and line text already pass through the `escape` filter, so enabling autoescape closes the remaining gap inside the helper while leaving the output byte-identical for normal input (existing golden-file tests are unchanged).

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
