### PR TITLE
fix(bigtable): Log warning on background task failure instead of exception

### DIFF
--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/_async/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/_async/client.py
@@ -416,11 +416,18 @@ class BigtableDataClientAsync(ClientWithProject):
         ):
             # raise error if not in an event loop in async client
             CrossSync.verify_async_event_loop()
-            self._channel_refresh_task = CrossSync.create_task(
-                self._manage_channel,
-                sync_executor=self._executor,
-                task_name=f"{self.__class__.__name__} channel refresh",
-            )
+            try:
+                self._channel_refresh_task = CrossSync.create_task(
+                    self._manage_channel,
+                    sync_executor=self._executor,
+                    task_name=f"{self.__class__.__name__} channel refresh",
+                )
+            except Exception as e:
+                _LOGGER.warning(
+                    f"Failed to start background channel refresh task: {e}. "
+                    "Channel refresh will be disabled."
+                )
+                self._channel_refresh_task = None
 
     @CrossSync.convert
     async def close(self, timeout: float | None = 2.0):
@@ -1158,13 +1165,22 @@ class _DataApiTargetAsync(abc.ABC):
                 raise RuntimeError(
                     f"{self.__class__.__name__} must be created within an async event loop context."
                 ) from e
-        self._register_instance_future = CrossSync.create_task(
-            self.client._register_instance,
-            self.instance_id,
-            self.app_profile_id,
-            id(self),
-            sync_executor=self.client._executor,
-        )
+        try:
+            self._register_instance_future: CrossSync.Future[None] | None = (
+                CrossSync.create_task(
+                    self.client._register_instance,
+                    self.instance_id,
+                    self.app_profile_id,
+                    id(self),
+                    sync_executor=self.client._executor,
+                )
+            )
+        except Exception as e:
+            _LOGGER.warning(
+                f"Failed to start background instance registration: {e}. "
+                "Requests will proceed without proactive channel warming."
+            )
+            self._register_instance_future = None
 
     def _create_operation(
         self, op_type: OperationType, **kwargs

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/_async/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/_async/client.py
@@ -1151,18 +1151,20 @@ class _DataApiTargetAsync(abc.ABC):
             default_retryable_errors or ()
         )
 
