### PR TITLE
feat: add user-agent delegation telemetry for pandas-gbq

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -2991,6 +2991,16 @@ class RowIterator(HTTPIterator):
             create_bqstorage_client = False
             bqstorage_client = None
 
+        if _versions_helpers.PANDAS_GBQ_VERSIONS.is_delegation_supported:
+            client_info = getattr(
+                getattr(self.client, "_connection", None), "_client_info", None
+            )
+            if client_info:
+                ua = client_info.user_agent or ""
+                if "pandas-gbq" not in ua:
+                    version = _versions_helpers.PANDAS_GBQ_VERSIONS.installed_version
+                    client_info.user_agent = f"{ua} pandas-gbq/{version}".strip()
+
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -3006,7 +3006,7 @@ class RowIterator(HTTPIterator):
                         )
                         client_info.user_agent = f"{ua} pandas-gbq/{version}".strip()
             except Exception as exc:
-                _LOGGER.warning("Failed to update telemetry user-agent: %s", exc)
+                _LOGGER.debug("Failed to update telemetry user-agent: %s", exc)
 
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -20,6 +20,7 @@ import base64
 import copy
 import datetime
 import functools
+import logging
 import operator
 import typing
 import warnings
@@ -86,6 +87,7 @@ if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud import bigquery_storage  # type: ignore
     from google.cloud.bigquery.dataset import DatasetReference
 
+_LOGGER = logging.getLogger(__name__)
 
 _NO_GEOPANDAS_ERROR = (
     "The geopandas library is not installed, please install "
@@ -2992,14 +2994,19 @@ class RowIterator(HTTPIterator):
             bqstorage_client = None
 
         if _versions_helpers.PANDAS_GBQ_VERSIONS.is_delegation_supported:
-            client_info = getattr(
-                getattr(self.client, "_connection", None), "_client_info", None
-            )
-            if client_info:
-                ua = client_info.user_agent or ""
-                if "pandas-gbq" not in ua:
-                    version = _versions_helpers.PANDAS_GBQ_VERSIONS.installed_version
-                    client_info.user_agent = f"{ua} pandas-gbq/{version}".strip()
+            try:
+                client_info = getattr(
+                    getattr(self.client, "_connection", None), "_client_info", None
+                )
+                if client_info:
+                    ua = getattr(client_info, "user_agent", None) or ""
+                    if "pandas-gbq" not in ua:
+                        version = (
+                            _versions_helpers.PANDAS_GBQ_VERSIONS.installed_version
+                        )
+                        client_info.user_agent = f"{ua} pandas-gbq/{version}".strip()
+            except Exception as exc:
+                _LOGGER.warning("Failed to update telemetry user-agent: %s", exc)
 
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5961,11 +5961,6 @@ class TestRowIterator(unittest.TestCase):
                 "gl-python/3.10.0",
             )
 
-    @pytest.fixture
-    def _caplog(self, caplog):
-        self._caplog = caplog
-
-    @pytest.mark.usefixtures("_caplog")
     def test_to_dataframe_delegated_when_user_agent_update_fails_logs_debug(self):
         pytest.importorskip("db_dtypes")
         pandas = pytest.importorskip("pandas")
@@ -5984,7 +5979,6 @@ class TestRowIterator(unittest.TestCase):
         mock_client = _mock_client()
         mock_client._connection = mock.Mock(_client_info=ReadOnlyClientInfo())
 
-        self._caplog.set_level(logging.DEBUG, logger="google.cloud.bigquery.table")
         with (
             mock.patch(
                 "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
@@ -5996,6 +5990,7 @@ class TestRowIterator(unittest.TestCase):
                 False,
             ),
             mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
+            self.assertLogs("google.cloud.bigquery.table", level="DEBUG") as cm,
         ):
             row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
             row_iterator.client = mock_client
@@ -6003,8 +5998,8 @@ class TestRowIterator(unittest.TestCase):
             df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
 
             self.assertIsInstance(df, pandas.DataFrame)
