### PR TITLE
feat: check python and dependency versions in spanner packages

### DIFF
--- a/packages/google-cloud-spanner/google/cloud/spanner/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner/__init__.py
@@ -15,6 +15,9 @@
 #
 from __future__ import absolute_import
 
+import google.api_core as api_core
+
+
 from google.cloud.spanner_v1 import (
     COMMIT_TIMESTAMP,
     AbstractSessionPool,
@@ -28,6 +31,12 @@ from google.cloud.spanner_v1 import (
     __version__,
     param_types,
 )
+
+if hasattr(api_core, "check_python_version") and hasattr(
+    api_core, "check_dependency_versions"
+):  # pragma: NO COVER
+    api_core.check_python_version(__name__)  # type: ignore
+    api_core.check_dependency_versions(__name__)  # type: ignore
 
 __all__ = (
     # google.cloud.spanner

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/__init__.py
@@ -15,6 +15,9 @@
 #
 from __future__ import absolute_import
 
+import google.api_core as api_core
+
+
 from google.cloud.spanner_v1 import gapic_version as package_version
 
 __version__: str = package_version.__version__
@@ -89,6 +92,12 @@ COMMIT_TIMESTAMP = "spanner.commit_timestamp()"
 This value can only be used for timestamp columns that have set the option
 ``(allow_commit_timestamp=true)`` in the schema.
 """
+
+if hasattr(api_core, "check_python_version") and hasattr(
+    api_core, "check_dependency_versions"
+):  # pragma: NO COVER
+    api_core.check_python_version(__name__)  # type: ignore
+    api_core.check_dependency_versions(__name__)  # type: ignore
 
 __all__ = (
     # google.cloud.spanner_v1


### PR DESCRIPTION
Adds `check_python_version(__name__)` and `check_dependency_versions(__name__)` to `google.cloud.spanner` and `google.cloud.spanner_v1` at package import time.

This establishes parity with the standard GAPIC-generated packages across the repository and ensures deprecation notices (such as Python version deprecations and upcoming `grpcio >= 1.83.0` PQC requirements) are consistently emitted when these packages are imported.

Towards: go/sdk:python-pqc