### PR TITLE
fix(ndb): use the single-argument generator.throw() signature

### DIFF
--- a/packages/google-cloud-ndb/google/cloud/ndb/tasklets.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/tasklets.py
@@ -314,8 +314,7 @@ class _TaskletFuture(Future):
             with self.context.use():
                 # Send the next value or exception into the generator
                 if error:
-                    traceback = error.__traceback__
-                    yielded = self.generator.throw(type(error), error, traceback)
+                    yielded = self.generator.throw(error)
 
                 else:
                     # send_value will be None if this is the first time

--- a/packages/google-cloud-ndb/tests/unit/test_tasklets.py
+++ b/packages/google-cloud-ndb/tests/unit/test_tasklets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from unittest import mock
 
 import pytest
@@ -362,6 +363,39 @@ class Test_TaskletFuture:
         assert future.exception() is error
         with pytest.raises(Exception):
             future.result()
+
+    @staticmethod
+    def test__advance_tasklet_dependency_raises_preserves_traceback(in_context):
+        """Regression test: the error reaches the generator with its traceback
+        and without a DeprecationWarning from the legacy throw() signature."""
+
+        def generator_function(dependency):
+            try:
+                yield dependency
+            except Exception as caught:
+                raise tasklets.Return(caught.__traceback__ is not None)
+
+        error = Exception("Spurious error.")
+        dependency = tasklets.Future()
+        generator = generator_function(dependency)
+        future = tasklets._TaskletFuture(generator, in_context)
+        future._advance_tasklet()
+
+        try:
+            raise error
+        except Exception:
+            pass  # give the exception a traceback, as a real failure would have
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            dependency.set_exception(error)
+
+        assert future.result() is True
+        assert not [
+            warning
+            for warning in caught_warnings
+            if issubclass(warning.category, DeprecationWarning)
+        ]
 
     @staticmethod
     def test__advance_tasklet_dependency_raises_with_try_except(in_context):


### PR DESCRIPTION
Fixes #18158

## Summary

`_TaskletFuture._advance_tasklet` throws exceptions into the wrapped generator using the three-argument form of `generator.throw()`, [deprecated in Python 3.12](https://docs.python.org/3/reference/expressions.html#generator.throw):

```python
if error:
    traceback = error.__traceback__
    yielded = self.generator.throw(type(error), error, traceback)
```

Every exception that crosses a tasklet boundary emits a `DeprecationWarning`. This library's own unit suite raises **70 warnings** today; with this change it raises **36**, so 34 of them came from this single line.

Today that is only noise, but the Python docs say the old signature "may be removed in a future version". `noxfile.py` already lists `3.15` in `ALL_INTERPRETERS`, so it is worth landing before that removal makes every tasklet-boundary exception raise `TypeError` instead of propagating.

## Changes

The single-argument form reads the traceback off the exception itself, so the local becomes redundant:

```python
if error:
    yielded = self.generator.throw(error)
```

Also adds a regression test asserting both halves of the contract: the exception still arrives with its `__traceback__` intact, and no `DeprecationWarning` is emitted. I verified the test fails against the old line and passes against the new one, so it genuinely guards the behaviour rather than just tracking it.

## Verification

- `pytest tests/unit` — 1833 passed, 1 skipped (1832 before, plus the new test); warnings drop from 70 to 36
- `ruff format --check` and `flake8 google tests` — clean
- Reproduced the original warning with only `google-cloud-ndb` and the standard library; see #18158 for the standalone snippet