-        try:
-            self._register_instance_future = CrossSync.create_task(
-                self.client._register_instance,
-                self.instance_id,
-                self.app_profile_id,
-                id(self),
-                sync_executor=self.client._executor,
-            )
-        except RuntimeError as e:
-            raise RuntimeError(
-                f"{self.__class__.__name__} must be created within an async event loop context."
-            ) from e
+        if CrossSync.is_async:
+            try:
+                CrossSync.verify_async_event_loop()
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"{self.__class__.__name__} must be created within an async event loop context."
+                ) from e
+        self._register_instance_future = CrossSync.create_task(
+            self.client._register_instance,
+            self.instance_id,
+            self.app_profile_id,
+            id(self),
+            sync_executor=self.client._executor,
+        )
 
     def _create_operation(
         self, op_type: OperationType, **kwargs

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/_sync_autogen/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/_sync_autogen/client.py
@@ -907,18 +907,13 @@ class _DataApiTarget(abc.ABC):
         self.default_retryable_errors: Sequence[type[Exception]] = (
             default_retryable_errors or ()
         )
-        try:
-            self._register_instance_future = CrossSync._Sync_Impl.create_task(
-                self.client._register_instance,
-                self.instance_id,
-                self.app_profile_id,
-                id(self),
-                sync_executor=self.client._executor,
-            )
-        except RuntimeError as e:
-            raise RuntimeError(
-                f"{self.__class__.__name__} must be created within an async event loop context."
-            ) from e
+        self._register_instance_future = CrossSync._Sync_Impl.create_task(
+            self.client._register_instance,
+            self.instance_id,
+            self.app_profile_id,
+            id(self),
+            sync_executor=self.client._executor,
+        )
 
     def _create_operation(
         self, op_type: OperationType, **kwargs

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/_sync_autogen/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/_sync_autogen/client.py
@@ -306,11 +306,17 @@ class BigtableDataClient(ClientWithProject):
             and (not self._disable_background_refresh)
         ):
             CrossSync._Sync_Impl.verify_async_event_loop()
-            self._channel_refresh_task = CrossSync._Sync_Impl.create_task(
-                self._manage_channel,
-                sync_executor=self._executor,
-                task_name=f"{self.__class__.__name__} channel refresh",
-            )
+            try:
+                self._channel_refresh_task = CrossSync._Sync_Impl.create_task(
+                    self._manage_channel,
+                    sync_executor=self._executor,
+                    task_name=f"{self.__class__.__name__} channel refresh",
+                )
+            except Exception as e:
+                _LOGGER.warning(
+                    f"Failed to start background channel refresh task: {e}. Channel refresh will be disabled."
+                )
+                self._channel_refresh_task = None
 
     def close(self, timeout: float | None = 2.0):
         """Cancel all background tasks"""
@@ -907,13 +913,21 @@ class _DataApiTarget(abc.ABC):
         self.default_retryable_errors: Sequence[type[Exception]] = (
             default_retryable_errors or ()
         )
-        self._register_instance_future = CrossSync._Sync_Impl.create_task(
-            self.client._register_instance,
-            self.instance_id,
-            self.app_profile_id,
-            id(self),
-            sync_executor=self.client._executor,
-        )
+        try:
+            self._register_instance_future: CrossSync._Sync_Impl.Future[None] | None = (
+                CrossSync._Sync_Impl.create_task(
+                    self.client._register_instance,
+                    self.instance_id,
+                    self.app_profile_id,
+                    id(self),
+                    sync_executor=self.client._executor,
+                )
+            )
+        except Exception as e:
+            _LOGGER.warning(
+                f"Failed to start background instance registration: {e}. Requests will proceed without proactive channel warming."
+            )
+            self._register_instance_future = None
 
     def _create_operation(
         self, op_type: OperationType, **kwargs

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_async/execute_query_iterator.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_async/execute_query_iterator.py
@@ -144,18 +144,20 @@ class ExecuteQueryIteratorAsync:
         )
         self._req_metadata = req_metadata
         self._column_info = column_info
-        try:
-            self._register_instance_task = CrossSync.create_task(
-                self._client._register_instance,
-                self._instance_id,
-                self.app_profile_id,
-                id(self),
-                sync_executor=self._client._executor,
-            )
-        except RuntimeError as e:
-            raise RuntimeError(
-                f"{self.__class__.__name__} must be created within an async event loop context."
-            ) from e
+        if CrossSync.is_async:
+            try:
+                CrossSync.verify_async_event_loop()
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"{self.__class__.__name__} must be created within an async event loop context."
+                ) from e
+        self._register_instance_task = CrossSync.create_task(
+            self._client._register_instance,
+            self._instance_id,
+            self.app_profile_id,
+            id(self),
+            sync_executor=self._client._executor,
+        )
 
     @property
     def is_closed(self) -> bool:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_async/execute_query_iterator.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_async/execute_query_iterator.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -59,6 +60,8 @@ if TYPE_CHECKING:
 __CROSS_SYNC_OUTPUT__ = (
     "google.cloud.bigtable.data.execute_query._sync_autogen.execute_query_iterator"
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _has_resume_token(response: ExecuteQueryResponse) -> bool:
@@ -151,13 +154,20 @@ class ExecuteQueryIteratorAsync:
                 raise RuntimeError(
                     f"{self.__class__.__name__} must be created within an async event loop context."
                 ) from e
-        self._register_instance_task = CrossSync.create_task(
-            self._client._register_instance,
-            self._instance_id,
-            self.app_profile_id,
-            id(self),
-            sync_executor=self._client._executor,
-        )
+        try:
+            self._register_instance_task = CrossSync.create_task(
+                self._client._register_instance,
+                self._instance_id,
+                self.app_profile_id,
+                id(self),
+                sync_executor=self._client._executor,
+            )
+        except Exception as e:
+            _LOGGER.warning(
+                f"Failed to start background instance registration: {e}. "
+                "Requests will proceed without proactive channel warming."
+            )
+            self._register_instance_task = None
 
     @property
     def is_closed(self) -> bool:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_sync_autogen/execute_query_iterator.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_sync_autogen/execute_query_iterator.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
 
 from google.api_core import retry as retries
@@ -46,6 +47,7 @@ from google.cloud.bigtable_v2.types.bigtable import ExecuteQueryResponse
 
 if TYPE_CHECKING:
     from google.cloud.bigtable.data import BigtableDataClient as DataClientType
+_LOGGER = logging.getLogger(__name__)
 
 
 def _has_resume_token(response: ExecuteQueryResponse) -> bool:
@@ -119,13 +121,19 @@ class ExecuteQueryIterator:
         )
         self._req_metadata = req_metadata
         self._column_info = column_info
