### PR TITLE
fix(auth): pass an explicit protocol to ssl.SSLContext() in tests

### DIFF
--- a/packages/google-auth/tests/transport/test__custom_tls_signer.py
+++ b/packages/google-auth/tests/transport/test__custom_tls_signer.py
@@ -215,7 +215,7 @@ def test_custom_tls_signer_provider():
             ENTERPRISE_CERT_FILE_PROVIDER
         )
         signer_object.load_libraries()
-        signer_object.attach_to_ssl_context(ssl.SSLContext())
+        signer_object.attach_to_ssl_context(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
 
     assert signer_object.should_use_provider()
     assert signer_object._enterprise_cert_file_path == ENTERPRISE_CERT_FILE_PROVIDER
@@ -238,7 +238,7 @@ def test_custom_tls_signer_failed_to_attach():
         signer_object._sign_callback = mock.MagicMock()
         signer_object._cert = b"mock cert"
         signer_object._offload_lib.ConfigureSslContext.return_value = False
-        signer_object.attach_to_ssl_context(ssl.SSLContext())
+        signer_object.attach_to_ssl_context(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
     assert excinfo.match("failed to configure ECP Offload SSL context")
 
 
@@ -249,7 +249,7 @@ def test_custom_tls_signer_failed_to_attach_provider():
         )
         signer_object._provider_lib = mock.MagicMock()
         signer_object._provider_lib.ECP_attach_to_ctx.return_value = False
-        signer_object.attach_to_ssl_context(ssl.SSLContext())
+        signer_object.attach_to_ssl_context(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
     assert excinfo.match("failed to configure ECP Provider SSL context")
 
 
@@ -258,12 +258,12 @@ def test_custom_tls_signer_failed_to_attach_no_libs():
         signer_object = _custom_tls_signer.CustomTlsSigner(ENTERPRISE_CERT_FILE)
         signer_object._offload_lib = None
         signer_object._signer_lib = None
-        signer_object.attach_to_ssl_context(ssl.SSLContext())
+        signer_object.attach_to_ssl_context(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
     assert excinfo.match("Invalid ECP configuration.")
 
 
 def test_cast_ssl_ctx_to_void_p_stdlib_success():
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     fake_impl = mock.Mock()
     fake_impl.name = "cpython"
     with mock.patch("sys.implementation", fake_impl):
@@ -282,7 +282,7 @@ def test_cast_ssl_ctx_to_void_p_stdlib_success():
 
 
 def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_pypy():
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     fake_impl = mock.Mock()
     fake_impl.name = "pypy"
 
@@ -295,7 +295,7 @@ def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_pypy():
 
 
 def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_trace_refs():
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     fake_impl = mock.Mock()
     fake_impl.name = "cpython"
 
@@ -317,7 +317,7 @@ def test_cast_ssl_ctx_to_void_p_stdlib_type_error():
 
 
 def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_debug_flag():
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     fake_impl = mock.Mock()
     fake_impl.name = "cpython"
     with mock.patch("sys.implementation", fake_impl), mock.patch(
@@ -331,7 +331,7 @@ def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_debug_flag():
 
 
 def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_free_threaded():
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
     def mock_get_config_var(var):
         if var == "Py_GIL_DISABLED":
@@ -351,7 +351,7 @@ def test_cast_ssl_ctx_to_void_p_stdlib_unsupported_runtime_free_threaded():
 
 
 def test_cast_ssl_ctx_to_void_p_stdlib_dynamic_offset():
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     with mock.patch("sys.getsizeof", return_value=40) as mock_sizeof:
         with mock.patch("ctypes.c_void_p.from_address") as mock_from_address:
             _custom_tls_signer._cast_ssl_ctx_to_void_p_stdlib(context)


### PR DESCRIPTION
Fixes #17760

Constructing `ssl.SSLContext()` without a protocol argument is deprecated since Python 3.10. `tests/transport/test__custom_tls_signer.py` does this ten times, so every run of the module emits 20 `DeprecationWarning`s (two per call site on 3.14).

### Change

Replace each bare `ssl.SSLContext()` with `ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)`. One file, +10/−10.

### Why `PROTOCOL_TLS_CLIENT` is the right protocol

- It is what the library actually receives in production: `transport/requests.py` and `transport/urllib3.py` obtain their contexts from `urllib3.util.ssl_.create_urllib3_context()`, which builds them with `PROTOCOL_TLS_CLIENT`. The tests now exercise `attach_to_ssl_context()` with the same kind of context the real code passes in.
- The tests never inspect `check_hostname`, `verify_mode` or `protocol`; they only hand the context to mocked native libraries via `_cast_ssl_ctx_to_void_p_stdlib`. So the stricter defaults of a client context (`check_hostname=True`, `verify_mode=CERT_REQUIRED`) do not affect any assertion.

### Verification

- `tests/transport/test__custom_tls_signer.py` on Python 3.10 and 3.14: 22 passed; `without protocol` warnings 20 → 0.
- Full `google-auth` unit suite on 3.10 and 3.14: all passing apart from two pre-existing `test_id_token` failures caused by a missing optional `jwt` module in the local environment (identical on an unmodified `main`).
- `black --check` and `flake8 --import-order-style=google` clean.
