### PR TITLE
chore(bigtable): improve system test instance usage

### DIFF
--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -309,6 +309,7 @@ def system_emulated(session):
 
     hostport = "localhost:8789"
     session.env["BIGTABLE_EMULATOR_HOST"] = hostport
+    session.env["GOOGLE_CLOUD_PROJECT"] = "emulated-test-project"
 
     p = subprocess.Popen(
         ["gcloud", "beta", "emulators", "bigtable", "start", "--host-port", hostport]

--- a/packages/google-cloud-bigtable/tests/system/admin_overlay/test_system_async.py
+++ b/packages/google-cloud-bigtable/tests/system/admin_overlay/test_system_async.py
@@ -347,14 +347,17 @@ async def test_optimize_restored_table(
         admin_v2.StorageType.HDD,
     )
 
-    instance_to_restore, _ = await create_instance(
-        instance_admin_client,
-        table_admin_client,
-        data_client,
-        admin_overlay_project_id,
-        instances_to_delete,
-        second_instance_storage_type,
-    )
+    if second_instance_storage_type == admin_v2.StorageType.HDD:
+        instance_to_restore = instance_with_backup
+    else:
+        instance_to_restore, _ = await create_instance(
+            instance_admin_client,
+            table_admin_client,
+            data_client,
+            admin_overlay_project_id,
+            instances_to_delete,
+            second_instance_storage_type,
+        )
 
     backup = await create_backup(
         instance_admin_client,

--- a/packages/google-cloud-bigtable/tests/system/admin_overlay/test_system_autogen.py
+++ b/packages/google-cloud-bigtable/tests/system/admin_overlay/test_system_autogen.py
@@ -259,14 +259,17 @@ def test_optimize_restored_table(
         instances_to_delete,
         admin_v2.StorageType.HDD,
     )
-    instance_to_restore, _ = create_instance(
-        instance_admin_client,
-        table_admin_client,
-        data_client,
-        admin_overlay_project_id,
-        instances_to_delete,
-        second_instance_storage_type,
-    )
+    if second_instance_storage_type == admin_v2.StorageType.HDD:
+        instance_to_restore = instance_with_backup
+    else:
+        instance_to_restore, _ = create_instance(
+            instance_admin_client,
+            table_admin_client,
+            data_client,
+            admin_overlay_project_id,
+            instances_to_delete,
+            second_instance_storage_type,
+        )
     backup = create_backup(
         instance_admin_client,
         table_admin_client,

--- a/packages/google-cloud-bigtable/tests/system/data/__init__.py
+++ b/packages/google-cloud-bigtable/tests/system/data/__init__.py
@@ -40,7 +40,11 @@ class SystemTestRunner:
         """
         Automatically deletes any test instances older than 1 day.
         """
+        from google.cloud.environment_vars import BIGTABLE_EMULATOR
         from tests.system.utils import clear_stale_instances
+
+        if os.getenv(BIGTABLE_EMULATOR):
+            return
 
         clear_stale_instances(project_id, "python-bigtable-tests", older_than_days=1)
 

--- a/packages/google-cloud-bigtable/tests/system/utils.py
+++ b/packages/google-cloud-bigtable/tests/system/utils.py
@@ -76,6 +76,8 @@ def clear_stale_instances(
                                         "skipping remainder to conserve API write request quota."
                                     )
                                     return
+                            except NotFound:
+                                pass
                             except Exception as e:
                                 print(f"Failed to delete stale instance {instance.name}: {e}")
                     except Exception as e:

--- a/packages/google-cloud-bigtable/tests/system/utils.py
+++ b/packages/google-cloud-bigtable/tests/system/utils.py
@@ -15,6 +15,7 @@
 from datetime import datetime, timedelta, timezone
 
 from google.api_core.exceptions import NotFound
+from google.cloud.environment_vars import BIGTABLE_EMULATOR
 
 from google.cloud import bigtable_admin_v2 as admin_v2
 
@@ -24,6 +25,8 @@ def clear_stale_instances(project_id: str, prefix: str, older_than_days: int = 1
     Synchronously deletes any instances in the given project that are older
     than older_than_days and whose name or display name matches the given prefix.
     """
+    if os.getenv(BIGTABLE_EMULATOR):
+        return
     client = admin_v2.BigtableInstanceAdminClient(
         client_options={"quota_project_id": project_id}
     )

--- a/packages/google-cloud-bigtable/tests/system/utils.py
+++ b/packages/google-cloud-bigtable/tests/system/utils.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from datetime import datetime, timedelta, timezone
+
+from typing import Union, Tuple
 
 from google.api_core.exceptions import NotFound
 from google.cloud.environment_vars import BIGTABLE_EMULATOR
@@ -20,7 +23,12 @@ from google.cloud.environment_vars import BIGTABLE_EMULATOR
 from google.cloud import bigtable_admin_v2 as admin_v2
 
 
-def clear_stale_instances(project_id: str, prefix: str, older_than_days: int = 1):
+def clear_stale_instances(
+    project_id: str,
+    prefix: Union[str, Tuple[str, ...]] = ("python-bigtable-tests", "g-c-p", "admin-overlay-instance"),
+    older_than_days: int = 1,
+    max_deletions: int = 5,
+):
     """
     Synchronously deletes any instances in the given project that are older
     than older_than_days and whose name or display name matches the given prefix.
@@ -32,6 +40,7 @@ def clear_stale_instances(project_id: str, prefix: str, older_than_days: int = 1
     )
     parent = client.common_project_path(project_id)
     next_page_token = ""
+    deleted_count = 0
 
     while True:
         try:
@@ -49,12 +58,28 @@ def clear_stale_instances(project_id: str, prefix: str, older_than_days: int = 1
 
             if display_name_matches or name_matches:
                 if instance.create_time:
-                    now = datetime.now(timezone.utc)
-                    if now - instance.create_time > timedelta(days=older_than_days):
-                        try:
-                            client.delete_instance(name=instance.name)
-                        except NotFound:
-                            pass
+                    try:
+                        create_time = instance.create_time
+                        if hasattr(create_time, "to_datetime"):
+                            create_time = create_time.to_datetime()
+                        if create_time.tzinfo is None:
+                            create_time = create_time.replace(tzinfo=timezone.utc)
+                        now = datetime.now(timezone.utc)
+                        if now - create_time > timedelta(days=older_than_days):
+                            try:
+                                print(f"Deleting stale instance: {instance.name}")
+                                client.delete_instance(name=instance.name)
+                                deleted_count += 1
+                                if deleted_count >= max_deletions:
+                                    print(
+                                        f"Reached cap of {max_deletions} stale instance deletions; "
+                                        "skipping remainder to conserve API write request quota."
+                                    )
+                                    return
+                            except Exception as e:
+                                print(f"Failed to delete stale instance {instance.name}: {e}")
+                    except Exception as e:
+                        print(f"Failed to check age for instance {instance.name}: {e}")
 
         next_page_token = response.next_page_token
         if not next_page_token:

--- a/packages/google-cloud-bigtable/tests/system/utils.py
+++ b/packages/google-cloud-bigtable/tests/system/utils.py
@@ -25,7 +25,11 @@ from google.cloud import bigtable_admin_v2 as admin_v2
 
 def clear_stale_instances(
     project_id: str,
-    prefix: Union[str, Tuple[str, ...]] = ("python-bigtable-tests", "g-c-p", "admin-overlay-instance"),
+    prefix: Union[str, Tuple[str, ...]] = (
+        "python-bigtable-tests",
+        "g-c-p",
+        "admin-overlay-instance",
+    ),
     older_than_days: int = 1,
     max_deletions: int = 5,
 ):
@@ -35,6 +39,7 @@ def clear_stale_instances(
     """
     if os.getenv(BIGTABLE_EMULATOR):
         return
+    print(f"Clearing stale instances in project {project_id}...")
     client = admin_v2.BigtableInstanceAdminClient(
         client_options={"quota_project_id": project_id}
     )
@@ -72,14 +77,15 @@ def clear_stale_instances(
                                 deleted_count += 1
                                 if deleted_count >= max_deletions:
                                     print(
-                                        f"Reached cap of {max_deletions} stale instance deletions; "
-                                        "skipping remainder to conserve API write request quota."
+                                        f"Reached cap of {max_deletions} stale instance deletions"
                                     )
                                     return
                             except NotFound:
                                 pass
                             except Exception as e:
-                                print(f"Failed to delete stale instance {instance.name}: {e}")
+                                print(
+                                    f"Failed to delete stale instance {instance.name}: {e}"
+                                )
                     except Exception as e:
                         print(f"Failed to check age for instance {instance.name}: {e}")
 

--- a/packages/google-cloud-bigtable/tests/system/v2_client/test_table_admin.py
+++ b/packages/google-cloud-bigtable/tests/system/v2_client/test_table_admin.py
@@ -334,23 +334,10 @@ def test_table_backup(
     assert restored_table in tables
     restored_table.delete()
 
-    # Testing `Backup.restore()` into a different instance:
-    # Setting up another instance...
-    alt_instance_id = f"gcp-alt-{unique_suffix}"
-    alt_cluster_id = f"{alt_instance_id}-cluster"
-    alt_instance = admin_client.instance(alt_instance_id, labels=instance_labels)
-    alt_cluster = alt_instance.cluster(
-        cluster_id=alt_cluster_id,
-        location_id=location_id,
-        serve_nodes=1,
-    )
-    create_op = alt_instance.create(clusters=[alt_cluster])
-    instances_to_delete.append(alt_instance)
-    create_op.result(timeout=240)
-
-    # Testing `restore()`...
-    restore_op = temp_backup.restore(restored_table_id, alt_instance_id)
+    # Testing `Backup.restore()`:
+    restored_table_id_2 = "test-backup-table-restored-2"
+    restore_op = temp_backup.restore(restored_table_id_2, data_instance_populated.instance_id)
     restore_op.result(timeout=240)
-    restored_table = alt_instance.table(restored_table_id)
-    assert restored_table in alt_instance.list_tables()
-    restored_table.delete()
+    restored_table_2 = data_instance_populated.table(restored_table_id_2)
+    assert restored_table_2 in data_instance_populated.list_tables()
+    restored_table_2.delete()

--- a/packages/google-cloud-bigtable/tests/system/v2_client/test_table_admin.py
+++ b/packages/google-cloud-bigtable/tests/system/v2_client/test_table_admin.py
@@ -336,7 +336,9 @@ def test_table_backup(
 
     # Testing `Backup.restore()`:
     restored_table_id_2 = "test-backup-table-restored-2"
-    restore_op = temp_backup.restore(restored_table_id_2, data_instance_populated.instance_id)
+    restore_op = temp_backup.restore(
+        restored_table_id_2, data_instance_populated.instance_id
+    )
     restore_op.result(timeout=240)
     restored_table_2 = data_instance_populated.table(restored_table_id_2)
     assert restored_table_2 in data_instance_populated.list_tables()


### PR DESCRIPTION
We have been hitting quota limits on bigtable system tests recently. This PR attempts to make a few improovements:
- Patched a [bug in the system_emulated tests](https://github.com/googleapis/google-cloud-python/pull/18148), where the tests would still try to [clean up stale GCP instances](https://github.com/googleapis/google-cloud-python/pull/17350), even in emulator mode
  - Also set a new dummy `GOOGLE_CLOUD_PROJECT` envvar in system_emulated mode, to prevent talking to the live GCP environment
- Improved the stale clean-up logic to add a cap to only clean up at max 5 old instances, along with additional logs
- Identified a couple placed in the tests where we can re-use existing instances instead of spinning up new ones