-        self._register_instance_task = CrossSync._Sync_Impl.create_task(
-            self._client._register_instance,
-            self._instance_id,
-            self.app_profile_id,
-            id(self),
-            sync_executor=self._client._executor,
-        )
+        try:
+            self._register_instance_task = CrossSync._Sync_Impl.create_task(
+                self._client._register_instance,
+                self._instance_id,
+                self.app_profile_id,
+                id(self),
+                sync_executor=self._client._executor,
+            )
+        except Exception as e:
+            _LOGGER.warning(
+                f"Failed to start background instance registration: {e}. Requests will proceed without proactive channel warming."
+            )
+            self._register_instance_task = None
 
     @property
     def is_closed(self) -> bool:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_sync_autogen/execute_query_iterator.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_sync_autogen/execute_query_iterator.py
@@ -119,18 +119,13 @@ class ExecuteQueryIterator:
         )
         self._req_metadata = req_metadata
         self._column_info = column_info
-        try:
-            self._register_instance_task = CrossSync._Sync_Impl.create_task(
-                self._client._register_instance,
-                self._instance_id,
-                self.app_profile_id,
-                id(self),
-                sync_executor=self._client._executor,
-            )
-        except RuntimeError as e:
-            raise RuntimeError(
-                f"{self.__class__.__name__} must be created within an async event loop context."
-            ) from e
+        self._register_instance_task = CrossSync._Sync_Impl.create_task(
+            self._client._register_instance,
+            self._instance_id,
+            self.app_profile_id,
+            id(self),
+            sync_executor=self._client._executor,
+        )
 
     @property
     def is_closed(self) -> bool:

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -404,6 +404,28 @@ class TestBigtableDataClientAsync:
             assert client._channel_refresh_task is None
             ping_and_warm.assert_not_called()
 
+    @CrossSync.pytest
+    async def test__start_background_channel_refresh_task_creation_failure(
+        self, caplog
+    ):
+        import logging
+
+        client = self._make_client(
+            project="project-id",
+            _disable_background_refresh=True,
+        )
+        client._disable_background_refresh = False
+        client._emulator_host = None
+        with mock.patch.object(
+            CrossSync, "create_task", side_effect=RuntimeError("can't start new thread")
+        ):
+            with caplog.at_level(logging.WARNING):
+                client._start_background_channel_refresh()
+                assert client._channel_refresh_task is None
+                assert "Failed to start background channel refresh task" in caplog.text
+                assert "can't start new thread" in caplog.text
+        await client.close()
+
     @CrossSync.drop
     @CrossSync.pytest
     async def test__start_background_channel_refresh_task_names(self):
@@ -1506,6 +1528,25 @@ class TestTableAsync:
         with pytest.raises(RuntimeError) as e:
             TableAsync(client, "instance-id", "table-id")
         assert e.match("TableAsync must be created within an async event loop context.")
+    @CrossSync.pytest
+    async def test_table_ctor_task_creation_failure_warns_and_continues(self, caplog):
+        import logging
+
+        client = self._make_client()
+        with mock.patch.object(
+            CrossSync, "create_task", side_effect=RuntimeError("can't start new thread")
+        ):
+            with caplog.at_level(logging.WARNING):
+                table = self._make_one(client)
+                assert table._register_instance_future is None
+                assert (
+                    "Failed to start background instance registration" in caplog.text
+                )
+                assert "can't start new thread" in caplog.text
+        async with table:
+            pass
+        await table.close()
+        await client.close()
 
     @CrossSync.pytest
     # iterate over all retryable rpcs

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -1528,6 +1528,7 @@ class TestTableAsync:
         with pytest.raises(RuntimeError) as e:
             TableAsync(client, "instance-id", "table-id")
         assert e.match("TableAsync must be created within an async event loop context.")
