### PR TITLE
feat(storage): add enable_bucket_metadata_cache opt-out

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/client.py
+++ b/packages/google-cloud-storage/google/cloud/storage/client.py
@@ -126,6 +126,13 @@ class Client(ClientWithProject):
         (Optional) An API key. Mutually exclusive with any other credentials.
         This parameter is an alias for setting `client_options.api_key` and
         will supercede any api key set in the `client_options` parameter.
+
+    :type enable_bucket_metadata_cache: bool
+    :param enable_bucket_metadata_cache:
+        (Optional, default True) Enables the background bucket-metadata cache
+        (App-centric Observability / ACO). Setting this to False disables the
+        cache and the background ``storage.buckets.get`` probe it triggers on
+        object-level operations, for principals granted object-only IAM roles.
     """
 
     SCOPE = (
@@ -146,6 +153,7 @@ class Client(ClientWithProject):
         extra_headers={},
         *,
         api_key=None,
+        enable_bucket_metadata_cache: bool = True,
     ):
         self._base_connection = None
 
@@ -292,7 +300,10 @@ class Client(ClientWithProject):
         connection.extra_headers = extra_headers
         self._connection = connection
         self._batch_stack = _LocalStack()
-        self._bucket_metadata_cache = BucketMetadataCache(self)
+        self._enable_bucket_metadata_cache = enable_bucket_metadata_cache
+        self._bucket_metadata_cache = (
+            BucketMetadataCache(self) if enable_bucket_metadata_cache else None
+        )
 
     def close(self):
         """Close the client and clear any cached metadata or active connections."""
@@ -1189,9 +1200,9 @@ class Client(ClientWithProject):
                 predefined_default_object_acl = DefaultObjectACL.validate_predefined(
                     predefined_default_object_acl
                 )
-                query_params["predefinedDefaultObjectAcl"] = (
-                    predefined_default_object_acl
-                )
+                query_params[
+                    "predefinedDefaultObjectAcl"
+                ] = predefined_default_object_acl
 
             if user_project is not None:
                 query_params["userProject"] = user_project

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -136,6 +136,32 @@ class TestClient(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
+    def test_ctor_bucket_metadata_cache_enabled_by_default(self):
+        credentials = _make_credentials()
+        client = self._make_one(project="PROJECT", credentials=credentials)
+
+        self.assertIsNotNone(client._bucket_metadata_cache)
+
+    def test_ctor_bucket_metadata_cache_opt_out(self):
+        credentials = _make_credentials()
+        client = self._make_one(
+            project="PROJECT",
+            credentials=credentials,
+            enable_bucket_metadata_cache=False,
+        )
+
+        self.assertIsNone(client._bucket_metadata_cache)
+
+    def test_close_ok_with_disabled_bucket_metadata_cache(self):
+        credentials = _make_credentials()
+        client = self._make_one(
+            project="PROJECT",
+            credentials=credentials,
+            enable_bucket_metadata_cache=False,
+        )
+
+        client.close()
+
     def test_ctor_connection_type(self):
         from google.cloud._http import ClientInfo
 


### PR DESCRIPTION
Fixes #17650

The background bucket-metadata cache (ACO) triggers `storage.buckets.get` on object-only operations like `list_blobs` / `download_*`, producing a continuous stream of denied-`storage.buckets.get` audit-log entries (ERROR severity) for principals granted object-only IAM roles — with no supported opt-out (the only workaround is mutating the private `_bucket_metadata_cache` attribute).

**Change:** new keyword-only constructor flag `enable_bucket_metadata_cache: bool = True` (mirroring the existing `api_key` pattern). When `False`, no `BucketMetadataCache` is instantiated, so `create_trace_span_helper`'s probe is inert — no background thread, no denied audit entries. `close()` already guards against a missing cache; `transfer_manager`'s client reconstruction is unaffected (it only carries `_initial_client_info`/\).

**Tests added (test_client.py):**
- cache enabled by default
- opt-out sets `_bucket_metadata_cache` to None
- `close()` works with the cache disabled

**Validation:**
- test_client.py + test_bucket.py + test__bucket_metadata_cache.py: 423 passed
- black --check: clean
- (gRPC/gapic suites need grpc deps not installable here; unrelated to this change)