### PR TITLE
chore(bigtable): added warning to MutationsBatcher

### DIFF
--- a/packages/google-cloud-bigtable/docs/classic_client/batcher.rst
+++ b/packages/google-cloud-bigtable/docs/classic_client/batcher.rst
@@ -1,6 +1,13 @@
 Mutations Batching
 ~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+   If using ``MutationsBatcher``, please ensure you are using
+   ``google-cloud-bigtable >= 2.42.0``, or consider migrating to the
+   batcher provided by the synchronous/asynchronous data client
+   (:mod:`google.cloud.bigtable.data`).
+
 .. automodule:: google.cloud.bigtable.batcher
   :members:
   :show-inheritance:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/batcher.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/batcher.py
@@ -186,6 +186,13 @@ class MutationsBatcher(object):
 
     Note on thread safety: The same :class:`MutationBatcher` cannot be shared by multiple end-user threads.
 
+    .. warning::
+
+       If using ``MutationsBatcher``, please ensure you are using
+       ``google-cloud-bigtable >= 2.42.0``, or consider migrating to the
+       batcher provided by the synchronous/asynchronous data client
+       (:mod:`google.cloud.bigtable.data`).
+
     :type table: class
     :param table: class:`~google.cloud.bigtable.table.Table`.
 

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/table.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/table.py
@@ -873,6 +873,13 @@ class Table(object):
             :end-before: [END bigtable_api_mutations_batcher]
             :dedent: 4
 
+        .. warning::
+
+           If using ``MutationsBatcher``, please ensure you are using
+           ``google-cloud-bigtable >= 2.42.0``, or consider migrating to the
+           batcher provided by the synchronous/asynchronous data client
+           (:mod:`google.cloud.bigtable.data`).
+
         :type flush_count: int
         :param flush_count: (Optional) Maximum number of rows per batch. If it
                 reaches the max number of rows it calls finish_batch() to


### PR DESCRIPTION
Add warning to upgrade to MutationsBatcher docstrings, related to https://github.com/googleapis/google-cloud-python/pull/18122