+
     @CrossSync.pytest
     async def test_table_ctor_task_creation_failure_warns_and_continues(self, caplog):
         import logging
@@ -1539,9 +1540,7 @@ class TestTableAsync:
             with caplog.at_level(logging.WARNING):
                 table = self._make_one(client)
                 assert table._register_instance_future is None
-                assert (
-                    "Failed to start background instance registration" in caplog.text
-                )
+                assert "Failed to start background instance registration" in caplog.text
                 assert "can't start new thread" in caplog.text
         async with table:
             pass

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -418,12 +418,17 @@ class TestBigtableDataClientAsync:
         client._emulator_host = None
         with mock.patch.object(
             CrossSync, "create_task", side_effect=RuntimeError("can't start new thread")
-        ):
+        ) as mock_create_task:
             with caplog.at_level(logging.WARNING):
                 client._start_background_channel_refresh()
                 assert client._channel_refresh_task is None
                 assert "Failed to start background channel refresh task" in caplog.text
                 assert "can't start new thread" in caplog.text
+                mock_create_task.assert_called_once_with(
+                    client._manage_channel,
+                    sync_executor=client._executor,
+                    task_name=f"{client.__class__.__name__} channel refresh",
+                )
         await client.close()
 
     @CrossSync.drop
@@ -1536,12 +1541,19 @@ class TestTableAsync:
         client = self._make_client()
         with mock.patch.object(
             CrossSync, "create_task", side_effect=RuntimeError("can't start new thread")
-        ):
+        ) as mock_create_task:
             with caplog.at_level(logging.WARNING):
                 table = self._make_one(client)
                 assert table._register_instance_future is None
                 assert "Failed to start background instance registration" in caplog.text
                 assert "can't start new thread" in caplog.text
+                mock_create_task.assert_called_once_with(
+                    client._register_instance,
+                    table.instance_id,
+                    table.app_profile_id,
+                    id(table),
+                    sync_executor=client._executor,
+                )
         async with table:
             pass
         await table.close()

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -358,12 +358,17 @@ class TestBigtableDataClient:
             CrossSync._Sync_Impl,
             "create_task",
             side_effect=RuntimeError("can't start new thread"),
-        ):
+        ) as mock_create_task:
             with caplog.at_level(logging.WARNING):
                 client._start_background_channel_refresh()
                 assert client._channel_refresh_task is None
                 assert "Failed to start background channel refresh task" in caplog.text
                 assert "can't start new thread" in caplog.text
+                mock_create_task.assert_called_once_with(
+                    client._manage_channel,
+                    sync_executor=client._executor,
+                    task_name=f"{client.__class__.__name__} channel refresh",
+                )
         client.close()
 
     def test__ping_and_warm_instances(self):
@@ -1290,12 +1295,19 @@ class TestTable:
             CrossSync._Sync_Impl,
             "create_task",
             side_effect=RuntimeError("can't start new thread"),
-        ):
+        ) as mock_create_task:
             with caplog.at_level(logging.WARNING):
                 table = self._make_one(client)
                 assert table._register_instance_future is None
                 assert "Failed to start background instance registration" in caplog.text
                 assert "can't start new thread" in caplog.text
+                mock_create_task.assert_called_once_with(
+                    client._register_instance,
+                    table.instance_id,
+                    table.app_profile_id,
+                    id(table),
+                    sync_executor=client._executor,
+                )
         with table:
             pass
         table.close()

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -346,6 +346,26 @@ class TestBigtableDataClient:
             assert client._channel_refresh_task is None
             ping_and_warm.assert_not_called()
 
