### PR TITLE
chore: user agent to include 'legacy-gcb' for pandas-related API requests

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/client.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/client.py
@@ -641,9 +641,9 @@ class Client(ClientWithProject):
             pandas_gbq = None  # type: ignore
 
         if pandas_gbq is None:
-            user_agent = "pandas-gbq/0.0.0"
+            user_agent = "pandas-gbq/0.0.0 legacy-gcb"
         else:
-            user_agent = f"pandas-gbq/{pandas_gbq.__version__}"
+            user_agent = f"pandas-gbq/{pandas_gbq.__version__} legacy-gcb"
 
         if client_info is None:
             amended_client_info = google.api_core.gapic_v1.client_info.ClientInfo(

--- a/packages/google-cloud-bigquery/tests/unit/test_client.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_client.py
@@ -865,7 +865,7 @@ class TestClient(unittest.TestCase):
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
         self.assertEqual(
-            kwargs["client_info"].user_agent, "app-agent pandas-gbq/0.13.0"
+            kwargs["client_info"].user_agent, "app-agent pandas-gbq/0.13.0 legacy-gcb"
         )
 
     def test_ensure_bqstorage_client_pandas_gbq_not_installed(self):
@@ -888,7 +888,7 @@ class TestClient(unittest.TestCase):
 
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
-        self.assertEqual(kwargs["client_info"].user_agent, "app-agent pandas-gbq/0.0.0")
+        self.assertEqual(kwargs["client_info"].user_agent, "app-agent pandas-gbq/0.0.0 legacy-gcb")
 
     def test_ensure_bqstorage_client_client_info_none(self):
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
@@ -905,7 +905,7 @@ class TestClient(unittest.TestCase):
 
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
-        self.assertEqual(kwargs["client_info"].user_agent, "pandas-gbq/0.0.0")
+        self.assertEqual(kwargs["client_info"].user_agent, "pandas-gbq/0.0.0 legacy-gcb")
 
     def test_ensure_bqstorage_client_client_info_user_agent_none(self):
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
@@ -926,7 +926,7 @@ class TestClient(unittest.TestCase):
 
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
-        self.assertEqual(kwargs["client_info"].user_agent, "pandas-gbq/0.0.0")
+        self.assertEqual(kwargs["client_info"].user_agent, "pandas-gbq/0.0.0 legacy-gcb")
 
     def test_ensure_bqstorage_client_missing_dependency(self):
         creds = _make_credentials()

--- a/packages/google-cloud-bigquery/tests/unit/test_client.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_client.py
@@ -888,7 +888,9 @@ class TestClient(unittest.TestCase):
 
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
-        self.assertEqual(kwargs["client_info"].user_agent, "app-agent pandas-gbq/0.0.0 legacy-gcb")
+        self.assertEqual(
+            kwargs["client_info"].user_agent, "app-agent pandas-gbq/0.0.0 legacy-gcb"
+        )
 
     def test_ensure_bqstorage_client_client_info_none(self):
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
@@ -905,7 +907,9 @@ class TestClient(unittest.TestCase):
 
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
-        self.assertEqual(kwargs["client_info"].user_agent, "pandas-gbq/0.0.0 legacy-gcb")
+        self.assertEqual(
+            kwargs["client_info"].user_agent, "pandas-gbq/0.0.0 legacy-gcb"
+        )
 
     def test_ensure_bqstorage_client_client_info_user_agent_none(self):
         bigquery_storage = pytest.importorskip("google.cloud.bigquery_storage")
@@ -926,7 +930,9 @@ class TestClient(unittest.TestCase):
 
         mock_client.assert_called_once()
         _, kwargs = mock_client.call_args
-        self.assertEqual(kwargs["client_info"].user_agent, "pandas-gbq/0.0.0 legacy-gcb")
+        self.assertEqual(
+            kwargs["client_info"].user_agent, "pandas-gbq/0.0.0 legacy-gcb"
+        )
 
     def test_ensure_bqstorage_client_missing_dependency(self):
         creds = _make_credentials()


### PR DESCRIPTION

This will allow us to disambiguate pandas-gbq usage from usage that hits it indirectly from the google-cloud-bigquery package.

 🦕