### PR TITLE
fix(storage): resolve reST link target mismatch in README and add long_description_content_type

### DIFF
--- a/.librarian/generator-input/client-post-processing/storage-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/storage-integration.yaml
@@ -347,7 +347,7 @@ replacements:
       .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
       .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
       .. _Enable the Google Cloud Storage API.:  https://console.cloud.google.com/flows/enableapi?apiid=storage-api.googleapis.com
-      .. _Setup Authentication.: https://cloud.google.com/docs/authentication/client-libraries
+      .. _Set up Authentication.: https://cloud.google.com/docs/authentication/client-libraries
 
       Installation
       ~~~~~~~~~~~~

--- a/packages/google-cloud-storage/README.rst
+++ b/packages/google-cloud-storage/README.rst
@@ -55,7 +55,7 @@ A step-by-step guide may also be found in `Get Started with Client Libraries`_.
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
 .. _Enable the Google Cloud Storage API.:  https://console.cloud.google.com/flows/enableapi?apiid=storage-api.googleapis.com
-.. _Setup Authentication.: https://cloud.google.com/docs/authentication/client-libraries
+.. _Set up Authentication.: https://cloud.google.com/docs/authentication/client-libraries
 
 Installation
 ~~~~~~~~~~~~

--- a/packages/google-cloud-storage/docs/README.rst
+++ b/packages/google-cloud-storage/docs/README.rst
@@ -55,7 +55,7 @@ A step-by-step guide may also be found in `Get Started with Client Libraries`_.
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
 .. _Enable the Google Cloud Storage API.:  https://console.cloud.google.com/flows/enableapi?apiid=storage-api.googleapis.com
-.. _Setup Authentication.: https://cloud.google.com/docs/authentication/client-libraries
+.. _Set up Authentication.: https://cloud.google.com/docs/authentication/client-libraries
 
 Installation
 ~~~~~~~~~~~~

--- a/packages/google-cloud-storage/setup.py
+++ b/packages/google-cloud-storage/setup.py
@@ -117,6 +117,7 @@ setuptools.setup(
     version=version,
     description=description,
     long_description=readme,
+    long_description_content_type="text/x-rst",
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     license="Apache-2.0",

--- a/packages/google-cloud-storage/setup.py
+++ b/packages/google-cloud-storage/setup.py
@@ -117,7 +117,6 @@ setuptools.setup(
     version=version,
     description=description,
     long_description=readme,
-    long_description_content_type="text/x-rst",
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     license="Apache-2.0",


### PR DESCRIPTION
Fixes a reST target name mismatch in `README.rst` and `docs/README.rst` that caused PyPI upload failures, and explicitly sets `long_description_content_type="text/x-rst"` in `setup.py`.

Verified with `twine check` (PASSED) and unit tests.

Related: #18211