+    def test__start_background_channel_refresh_task_creation_failure(self, caplog):
+        import logging
+
+        client = self._make_client(
+            project="project-id", _disable_background_refresh=True
+        )
+        client._disable_background_refresh = False
+        client._emulator_host = None
+        with mock.patch.object(
+            CrossSync._Sync_Impl,
+            "create_task",
+            side_effect=RuntimeError("can't start new thread"),
+        ):
+            with caplog.at_level(logging.WARNING):
+                client._start_background_channel_refresh()
+                assert client._channel_refresh_task is None
+                assert "Failed to start background channel refresh task" in caplog.text
+                assert "can't start new thread" in caplog.text
+        client.close()
+
     def test__ping_and_warm_instances(self):
         """test ping and warm with mocked asyncio.gather"""
         client_mock = mock.Mock()
@@ -1260,6 +1280,25 @@ class TestTable:
             with pytest.raises(ValueError) as e:
                 self._make_one(client, **{operation_timeout: -1})
             assert "operation_timeout must be greater than 0" in str(e.value)
+        client.close()
+
+    def test_table_ctor_task_creation_failure_warns_and_continues(self, caplog):
+        import logging
+
+        client = self._make_client()
+        with mock.patch.object(
+            CrossSync._Sync_Impl,
+            "create_task",
+            side_effect=RuntimeError("can't start new thread"),
+        ):
+            with caplog.at_level(logging.WARNING):
+                table = self._make_one(client)
+                assert table._register_instance_future is None
+                assert "Failed to start background instance registration" in caplog.text
+                assert "can't start new thread" in caplog.text
+        with table:
+            pass
+        table.close()
         client.close()
 
     @pytest.mark.parametrize(

--- a/packages/google-cloud-bigtable/tests/unit/data/execute_query/_async/test_query_iterator.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/execute_query/_async/test_query_iterator.py
@@ -401,3 +401,56 @@ class TestQueryIteratorAsync:
 
         # The close method should be called by the finally block on error
         client_mock._remove_instance_registration.assert_called_once()
+
+    @CrossSync.drop
+    def test_iterator_ctor_sync(self):
+        # initializing iterator in a sync context should raise RuntimeError
+        client_mock = mock.Mock()
+        client_mock._register_instance = CrossSync.Mock()
+        with pytest.raises(RuntimeError) as e:
+            self._make_one(
+                client=client_mock,
+                instance_id="test-instance",
+                app_profile_id="test_profile",
+                request_body={},
+                prepare_metadata=_pb_metadata_to_metadata_types(
+                    metadata(column("test1", int64_type()))
+                ),
+                attempt_timeout=10,
+                operation_timeout=10,
+            )
+        assert e.match(
+            f"{self._target_class().__name__} must be created within an async event loop context."
+        )
+
+    @CrossSync.pytest
+    async def test_iterator_ctor_task_creation_failure_warns_and_continues(
+        self, caplog
+    ):
+        import logging
+
+        client_mock = mock.Mock()
+        client_mock._register_instance = CrossSync.Mock()
+        client_mock._remove_instance_registration = CrossSync.Mock()
+        client_mock._executor = concurrent.futures.ThreadPoolExecutor()
+        with mock.patch.object(
+            CrossSync, "create_task", side_effect=RuntimeError("can't start new thread")
+        ):
+            with caplog.at_level(logging.WARNING):
+                iterator = self._make_one(
+                    client=client_mock,
+                    instance_id="test-instance",
+                    app_profile_id="test_profile",
+                    request_body={},
+                    prepare_metadata=_pb_metadata_to_metadata_types(
+                        metadata(column("test1", int64_type()))
+                    ),
+                    attempt_timeout=10,
+                    operation_timeout=10,
+                )
+                assert iterator._register_instance_task is None
+                assert (
+                    "Failed to start background instance registration" in caplog.text
+                )
+                assert "can't start new thread" in caplog.text
+        await iterator.close()

--- a/packages/google-cloud-bigtable/tests/unit/data/execute_query/_async/test_query_iterator.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/execute_query/_async/test_query_iterator.py
@@ -435,7 +435,7 @@ class TestQueryIteratorAsync:
         client_mock._executor = concurrent.futures.ThreadPoolExecutor()
         with mock.patch.object(
             CrossSync, "create_task", side_effect=RuntimeError("can't start new thread")
-        ):
+        ) as mock_create_task:
             with caplog.at_level(logging.WARNING):
                 iterator = self._make_one(
                     client=client_mock,
@@ -451,4 +451,11 @@ class TestQueryIteratorAsync:
                 assert iterator._register_instance_task is None
                 assert "Failed to start background instance registration" in caplog.text
                 assert "can't start new thread" in caplog.text
+                mock_create_task.assert_called_once_with(
+                    client_mock._register_instance,
+                    "test-instance",
+                    "test_profile",
+                    id(iterator),
+                    sync_executor=client_mock._executor,
+                )
         await iterator.close()

--- a/packages/google-cloud-bigtable/tests/unit/data/execute_query/_async/test_query_iterator.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/execute_query/_async/test_query_iterator.py
@@ -449,8 +449,6 @@ class TestQueryIteratorAsync:
                     operation_timeout=10,
                 )
                 assert iterator._register_instance_task is None
