### PR TITLE
test(bigtable): temporarily disable real-service system tests, keep emulated

### DIFF
--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -325,7 +325,9 @@ def system_emulated(session):
 @nox.session(py="3.12")
 @nox.parametrize(
     "test_type",
-    ["system_default", "system_emulated"],
+    # TODO: Re-enable "system_default" once the real-service system tests are
+    # green again. Only the emulated system tests run for now.
+    ["system_emulated"],
 )
 def system(session, test_type):
     """Run the system/emulator tests."""


### PR DESCRIPTION
## Summary

Temporarily disables the `system_default` (real Cloud Bigtable service) system-test parametrization for `google-cloud-bigtable`, leaving `system_emulated` running.

The `system` nox session previously ran both `system_default` and `system_emulated`. This drops `system_default` from the parametrize list so only the emulator-backed system tests run.

A `TODO` is left in `noxfile.py` to re-enable `system_default` once the real-service system tests are green again. The `system_default` function itself is left intact (still referenced from `test_map`), so re-enabling is a one-line revert.

## Change

```diff
 @nox.parametrize(
     "test_type",
-    ["system_default", "system_emulated"],
+    # TODO: Re-enable "system_default" once the real-service system tests are
+    # green again. Only the emulated system tests run for now.
+    ["system_emulated"],
 )
```

See follow up issue https://github.com/googleapis/google-cloud-python/issues/18162