-            self.assertIn(
-                "Failed to update telemetry user-agent", self._caplog.text
+            self.assertTrue(
+                any("Failed to update telemetry user-agent" in msg for msg in cm.output)
             )
 
     def test_to_geodataframe_updates_user_agent(self):

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5961,6 +5961,48 @@ class TestRowIterator(unittest.TestCase):
                 "gl-python/3.10.0",
             )
 
+    def test_to_dataframe_delegated_when_user_agent_update_fails_logs_warning(self):
+        pytest.importorskip("db_dtypes")
+        pandas = pytest.importorskip("pandas")
+        mock_pandas_gbq = mock.Mock()
+        mock_pandas_gbq.__version__ = "1.0.0"
+
+        class ReadOnlyClientInfo:
+            @property
+            def user_agent(self):
+                return "gl-python/3.10.0"
+
+            @user_agent.setter
+            def user_agent(self, value):
+                raise AttributeError("user_agent is read-only")
+
+        mock_client = _mock_client()
+        mock_client._connection = mock.Mock(_client_info=ReadOnlyClientInfo())
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.SUPPORTS_RANGE_PYARROW",
+                False,
+            ),
+            mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
+            mock.patch("google.cloud.bigquery.table._LOGGER.warning") as mock_log,
+        ):
+            row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+            row_iterator.client = mock_client
+
+            df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
+
+            self.assertIsInstance(df, pandas.DataFrame)
+            mock_log.assert_called_once()
+            self.assertIn(
+                "Failed to update telemetry user-agent", mock_log.call_args[0][0]
+            )
+
     def test_to_geodataframe_updates_user_agent(self):
         pytest.importorskip("geopandas")
         pyarrow = pytest.importorskip("pyarrow")

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5961,6 +5961,11 @@ class TestRowIterator(unittest.TestCase):
                 "gl-python/3.10.0",
             )
 
+    @pytest.fixture
+    def _caplog(self, caplog):
+        self._caplog = caplog
+
+    @pytest.mark.usefixtures("_caplog")
     def test_to_dataframe_delegated_when_user_agent_update_fails_logs_debug(self):
         pytest.importorskip("db_dtypes")
         pandas = pytest.importorskip("pandas")
@@ -5979,6 +5984,7 @@ class TestRowIterator(unittest.TestCase):
         mock_client = _mock_client()
         mock_client._connection = mock.Mock(_client_info=ReadOnlyClientInfo())
 
+        self._caplog.set_level(logging.DEBUG, logger="google.cloud.bigquery.table")
         with (
             mock.patch(
                 "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
@@ -5990,7 +5996,6 @@ class TestRowIterator(unittest.TestCase):
                 False,
             ),
             mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
-            mock.patch("google.cloud.bigquery.table._LOGGER.debug") as mock_log,
         ):
             row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
             row_iterator.client = mock_client
@@ -5998,9 +6003,8 @@ class TestRowIterator(unittest.TestCase):
             df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
 
             self.assertIsInstance(df, pandas.DataFrame)
-            mock_log.assert_called_once()
             self.assertIn(
-                "Failed to update telemetry user-agent", mock_log.call_args[0][0]
+                "Failed to update telemetry user-agent", self._caplog.text
             )
 
     def test_to_geodataframe_updates_user_agent(self):

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5981,6 +5981,11 @@ class TestRowIterator(unittest.TestCase):
                 new_callable=mock.PropertyMock,
                 return_value=True,
             ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.installed_version",
+                new_callable=mock.PropertyMock,
+                return_value="1.0.0",
+            ),
             mock.patch.object(row_iterator, "to_arrow", return_value=batch),
         ):
             _ = row_iterator.to_geodataframe(create_bqstorage_client=False)

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5961,7 +5961,7 @@ class TestRowIterator(unittest.TestCase):
                 "gl-python/3.10.0",
             )
 
-    def test_to_dataframe_delegated_when_user_agent_update_fails_logs_warning(self):
+    def test_to_dataframe_delegated_when_user_agent_update_fails_logs_debug(self):
         pytest.importorskip("db_dtypes")
         pandas = pytest.importorskip("pandas")
         mock_pandas_gbq = mock.Mock()