-                assert (
-                    "Failed to start background instance registration" in caplog.text
-                )
+                assert "Failed to start background instance registration" in caplog.text
                 assert "can't start new thread" in caplog.text
         await iterator.close()

--- a/packages/google-cloud-bigtable/tests/unit/data/execute_query/_sync_autogen/test_query_iterator.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/execute_query/_sync_autogen/test_query_iterator.py
@@ -350,3 +350,32 @@ class TestQueryIterator:
                 for _ in iterator:
                     pass
         client_mock._remove_instance_registration.assert_called_once()
+
+    def test_iterator_ctor_task_creation_failure_warns_and_continues(self, caplog):
+        import logging
+
+        client_mock = mock.Mock()
+        client_mock._register_instance = CrossSync._Sync_Impl.Mock()
+        client_mock._remove_instance_registration = CrossSync._Sync_Impl.Mock()
+        client_mock._executor = concurrent.futures.ThreadPoolExecutor()
+        with mock.patch.object(
+            CrossSync._Sync_Impl,
+            "create_task",
+            side_effect=RuntimeError("can't start new thread"),
+        ):
+            with caplog.at_level(logging.WARNING):
+                iterator = self._make_one(
+                    client=client_mock,
+                    instance_id="test-instance",
+                    app_profile_id="test_profile",
+                    request_body={},
+                    prepare_metadata=_pb_metadata_to_metadata_types(
+                        metadata(column("test1", int64_type()))
+                    ),
+                    attempt_timeout=10,
+                    operation_timeout=10,
+                )
+                assert iterator._register_instance_task is None
+                assert "Failed to start background instance registration" in caplog.text
+                assert "can't start new thread" in caplog.text
+        iterator.close()

--- a/packages/google-cloud-bigtable/tests/unit/data/execute_query/_sync_autogen/test_query_iterator.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/execute_query/_sync_autogen/test_query_iterator.py
@@ -362,7 +362,7 @@ class TestQueryIterator:
             CrossSync._Sync_Impl,
             "create_task",
             side_effect=RuntimeError("can't start new thread"),
-        ):
+        ) as mock_create_task:
             with caplog.at_level(logging.WARNING):
                 iterator = self._make_one(
                     client=client_mock,
@@ -378,4 +378,11 @@ class TestQueryIterator:
                 assert iterator._register_instance_task is None
                 assert "Failed to start background instance registration" in caplog.text
                 assert "can't start new thread" in caplog.text
+                mock_create_task.assert_called_once_with(
+                    client_mock._register_instance,
+                    "test-instance",
+                    "test_profile",
+                    id(iterator),
+                    sync_executor=client_mock._executor,
+                )
         iterator.close()


### PR DESCRIPTION
Bigtable data clients use background threads/coroutines to keep grpc channels warmed, and refresh them before expiration. These background tasks can fail due to resource exhaustion, or other issues.

This PR will log a warning and continue if there is an error during task set up, instead of rasing an exception

Also improves exception capture, which would sometimes state misleading information about the cause of the error.