### PR TITLE
chore: cancel old GA jobs when new commit is pushed

### DIFF
--- a/.github/workflows/bigtable-conformance.yaml
+++ b/.github/workflows/bigtable-conformance.yaml
@@ -1,6 +1,10 @@
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/django-spanner-django5.2_tests.yml
+++ b/.github/workflows/django-spanner-django5.2_tests.yml
@@ -1,6 +1,10 @@
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/import-profiler.yml
+++ b/.github/workflows/import-profiler.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   initialize:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,10 @@ name: lint
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   NOX_REUSE_EXISTING_VIRTUALENVS: "true"
   NOX_ENVDIR: "/tmp/shared_nox_envs"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,6 +12,10 @@ name: unittest
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   PACKAGE_DIRS: packages preview-packages
   NOX_REUSE_EXISTING_VIRTUALENVS: "true"


### PR DESCRIPTION
cancel stale jobs, to preserve room in queue for new ones