@@ -5990,7 +5990,7 @@ class TestRowIterator(unittest.TestCase):
                 False,
             ),
             mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
-            mock.patch("google.cloud.bigquery.table._LOGGER.warning") as mock_log,
+            mock.patch("google.cloud.bigquery.table._LOGGER.debug") as mock_log,
         ):
             row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
             row_iterator.client = mock_client

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -16,6 +16,7 @@ import copy
 import datetime
 import logging
 import re
+import sys
 import time
 import types
 import unittest
@@ -5794,6 +5795,223 @@ class TestRowIterator(unittest.TestCase):
             if issubclass(w.category, (PendingDeprecationWarning, DeprecationWarning))
         ]
         self.assertEqual(len(deprecation_warnings), 0)
+
+    def test_to_dataframe_delegated_updates_user_agent(self):
+        pytest.importorskip("db_dtypes")
+        pandas = pytest.importorskip("pandas")
+        mock_pandas_gbq = mock.Mock()
+        mock_pandas_gbq.__version__ = "1.0.0"
+
+        mock_client_info = mock.Mock()
+        mock_client_info.user_agent = "gl-python/3.10.0"
+
+        mock_client = _mock_client()
+        mock_client._connection = mock.Mock(_client_info=mock_client_info)
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.SUPPORTS_RANGE_PYARROW",
+                False,
+            ),
+            mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
+        ):
+            row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+            row_iterator.client = mock_client
+
+            df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
+
+            self.assertIsInstance(df, pandas.DataFrame)
+            self.assertEqual(
+                mock_client_info.user_agent,
+                "gl-python/3.10.0 pandas-gbq/1.0.0",
+            )
+
+    def test_to_dataframe_delegated_does_not_duplicate_user_agent(self):
+        pytest.importorskip("db_dtypes")
+        pandas = pytest.importorskip("pandas")
+        mock_pandas_gbq = mock.Mock()
+        mock_pandas_gbq.__version__ = "1.0.0"
+
+        mock_client_info = mock.Mock()
+        mock_client_info.user_agent = "gl-python/3.10.0 pandas-gbq/1.0.0"
+
+        mock_client = _mock_client()
+        mock_client._connection = mock.Mock(_client_info=mock_client_info)
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.SUPPORTS_RANGE_PYARROW",
+                False,
+            ),
+            mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
+        ):
+            row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+            row_iterator.client = mock_client
+
+            df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
+
+            self.assertIsInstance(df, pandas.DataFrame)
+            self.assertEqual(
+                mock_client_info.user_agent,
+                "gl-python/3.10.0 pandas-gbq/1.0.0",
+            )
+
+    def test_to_dataframe_delegated_when_client_info_is_none(self):
+        pytest.importorskip("db_dtypes")
+        pandas = pytest.importorskip("pandas")
+        mock_pandas_gbq = mock.Mock()
+        mock_pandas_gbq.__version__ = "1.0.0"
+
+        mock_client = _mock_client()
+        mock_client._connection = mock.Mock(_client_info=None)
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.SUPPORTS_RANGE_PYARROW",
+                False,
+            ),
+            mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
+        ):
+            row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+            row_iterator.client = mock_client
+
+            df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
+
+            self.assertIsInstance(df, pandas.DataFrame)
+
+    def test_to_dataframe_delegated_when_user_agent_is_none(self):
+        pytest.importorskip("db_dtypes")
+        pandas = pytest.importorskip("pandas")
+        mock_pandas_gbq = mock.Mock()
+        mock_pandas_gbq.__version__ = "1.0.0"
+
+        mock_client_info = mock.Mock()
+        mock_client_info.user_agent = None
+
+        mock_client = _mock_client()
+        mock_client._connection = mock.Mock(_client_info=mock_client_info)
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.SUPPORTS_RANGE_PYARROW",
+                False,
+            ),
+            mock.patch.dict(sys.modules, {"pandas_gbq": mock_pandas_gbq}),
+        ):
+            row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+            row_iterator.client = mock_client
+
+            df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
+
+            self.assertIsInstance(df, pandas.DataFrame)
+            self.assertEqual(
+                mock_client_info.user_agent,
+                "pandas-gbq/1.0.0",
+            )
+
+    def test_to_dataframe_delegated_false_does_not_update_user_agent(self):
+        pytest.importorskip("db_dtypes")
+        pandas = pytest.importorskip("pandas")
+
+        mock_client_info = mock.Mock()
+        mock_client_info.user_agent = "gl-python/3.10.0"
+
+        mock_client = _mock_client()
+        mock_client._connection = mock.Mock(_client_info=mock_client_info)
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.SUPPORTS_RANGE_PYARROW",
+                False,
+            ),
+        ):
+            row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+            row_iterator.client = mock_client
+
+            df = row_iterator.to_dataframe(progress_bar_type="tqdm", timeout=5.0)
+
+            self.assertIsInstance(df, pandas.DataFrame)
+            self.assertEqual(
+                mock_client_info.user_agent,
+                "gl-python/3.10.0",
+            )
+
+    def test_to_geodataframe_updates_user_agent(self):
+        pytest.importorskip("geopandas")
+        pyarrow = pytest.importorskip("pyarrow")
+        row_iterator = self._make_one_from_data(
+            (("name", "STRING"), ("geog", "GEOGRAPHY")),
+            (("foo", "Point(0 0)"),),
+        )
+        mock_client_info = mock.Mock(user_agent="test-agent")
+        row_iterator.client._connection = mock.Mock(_client_info=mock_client_info)
+        batch = pyarrow.RecordBatch.from_arrays(
+            [pyarrow.array(["foo"]), pyarrow.array(["Point(0 0)"])],
+            names=["name", "geog"],
+        )
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=True,
+            ),
+            mock.patch.object(row_iterator, "to_arrow", return_value=batch),
+        ):
+            _ = row_iterator.to_geodataframe(create_bqstorage_client=False)
+
+            self.assertIn("pandas-gbq/", mock_client_info.user_agent)
+
+    def test_to_geodataframe_delegated_false_does_not_update_user_agent(self):
+        pytest.importorskip("geopandas")
+        pyarrow = pytest.importorskip("pyarrow")
+        row_iterator = self._make_one_from_data(
+            (("name", "STRING"), ("geog", "GEOGRAPHY")),
+            (("foo", "Point(0 0)"),),
+        )
+        mock_client_info = mock.Mock(user_agent="test-agent")
+        row_iterator.client._connection = mock.Mock(_client_info=mock_client_info)
+        batch = pyarrow.RecordBatch.from_arrays(
+            [pyarrow.array(["foo"]), pyarrow.array(["Point(0 0)"])],
+            names=["name", "geog"],
+        )
+
+        with (
+            mock.patch(
+                "google.cloud.bigquery._versions_helpers.PandasGBQVersions.is_delegation_supported",
+                new_callable=mock.PropertyMock,
+                return_value=False,
+            ),
+            mock.patch.object(row_iterator, "to_arrow", return_value=batch),
+        ):
+            _ = row_iterator.to_geodataframe(create_bqstorage_client=False)
+
+            self.assertEqual(mock_client_info.user_agent, "test-agent")
 
 
 class TestPartitionRange(unittest.TestCase):


### PR DESCRIPTION
Appends `pandas-gbq/<version>` to `ClientInfo.user_agent` when `RowIterator.to_dataframe()` or `RowIterator.to_geodataframe()` is executed and query delegation is supported by `pandas-gbq`.

This PR enables backend metrics and BigQuery audit logs to differentiate between direct client-side conversion and delegated conversions, without altering existing DataFrame results or runtime behavior.

Supersedes #17704.

### Key Changes
- **`google/cloud/bigquery/table.py`**: Injects `pandas-gbq/<version>` into `client_info.user_agent` with deduplication check when `PANDAS_GBQ_VERSIONS.is_delegation_supported` is `True`.
- **`tests/unit/test_table.py`**: Adds unit tests for user-agent injection, deduplication, missing `client_info`/`user_agent`, and unsupported fallback behavior.


Fixes #<540939659> 🦕