### PR TITLE
feat(auth): [aiohttp] Add mTLS reconfiguration logic when certificate mismatch for existing credentials & Agent Identity workloads 

### DIFF
--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -179,7 +179,9 @@ async def get_client_cert_and_key(client_cert_callback=None):
     return has_cert, cert, key
 
 
-async def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback=None):
+async def check_parameters_for_unauthorized_response(
+    cached_cert, client_cert_callback=None
+):
     """Async helper to retrieve certs and compute fingerprints for mTLS rotation.
 
     Args:
@@ -187,13 +189,13 @@ async def check_parameters_for_unauthorized_response(cached_cert, client_cert_ca
         client_cert_callback (Optional[Callable[[], (bytes, bytes)]]): An
             optional callback which returns client certificate bytes and private
             key bytes both in PEM format.
- 
+
     Returns:
         bytes: The client callback cert bytes.
         bytes: The client callback key bytes.
         str: The base64-encoded SHA256 cached fingerprint.
         str: The base64-encoded SHA256 current cert fingerprint.
-  
+
     """
     is_mtls, call_cert_bytes, call_key_bytes = await get_client_cert_and_key(
         client_cert_callback

--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -179,7 +179,7 @@ async def get_client_cert_and_key(client_cert_callback=None):
     return has_cert, cert, key
 
 
-async def check_parameters_for_unauthorized_response(client_cert_callback, cached_cert):
+async def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback):
     """Async helper to retrieve certs and compute fingerprints for mTLS rotation."""
     is_mtls, call_cert_bytes, call_key_bytes = await get_client_cert_and_key(
         client_cert_callback

--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -23,7 +23,6 @@ import ssl
 from typing import Optional
 
 from google.auth import _agent_identity_utils, exceptions
-from google.auth.transport import _mtls_helper
 from google.auth.transport._mtls_helper import secure_cert_key_paths
 import google.auth.transport.mtls
 

--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -179,8 +179,22 @@ async def get_client_cert_and_key(client_cert_callback=None):
     return has_cert, cert, key
 
 
-async def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback):
-    """Async helper to retrieve certs and compute fingerprints for mTLS rotation."""
+async def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback=None):
+    """Async helper to retrieve certs and compute fingerprints for mTLS rotation.
+
+    Args:
+        cached_cert (bytes): The cached client certificate.
+        client_cert_callback (Optional[Callable[[], (bytes, bytes)]]): An
+            optional callback which returns client certificate bytes and private
+            key bytes both in PEM format.
+ 
+    Returns:
+        bytes: The client callback cert bytes.
+        bytes: The client callback key bytes.
+        str: The base64-encoded SHA256 cached fingerprint.
+        str: The base64-encoded SHA256 current cert fingerprint.
+  
+    """
     is_mtls, call_cert_bytes, call_key_bytes = await get_client_cert_and_key(
         client_cert_callback
     )

--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -22,7 +22,8 @@ import logging
 import ssl
 from typing import Optional
 
-from google.auth import exceptions
+from google.auth import _agent_identity_utils, exceptions
+from google.auth.transport import _mtls_helper
 from google.auth.transport._mtls_helper import secure_cert_key_paths
 import google.auth.transport.mtls
 
@@ -177,3 +178,30 @@ async def get_client_cert_and_key(client_cert_callback=None):
 
     has_cert, cert, key, _ = await get_client_ssl_credentials()
     return has_cert, cert, key
+
+
+async def check_parameters_for_unauthorized_response(client_cert_callback, cached_cert):
+    """Async helper to retrieve certs and compute fingerprints for mTLS rotation."""
+    is_mtls, call_cert_bytes, call_key_bytes = await get_client_cert_and_key(
+        client_cert_callback
+    )
+    if not is_mtls or not call_cert_bytes:
+        return None, None, None, None
+
+    def _fetch_fingerprints():
+        cert_obj = _agent_identity_utils.parse_certificate(call_cert_bytes)
+        current_fingerprint = _agent_identity_utils.calculate_certificate_fingerprint(
+            cert_obj
+        )
+        if cached_cert:
+            cached_fingerprint = _agent_identity_utils.get_cached_cert_fingerprint(
+                cached_cert
+            )
+        else:
+            cached_fingerprint = current_fingerprint
+        return cached_fingerprint, current_fingerprint
+
+    cached_fingerprint, current_cert_fingerprint = await _run_in_executor(
+        _fetch_fingerprints
+    )
+    return call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint

--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -191,11 +191,9 @@ async def check_parameters_for_unauthorized_response(
             key bytes both in PEM format.
 
     Returns:
-        bytes: The client callback cert bytes.
-        bytes: The client callback key bytes.
-        str: The base64-encoded SHA256 cached fingerprint.
-        str: The base64-encoded SHA256 current cert fingerprint.
-
+        Tuple[Optional[bytes], Optional[bytes], Optional[str], Optional[str]]:
+            call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint.
+        Returns (None, None, None, None) if mTLS is disabled or no client certificate is present.
     """
     is_mtls, call_cert_bytes, call_key_bytes = await get_client_cert_and_key(
         client_cert_callback
@@ -213,7 +211,7 @@ async def check_parameters_for_unauthorized_response(
                 cached_cert
             )
         else:
-            cached_fingerprint = current_fingerprint
+            cached_fingerprint = None
         return cached_fingerprint, current_fingerprint
 
     cached_fingerprint, current_cert_fingerprint = await _run_in_executor(

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -331,6 +331,8 @@ class AsyncAuthorizedSession:
                                     "Client certificate has changed, reconfiguring mTLS "
                                     "channel."
                                 )
+                                if self._mtls_init_task and self._mtls_init_task.done():
+                                    self._mtls_init_task = None
                                 await self.configure_mtls_channel(
                                     lambda: (call_cert_bytes, call_key_bytes)
                                 )

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -316,7 +316,13 @@ class AsyncAuthorizedSession:
                 )
                 if response.status_code == http_client.UNAUTHORIZED:
                     try:
-                        call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint = google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response(
+                        (
+                            call_cert_bytes, 
+                            call_key_bytes, 
+                            cached_fingerprint, 
+                            current_cert_fingerprint
+                        ) = await mtls._run_in_executor(
+                            google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
                             self._cached_cert
                         )
                         if cached_fingerprint != current_cert_fingerprint:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -397,11 +397,6 @@ class AsyncAuthorizedSession:
                                         )
                 if is_streaming:
                     return response
-                if hasattr(response, "close"):
-                    if asyncio.iscoroutinefunction(response.close):
-                        await response.close()
-                    else:
-                        response.close()
                 try:
                     await self._credentials.refresh(self._auth_request)
                 except exceptions.RefreshError as e:
@@ -410,6 +405,13 @@ class AsyncAuthorizedSession:
                         e,
                     )
                     return response
+
+                if hasattr(response, "close"):
+                    if asyncio.iscoroutinefunction(response.close):
+                        await response.close()
+                    else:
+                        response.close()
+                
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1
                 return await self.request(
                     method,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -329,150 +329,149 @@ class AsyncAuthorizedSession:
 
         if response.status_code == http_client.UNAUTHORIZED:
             if _auth_retry_count < 2:
-                if max_allowed_time is not None:
-                    elapsed = time.monotonic() - start_time
-                    remaining_time = max(0.0, max_allowed_time - elapsed)
-                    if remaining_time == 0.0:
-                        raise google.auth.exceptions.TimeoutError(
-                            "Timeout exceeded before credential refresh could begin"
-                        )
-                else:
-                    remaining_time = None
-                is_streaming = data is not None and (
-                    isinstance(
-                        data, (collections.abc.Iterator, collections.abc.AsyncIterable)
-                    )
-                    or hasattr(data, "read")
-                )
-
-                async def _recover_auth_state():
-                    is_mtls_endpoint = False
-                    if getattr(self, "is_mtls", False):
-                        hostname = urllib.parse.urlsplit(url).hostname
-                        if hostname:
-                            is_mtls_endpoint = any(
-                                hostname == prefix or hostname.endswith("." + prefix)
-                                for prefix in _MTLS_URL_PREFIXES
+                try:
+                    if max_allowed_time is not None:
+                        elapsed = time.monotonic() - start_time
+                        remaining_time = max(0.0, max_allowed_time - elapsed)
+                        if remaining_time == 0.0:
+                            raise google.auth.exceptions.TimeoutError(
+                                "Timeout exceeded before credential refresh could begin"
                             )
-                        # Snapshot the stale certificate state BEFORE acquiring the lock.
-                        # This represents the cert that caused the 401 rejection.
-                        if is_mtls_endpoint:
-                            if self._mtls_rotation_lock is None:
-                                self._mtls_rotation_lock = asyncio.Lock()
-                            # Snapshot the counter state BEFORE acquiring the lock.
-                            check_counter_at_error = self._mtls_check_counter
-
-                            async with self._mtls_rotation_lock:
-                                # Check if another coroutine already reconfigured mTLS or
-                                # ran the validation check.
-                                if self._mtls_check_counter > check_counter_at_error:
-                                    pass
-                                else:
-                                    try:
-                                        (
-                                            call_cert_bytes,
-                                            call_key_bytes,
-                                            cached_fingerprint,
-                                            current_cert_fingerprint,
-                                        ) = await mtls.check_parameters_for_unauthorized_response(
-                                            self._client_cert_callback,
-                                            self._cached_cert,
-                                        )
-                                    except (
-                                        exceptions.ClientCertError,
-                                        exceptions.MutualTLSChannelError,
-                                        OSError,
-                                        ValueError,
-                                        ImportError,
-                                    ) as e:
-                                        _LOGGER.warning(
-                                            "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                                            e,
-                                        )
-                                        return response
-                                    else:
-                                        if (
-                                            current_cert_fingerprint is not None
-                                            and cached_fingerprint
-                                            != current_cert_fingerprint
-                                        ):
-                                            saved_callback = self._client_cert_callback
-                                            try:
-                                                _LOGGER.info(
-                                                    "Client certificate has changed, reconfiguring mTLS "
-                                                    "channel."
-                                                )
-                                                if (
-                                                    self._mtls_init_task
-                                                    and self._mtls_init_task.done()
-                                                ):
-                                                    self._mtls_init_task = None
-                                                await self.configure_mtls_channel(
-                                                    lambda: (
-                                                        call_cert_bytes,
-                                                        call_key_bytes,
-                                                    )
-                                                )
-                                            except Exception as e:
-                                                _LOGGER.error(
-                                                    "Failed to reconfigure mTLS channel: %s",
-                                                    e,
-                                                )
-                                                if hasattr(response, "close"):
-                                                    if asyncio.iscoroutinefunction(
-                                                        response.close
-                                                    ):
-                                                        await response.close()
-                                                    else:
-                                                        response.close()
-                                                raise exceptions.MutualTLSChannelError(
-                                                    "Failed to reconfigure mTLS channel"
-                                                ) from e
-                                            finally:
-                                                self._client_cert_callback = (
-                                                    saved_callback
-                                                )
-                                        else:
-                                            _LOGGER.info(
-                                                "Skipping reconfiguration of mTLS channel because the client"
-                                                " certificate has not changed."
-                                            )
-                                    finally:
-                                        # Always increment so waiting tasks skip the check block
-                                        self._mtls_check_counter += 1
-                    if is_streaming:
-                        return response
-                    try:
-                        await self._credentials.refresh(self._auth_request)
-                    except NotImplementedError:
-                        _LOGGER.debug("Credentials do not implement refresh().")
-                    except (
-                        exceptions.RefreshError,
-                        getattr(exceptions, "InvalidOperation", Exception),
-                    ) as e:
-                        _LOGGER.debug(
-                            "Credential refresh failed, returning 401 response. Error: %s",
-                            e,
+                    else:
+                        remaining_time = None
+                    is_streaming = data is not None and (
+                        isinstance(
+                            data, (collections.abc.Iterator, collections.abc.AsyncIterable)
                         )
-                        return response
-
-                    # Return None to explicitly signal successful recovery & trigger retry if needed
-                    return None
-
-                async with timeout_guard(remaining_time) as auth_with_timeout:
-                    early_return_response = await auth_with_timeout(
-                        _recover_auth_state()
+                        or hasattr(data, "read")
                     )
+                    async def _recover_auth_state():
+                        is_mtls_endpoint = False
+                        if getattr(self, "is_mtls", False):
+                            hostname = urllib.parse.urlsplit(url).hostname
+                            if hostname:
+                                is_mtls_endpoint = any(
+                                    hostname == prefix or hostname.endswith("." + prefix)
+                                    for prefix in _MTLS_URL_PREFIXES
+                                )
+                            # Snapshot the stale certificate state BEFORE acquiring the lock.
+                            # This represents the cert that caused the 401 rejection.
+                            if is_mtls_endpoint:
+                                if self._mtls_rotation_lock is None:
+                                    self._mtls_rotation_lock = asyncio.Lock()
+                                # Snapshot the counter state BEFORE acquiring the lock.
+                                check_counter_at_error = self._mtls_check_counter
+                                async with self._mtls_rotation_lock:
+                                    # Check if another coroutine already reconfigured mTLS or
+                                    # ran the validation check.
+                                    if self._mtls_check_counter > check_counter_at_error:
+                                        pass
+                                    else:
+                                        try:
+                                            (
+                                                call_cert_bytes,
+                                                call_key_bytes,
+                                                cached_fingerprint,
+                                                current_cert_fingerprint,
+                                            ) = await mtls.check_parameters_for_unauthorized_response(
+                                                self._client_cert_callback,
+                                                self._cached_cert,
+                                            )
+                                        except (
+                                            exceptions.ClientCertError,
+                                            exceptions.MutualTLSChannelError,
+                                            OSError,
+                                            ValueError,
+                                            ImportError,
+                                        ) as e:
+                                            _LOGGER.warning(
+                                                "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                                e,
+                                            )
+                                            return response
+                                        else:
+                                            if (
+                                                current_cert_fingerprint is not None
+                                                and cached_fingerprint
+                                                != current_cert_fingerprint
+                                            ):
+                                                saved_callback = self._client_cert_callback
+                                                try:
+                                                    _LOGGER.info(
+                                                        "Client certificate has changed, reconfiguring mTLS "
+                                                        "channel."
+                                                    )
+                                                    if (
+                                                        self._mtls_init_task
+                                                        and self._mtls_init_task.done()
+                                                    ):
+                                                        self._mtls_init_task = None
+                                                    await self.configure_mtls_channel(
+                                                        lambda: (
+                                                            call_cert_bytes,
+                                                            call_key_bytes,
+                                                        )
+                                                    )
+                                                except Exception as e:
+                                                    _LOGGER.error(
+                                                        "Failed to reconfigure mTLS channel: %s",
+                                                        e,
+                                                    )
+                                                    raise exceptions.MutualTLSChannelError(
+                                                        "Failed to reconfigure mTLS channel"
+                                                    ) from e
+                                                finally:
+                                                    self._client_cert_callback = (
+                                                        saved_callback
+                                                    )
+                                            else:
+                                                _LOGGER.info(
+                                                    "Skipping reconfiguration of mTLS channel because the client"
+                                                    " certificate has not changed."
+                                                )
+                                        finally:
+                                            # Always increment so waiting tasks skip the check block
+                                            self._mtls_check_counter += 1
+                        try:
+                            await self._credentials.refresh(self._auth_request)
+                        except NotImplementedError:
+                            _LOGGER.debug("Credentials do not implement refresh().")
+                        except (
+                            exceptions.RefreshError,
+                            getattr(exceptions, "InvalidOperation", Exception),
+                        ) as e:
+                            _LOGGER.debug(
+                                "Credential refresh failed, returning 401 response. Error: %s",
+                                e,
+                            )
+                            return response
+
+                        if is_streaming:
+                            return response
+                        # Return None to explicitly signal successful recovery & trigger retry if needed
+                        return None
+                    async with timeout_guard(remaining_time) as auth_with_timeout:
+                        early_return_response = await auth_with_timeout(
+                            _recover_auth_state()
+                        )
+                except (Exception, asyncio.CancelledError):
+                    if hasattr(response, "close"):
+                        try:
+                            if asyncio.iscoroutinefunction(response.close):
+                                await response.close()
+                            else:
+                                response.close()
+                        except Exception:
+                            pass
+                    raise
                 # If it returned a response (meaning streaming or error), bail out
                 if early_return_response is not None:
                     return early_return_response
-
                 if hasattr(response, "close"):
                     if asyncio.iscoroutinefunction(response.close):
                         await response.close()
                     else:
                         response.close()
-
                 if max_allowed_time is not None:
                     remaining_time = max(
                         0.0, max_allowed_time - (time.monotonic() - start_time)
@@ -481,7 +480,6 @@ class AsyncAuthorizedSession:
                         raise google.auth.exceptions.TimeoutError(
                             "Timeout exceeded before retrying the request"
                         )
-
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1
                 return await self.request(
                     method,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -42,8 +42,7 @@ else:
         ClientTimeout = None
 
 _LOGGER = logging.getLogger(__name__)
-_MTLS_URL_PREFIXES = ["mtls.googleapis.com", "mtls.sandbox.googleapis.com"]
-
+_MTLS_URL_PREFIXES = ["mtls.googleapis.com", "mtls.sandbox.googleapis.com", ".p.googleapis.com"]
 
 # Tracks the internal aiohttp installation and usage
 try:
@@ -364,6 +363,7 @@ class AsyncAuthorizedSession:
 
                     async def _recover_auth_state():
                         is_mtls_endpoint = False
+                        refresh_counter_at_error = self._refresh_counter
                         if getattr(self, "is_mtls", False):
                             hostname = urllib.parse.urlsplit(url).hostname
                             if hostname:
@@ -456,7 +456,6 @@ class AsyncAuthorizedSession:
                                             self._mtls_check_counter += 1
                         if self._refresh_lock is None:
                             self._refresh_lock = asyncio.Lock()
-                        refresh_counter_at_error = self._refresh_counter
 
                         async with self._refresh_lock:
                             # Check if another task already refreshed credentials while we were waiting

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -361,7 +361,6 @@ class AsyncAuthorizedSession:
                                         await self.configure_mtls_channel(
                                             lambda: (call_cert_bytes, call_key_bytes)
                                         )
-                                        continue
                                     except Exception as e:
                                         _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
                                         raise exceptions.MutualTLSChannelError(

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -393,8 +393,8 @@ class AsyncAuthorizedSession:
                                                 cached_fingerprint,
                                                 current_cert_fingerprint,
                                             ) = await mtls.check_parameters_for_unauthorized_response(
-                                                self._client_cert_callback,
                                                 self._cached_cert,
+                                                self._client_cert_callback,
                                             )
                                         except (
                                             exceptions.ClientCertError,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -396,6 +396,7 @@ class AsyncAuthorizedSession:
                                             cached_fingerprint
                                             != current_cert_fingerprint
                                         ):
+                                            saved_callback = self._client_cert_callback
                                             try:
                                                 _LOGGER.info(
                                                     "Client certificate has changed, reconfiguring mTLS "
@@ -407,7 +408,7 @@ class AsyncAuthorizedSession:
                                                 ):
                                                     self._mtls_init_task = None
                                                 await self.configure_mtls_channel(
-                                                    self._client_cert_callback
+                                                    lambda: (call_cert_bytes, call_key_bytes)
                                                 )
                                             except Exception as e:
                                                 _LOGGER.error(
@@ -424,6 +425,8 @@ class AsyncAuthorizedSession:
                                                 raise exceptions.MutualTLSChannelError(
                                                     "Failed to reconfigure mTLS channel"
                                                 ) from e
+                                            finally:
+                                                self._client_cert_callback = saved_callback
                                         else:
                                             _LOGGER.info(
                                                 "Skipping reconfiguration of mTLS channel because the client"

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -319,6 +319,7 @@ class AsyncAuthorizedSession:
         )
         request_headers = dict(headers) if headers is not None else {}
         start_time = time.monotonic()
+        refresh_counter_at_error = self._refresh_counter
         async with timeout_guard(max_allowed_time) as with_timeout:
             await with_timeout(
                 # Note: before_request will attempt to refresh credentials if expired.
@@ -365,7 +366,6 @@ class AsyncAuthorizedSession:
 
                     async def _recover_auth_state():
                         is_mtls_endpoint = False
-                        refresh_counter_at_error = self._refresh_counter
                         if getattr(self, "is_mtls", False):
                             hostname = urllib.parse.urlsplit(url).hostname
                             if hostname:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -333,62 +333,68 @@ class AsyncAuthorizedSession:
                     )
                     or hasattr(data, "read")
                 )
-                if getattr(self, "is_mtls", False) and any(
-                    prefix in url for prefix in MTLS_URL_PREFIXES
-                ):
+                is_mtls_endpoint = False
+                if getattr(self, "is_mtls", False):
+                    hostname = urllib.parse.urlsplit(url).hostname
+                    if hostname:
+                        is_mtls_endpoint = any(
+                            hostname == prefix or hostname.endswith("." + prefix)
+                            for prefix in MTLS_URL_PREFIXES
+                        )
                     # Snapshot the stale certificate state BEFORE acquiring the lock.
                     # This represents the cert that caused the 401 rejection.
-                    stale_cert = self._cached_cert
-
-                    # Wait in line to acquire the lock
-                    async with self._mtls_rotation_lock:
-                        # Check Did another coroutine already reconfigure mTLS
-                        if self._cached_cert != stale_cert:
-                            # Yes! Another request already updated the channel
-                            pass
-                        else:
-                            try:
-                                (
-                                    call_cert_bytes,
-                                    call_key_bytes,
-                                    cached_fingerprint,
-                                    current_cert_fingerprint,
-                                ) = await mtls._run_in_executor(
-                                    google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                                    self._cached_cert,
-                                )
-                            except Exception as e:
-                                _LOGGER.warning(
-                                    "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                                    e,
-                                )
+                    if is_mtls_endpoint:
+                        stale_cert = self._cached_cert
+    
+                        # Wait in line to acquire the lock
+                        async with self._mtls_rotation_lock:
+                            # Check Did another coroutine already reconfigure mTLS
+                            if self._cached_cert != stale_cert:
+                                # Yes! Another request already updated the channel
+                                pass
                             else:
-                                if cached_fingerprint != current_cert_fingerprint:
-                                    try:
-                                        _LOGGER.info(
-                                            "Client certificate has changed, reconfiguring mTLS "
-                                            "channel."
-                                        )
-                                        if (
-                                            self._mtls_init_task
-                                            and self._mtls_init_task.done()
-                                        ):
-                                            self._mtls_init_task = None
-                                        await self.configure_mtls_channel(
-                                            lambda: (call_cert_bytes, call_key_bytes)
-                                        )
-                                    except Exception as e:
-                                        _LOGGER.error(
-                                            "Failed to reconfigure mTLS channel: %s", e
-                                        )
-                                        raise exceptions.MutualTLSChannelError(
-                                            "Failed to reconfigure mTLS channel"
-                                        ) from e
-                                else:
-                                    _LOGGER.info(
-                                        "Skipping reconfiguration of mTLS channel because the client"
-                                        " certificate has not changed."
+                                try:
+                                    (
+                                        call_cert_bytes,
+                                        call_key_bytes,
+                                        cached_fingerprint,
+                                        current_cert_fingerprint,
+                                    ) = await mtls._run_in_executor(
+                                        google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
+                                        self._cached_cert,
                                     )
+                                except Exception as e:
+                                    _LOGGER.warning(
+                                        "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                        e,
+                                    )
+                                else:
+                                    if cached_fingerprint != current_cert_fingerprint:
+                                        try:
+                                            _LOGGER.info(
+                                                "Client certificate has changed, reconfiguring mTLS "
+                                                "channel."
+                                            )
+                                            if (
+                                                self._mtls_init_task
+                                                and self._mtls_init_task.done()
+                                            ):
+                                                self._mtls_init_task = None
+                                            await self.configure_mtls_channel(
+                                                lambda: (call_cert_bytes, call_key_bytes)
+                                            )
+                                        except Exception as e:
+                                            _LOGGER.error(
+                                                "Failed to reconfigure mTLS channel: %s", e
+                                            )
+                                            raise exceptions.MutualTLSChannelError(
+                                                "Failed to reconfigure mTLS channel"
+                                            ) from e
+                                    else:
+                                        _LOGGER.info(
+                                            "Skipping reconfiguration of mTLS channel because the client"
+                                            " certificate has not changed."
+                                        )
                 if is_streaming:
                     return response
                 if hasattr(response, "close"):

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -161,6 +161,9 @@ class AsyncAuthorizedSession:
         self._auth_request = _auth_request
         self._mtls_rotation_lock: Optional[asyncio.Lock] = None
         self._mtls_check_counter = 0
+        self._refresh_lock: Optional[asyncio.Lock] = None
+        self._refresh_counter = 0
+
 
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
@@ -429,22 +432,34 @@ class AsyncAuthorizedSession:
                                                     "Skipping reconfiguration of mTLS channel because the client"
                                                     " certificate has not changed."
                                                 )
-                                        finally:
                                             # Always increment so waiting tasks skip the check block
                                             self._mtls_check_counter += 1
-                        try:
-                            await self._credentials.refresh(self._auth_request)
-                        except NotImplementedError:
-                            _LOGGER.debug("Credentials do not implement refresh().")
-                        except (
-                            exceptions.RefreshError,
-                            getattr(exceptions, "InvalidOperation", Exception),
-                        ) as e:
-                            _LOGGER.debug(
-                                "Credential refresh failed, returning 401 response. Error: %s",
-                                e,
-                            )
-                            return response
+                        if self._refresh_lock is None:
+                            self._refresh_lock = asyncio.Lock()
+                        refresh_counter_at_error = self._refresh_counter
+
+                        async with self._refresh_lock:
+                            # Check if another task already refreshed credentials while we were waiting
+                            if self._refresh_counter > refresh_counter_at_error:
+                                _LOGGER.debug(
+                                    "Credentials were already refreshed by a concurrent task. Skipping duplicate refresh."
+                                )
+                            else:
+                                try:
+                                    await self._credentials.refresh(self._auth_request)
+                                except NotImplementedError:
+                                    _LOGGER.debug("Credentials do not implement refresh().")
+                                except (
+                                    exceptions.RefreshError,
+                                    getattr(exceptions, "InvalidOperation", Exception),
+                                ) as e:
+                                    _LOGGER.debug(
+                                        "Credential refresh failed, returning 401 response. Error: %s",
+                                        e,
+                                    )
+                                    return response
+                                else:
+                                    self._refresh_counter += 1
 
                         if is_streaming:
                             return response

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -384,12 +384,7 @@ class AsyncAuthorizedSession:
                                                 and self._mtls_init_task.done()
                                             ):
                                                 self._mtls_init_task = None
-                                            await self.configure_mtls_channel(
-                                                lambda: (
-                                                    call_cert_bytes,
-                                                    call_key_bytes,
-                                                )
-                                            )
+                                            await self.configure_mtls_channel(self._client_cert_callback)
                                         except Exception as e:
                                             _LOGGER.error(
                                                 "Failed to reconfigure mTLS channel: %s",

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -151,7 +151,7 @@ class AsyncAuthorizedSession:
         self._mtls_init_task = None
         self._cached_cert = None
         self._client_cert_callback = None
-        self._old_auth_requests = []  # type: list
+        self._old_auth_requests: list[transport.Request] = []
         if _auth_request is None:
             raise exceptions.TransportError(
                 "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
@@ -327,11 +327,8 @@ class AsyncAuthorizedSession:
 
         if response.status_code == http_client.UNAUTHORIZED:
             if _auth_retry_count < 2:
-                is_streaming = (
-                    data is not None
-                    and isinstance(
-                        data, (collections.abc.Iterator, collections.abc.AsyncIterable)
-                    )
+                is_streaming = data is not None and (
+                    isinstance(data, (collections.abc.Iterator, collections.abc.AsyncIterable))
                     or hasattr(data, "read")
                 )
                 is_mtls_endpoint = False
@@ -366,7 +363,13 @@ class AsyncAuthorizedSession:
                                         self._cached_cert,
                                         self._client_cert_callback,
                                     )
-                                except Exception as e:
+                                except (
+                                    exceptions.ClientCertError,
+                                    exceptions.MutualTLSChannelError,
+                                    OSError,
+                                    ValueError,
+                                    ImportError,
+                                ) as e:
                                     _LOGGER.warning(
                                         "Failed to check client certificate parameters: %s. Proceeding with original response.",
                                         e,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -374,10 +374,9 @@ class AsyncAuthorizedSession:
                                             call_key_bytes,
                                             cached_fingerprint,
                                             current_cert_fingerprint,
-                                        ) = await mtls._run_in_executor(
-                                            google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                                            self._cached_cert,
-                                            self._client_cert_callback,
+                                        ) = await mtls.check_parameters_for_unauthorized_response(
+                                             self._client_cert_callback,
+                                             self._cached_cert,
                                         )
                                     except (
                                         exceptions.ClientCertError,
@@ -393,8 +392,8 @@ class AsyncAuthorizedSession:
                                         return response
                                     else:
                                         if (
-                                            cached_fingerprint
-                                            != current_cert_fingerprint
+                                            current_cert_fingerprint is not None
+                                            and cached_fingerprint != current_cert_fingerprint
                                         ):
                                             saved_callback = self._client_cert_callback
                                             try:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -375,8 +375,8 @@ class AsyncAuthorizedSession:
                                             cached_fingerprint,
                                             current_cert_fingerprint,
                                         ) = await mtls.check_parameters_for_unauthorized_response(
-                                             self._client_cert_callback,
-                                             self._cached_cert,
+                                            self._client_cert_callback,
+                                            self._cached_cert,
                                         )
                                     except (
                                         exceptions.ClientCertError,
@@ -393,7 +393,8 @@ class AsyncAuthorizedSession:
                                     else:
                                         if (
                                             current_cert_fingerprint is not None
-                                            and cached_fingerprint != current_cert_fingerprint
+                                            and cached_fingerprint
+                                            != current_cert_fingerprint
                                         ):
                                             saved_callback = self._client_cert_callback
                                             try:
@@ -407,7 +408,10 @@ class AsyncAuthorizedSession:
                                                 ):
                                                     self._mtls_init_task = None
                                                 await self.configure_mtls_channel(
-                                                    lambda: (call_cert_bytes, call_key_bytes)
+                                                    lambda: (
+                                                        call_cert_bytes,
+                                                        call_key_bytes,
+                                                    )
                                                 )
                                             except Exception as e:
                                                 _LOGGER.error(
@@ -425,7 +429,9 @@ class AsyncAuthorizedSession:
                                                     "Failed to reconfigure mTLS channel"
                                                 ) from e
                                             finally:
-                                                self._client_cert_callback = saved_callback
+                                                self._client_cert_callback = (
+                                                    saved_callback
+                                                )
                                         else:
                                             _LOGGER.info(
                                                 "Skipping reconfiguration of mTLS channel because the client"

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -318,61 +318,84 @@ class AsyncAuthorizedSession:
                         url, method, data, headers, actual_timeout, **kwargs
                     )
                 )
-                if response.status_code == http_client.UNAUTHORIZED:
-                    if getattr(self, "is_mtls", False) and any(
-                        prefix in url for prefix in MTLS_URL_PREFIXES
-                    ):
-                        # Snapshot the stale certificate state BEFORE acquiring the lock.
-                        # This represents the cert that caused the 401 rejection.
-                        stale_cert = self._cached_cert
-
-                        # Wait in line to acquire the lock
-                        async with self._mtls_rotation_lock:
-                            # Check Did another coroutine already reconfigure mTLS 
-                            if self._cached_cert != stale_cert:
-                                # Yes! Another request already updated the channel
-                                pass
-                            else:
-                                try:
-                                    (
-                                        call_cert_bytes,
-                                        call_key_bytes,
-                                        cached_fingerprint,
-                                        current_cert_fingerprint,
-                                    ) = await mtls._run_in_executor(
-                                        google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                                        self._cached_cert,
-                                    )
-                                    if cached_fingerprint != current_cert_fingerprint:
-                                        try:
-                                            _LOGGER.info(
-                                                "Client certificate has changed, reconfiguring mTLS "
-                                                "channel."
-                                            )
-                                            if self._mtls_init_task and self._mtls_init_task.done():
-                                                self._mtls_init_task = None
-                                            await self.configure_mtls_channel(
-                                                lambda: (call_cert_bytes, call_key_bytes)
-                                            )
-                                            continue
-                                        except Exception as e:
-                                            _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
-                                            raise exceptions.MutualTLSChannelError(
-                                                "Failed to reconfigure mTLS channel"
-                                            ) from e
-                                    else:
-                                        _LOGGER.info(
-                                            "Skipping reconfiguration of mTLS channel because the client"
-                                            " certificate has not changed."
-                                        )
-                                except Exception as e:
-                                    _LOGGER.warning(
-                                        "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                                        e,
-                                    )
 
                 if response.status_code not in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                     break
+        
+        if response.status_code == http_client.UNAUTHORIZED:
+            _auth_retry_count = kwargs.pop("_auth_retry_count", 0)
+            if _auth_retry_count < 2:
+                is_streaming = data is not None and isinstance(data, (collections.abc.Iterator, collections.abc.AsyncIterable)) or hasattr(data, "read")
+                if getattr(self, "is_mtls", False) and any(
+                    prefix in url for prefix in MTLS_URL_PREFIXES
+                ):
+                    # Snapshot the stale certificate state BEFORE acquiring the lock.
+                    # This represents the cert that caused the 401 rejection.
+                    stale_cert = self._cached_cert
+
+                    # Wait in line to acquire the lock
+                    async with self._mtls_rotation_lock:
+                        # Check Did another coroutine already reconfigure mTLS 
+                        if self._cached_cert != stale_cert:
+                            # Yes! Another request already updated the channel
+                            pass
+                        else:
+                            try:
+                                (
+                                    call_cert_bytes,
+                                    call_key_bytes,
+                                    cached_fingerprint,
+                                    current_cert_fingerprint,
+                                ) = await mtls._run_in_executor(
+                                    google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
+                                    self._cached_cert,
+                                )
+                                if cached_fingerprint != current_cert_fingerprint:
+                                    try:
+                                        _LOGGER.info(
+                                            "Client certificate has changed, reconfiguring mTLS "
+                                            "channel."
+                                        )
+                                        if self._mtls_init_task and self._mtls_init_task.done():
+                                            self._mtls_init_task = None
+                                        await self.configure_mtls_channel(
+                                            lambda: (call_cert_bytes, call_key_bytes)
+                                        )
+                                        continue
+                                    except Exception as e:
+                                        _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
+                                        raise exceptions.MutualTLSChannelError(
+                                            "Failed to reconfigure mTLS channel"
+                                        ) from e
+                                else:
+                                    _LOGGER.info(
+                                        "Skipping reconfiguration of mTLS channel because the client"
+                                        " certificate has not changed."
+                                    )
+                            except Exception as e:
+                                _LOGGER.warning(
+                                    "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                    e,
+                                )
+                if is_streaming:
+                    return response
+                if hasattr(response, "close"):
+                    if asyncio.iscoroutinefunction(response.close):
+                        await response.close()
+                    else:
+                        response.close()
+                await self._credentials.refresh(self._auth_request)
+                kwargs["_auth_retry_count"] = _auth_retry_count + 1
+                return await self.request(
+                    method,
+                    url,
+                    data=data,
+                    headers=headers,
+                    max_allowed_time=max_allowed_time,
+                    timeout=timeout,
+                    total_attempts=total_attempts,
+                    **kwargs
+                )
         return response
 
     @functools.wraps(request)

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -153,6 +153,7 @@ class AsyncAuthorizedSession:
                 "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
             )
         self._auth_request = _auth_request
+        self._mtls_rotation_lock = asyncio.Lock()
 
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
@@ -319,43 +320,54 @@ class AsyncAuthorizedSession:
                     if getattr(self, "is_mtls", False) and any(
                         prefix in url for prefix in MTLS_URL_PREFIXES
                     ):
-                        try:
-                            (
-                                call_cert_bytes,
-                                call_key_bytes,
-                                cached_fingerprint,
-                                current_cert_fingerprint,
-                            ) = await mtls._run_in_executor(
-                                google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                                self._cached_cert,
-                            )
-                            if cached_fingerprint != current_cert_fingerprint:
+                        # Snapshot the stale certificate state BEFORE acquiring the lock.
+                        # This represents the cert that caused the 401 rejection.
+                        stale_cert = self._cached_cert
+
+                        # Wait in line to acquire the lock
+                        async with self._mtls_rotation_lock:
+                            # Check Did another coroutine already reconfigure mTLS 
+                            if self._cached_cert != stale_cert:
+                                # Yes! Another request already updated the channel
+                                pass
+                            else:
                                 try:
-                                    _LOGGER.info(
-                                        "Client certificate has changed, reconfiguring mTLS "
-                                        "channel."
+                                    (
+                                        call_cert_bytes,
+                                        call_key_bytes,
+                                        cached_fingerprint,
+                                        current_cert_fingerprint,
+                                    ) = await mtls._run_in_executor(
+                                        google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
+                                        self._cached_cert,
                                     )
-                                    if self._mtls_init_task and self._mtls_init_task.done():
-                                        self._mtls_init_task = None
-                                    await self.configure_mtls_channel(
-                                        lambda: (call_cert_bytes, call_key_bytes)
-                                    )
-                                    continue
+                                    if cached_fingerprint != current_cert_fingerprint:
+                                        try:
+                                            _LOGGER.info(
+                                                "Client certificate has changed, reconfiguring mTLS "
+                                                "channel."
+                                            )
+                                            if self._mtls_init_task and self._mtls_init_task.done():
+                                                self._mtls_init_task = None
+                                            await self.configure_mtls_channel(
+                                                lambda: (call_cert_bytes, call_key_bytes)
+                                            )
+                                            continue
+                                        except Exception as e:
+                                            _LOGGER.warning(
+                                                "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
+                                                e,
+                                            )
+                                    else:
+                                        _LOGGER.info(
+                                            "Skipping reconfiguration of mTLS channel because the client"
+                                            " certificate has not changed."
+                                        )
                                 except Exception as e:
                                     _LOGGER.warning(
-                                        "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
+                                        "Failed to check client certificate parameters: %s. Proceeding with original response.",
                                         e,
                                     )
-                            else:
-                                _LOGGER.info(
-                                    "Skipping reconfiguration of mTLS channel because the client"
-                                    " certificate has not changed."
-                                )
-                        except Exception as e:
-                            _LOGGER.warning(
-                                "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                                e,
-                            )
 
                 if response.status_code not in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                     break

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -160,6 +160,8 @@ class AsyncAuthorizedSession:
             )
         self._auth_request = _auth_request
         self._mtls_rotation_lock = None  # type: Optional[asyncio.Lock]
+        self._mtls_check_counter = 0
+
 
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
@@ -360,10 +362,13 @@ class AsyncAuthorizedSession:
     
                             if self._mtls_rotation_lock is None:
                                 self._mtls_rotation_lock = asyncio.Lock()
+                            # Snapshot the counter state BEFORE acquiring the lock.
+                            check_counter_at_error = self._mtls_check_counter
     
                             async with self._mtls_rotation_lock:
-                                # Check Did another coroutine already reconfigure mTLS
-                                if self._cached_cert != stale_cert:
+                                # Check if another coroutine already reconfigured mTLS or 
+                                # ran the validation check.
+                                if self._mtls_check_counter > check_counter_at_error:
                                     pass
                                 else:
                                     try:
@@ -424,6 +429,9 @@ class AsyncAuthorizedSession:
                                                 "Skipping reconfiguration of mTLS channel because the client"
                                                 " certificate has not changed."
                                             )
+                                    finally:
+                                        # Always increment so waiting tasks skip the check block
+                                        self._mtls_check_counter += 1
                     if is_streaming:
                         return response
                     try:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -358,7 +358,6 @@ class AsyncAuthorizedSession:
                         # Snapshot the stale certificate state BEFORE acquiring the lock.
                         # This represents the cert that caused the 401 rejection.
                         if is_mtls_endpoint:
-                            stale_cert = self._cached_cert
 
                             if self._mtls_rotation_lock is None:
                                 self._mtls_rotation_lock = asyncio.Lock()

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -43,7 +43,11 @@ else:
         ClientTimeout = None
 
 _LOGGER = logging.getLogger(__name__)
-_MTLS_URL_PREFIXES = ["mtls.googleapis.com", "mtls.sandbox.googleapis.com", ".p.googleapis.com"]
+_MTLS_URL_PREFIXES = [
+    "mtls.googleapis.com",
+    "mtls.sandbox.googleapis.com",
+    ".p.googleapis.com",
+]
 
 # Tracks the internal aiohttp installation and usage
 try:
@@ -221,14 +225,14 @@ class AsyncAuthorizedSession:
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
                             while len(self._old_auth_requests) >= 2:
-                                     oldest_auth_request = self._old_auth_requests.pop(0)
-                                     try:
-                                         if hasattr(oldest_auth_request, "close"):
-                                             res = oldest_auth_request.close()
-                                             if inspect.isawaitable(res):
-                                                 await res
-                                     except Exception:
-                                         pass
+                                oldest_auth_request = self._old_auth_requests.pop(0)
+                                try:
+                                    if hasattr(oldest_auth_request, "close"):
+                                        res = oldest_auth_request.close()
+                                        if inspect.isawaitable(res):
+                                            await res
+                                except Exception:
+                                    pass
 
                             self._old_auth_requests.append(old_auth_request)
 

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -42,7 +42,7 @@ else:
         ClientTimeout = None
 
 _LOGGER = logging.getLogger(__name__)
-MTLS_URL_PREFIXES = ["mtls.googleapis.com", "mtls.sandbox.googleapis.com"]
+_MTLS_URL_PREFIXES = ["mtls.googleapis.com", "mtls.sandbox.googleapis.com"]
 
 
 # Tracks the internal aiohttp installation and usage
@@ -159,7 +159,7 @@ class AsyncAuthorizedSession:
                 "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
             )
         self._auth_request = _auth_request
-        self._mtls_rotation_lock = None  # type: Optional[asyncio.Lock]
+        self._mtls_rotation_lock: Optional[asyncio.Lock] = None
         self._mtls_check_counter = 0
 
     async def configure_mtls_channel(self, client_cert_callback=None):
@@ -353,7 +353,7 @@ class AsyncAuthorizedSession:
                         if hostname:
                             is_mtls_endpoint = any(
                                 hostname == prefix or hostname.endswith("." + prefix)
-                                for prefix in MTLS_URL_PREFIXES
+                                for prefix in _MTLS_URL_PREFIXES
                             )
                         # Snapshot the stale certificate state BEFORE acquiring the lock.
                         # This represents the cert that caused the 401 rejection.

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -352,7 +352,6 @@ class AsyncAuthorizedSession:
                         async with self._mtls_rotation_lock:
                             # Check Did another coroutine already reconfigure mTLS
                             if self._cached_cert != stale_cert:
-                                # Yes! Another request already updated the channel
                                 pass
                             else:
                                 try:
@@ -370,6 +369,7 @@ class AsyncAuthorizedSession:
                                         "Failed to check client certificate parameters: %s. Proceeding with original response.",
                                         e,
                                     )
+                                    return response
                                 else:
                                     if cached_fingerprint != current_cert_fingerprint:
                                         try:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -315,7 +315,7 @@ class AsyncAuthorizedSession:
                     )
                 )
                 if response.status_code == http_client.UNAUTHORIZED:
-                    if self.is_mtls:
+                    try:
                         call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint = google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response(
                             self._cached_cert
                         )
@@ -330,15 +330,20 @@ class AsyncAuthorizedSession:
                                 )
                                 continue
                             except Exception as e:
-                                _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
-                                raise exceptions.MutualTLSChannelError(
-                                    "Failed to reconfigure mTLS channel"
-                                ) from e
+                                _LOGGER.warning(
+                                    "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
+                                    e
+                                )
                         else:
-                            _LOGGER.info(
+                             _LOGGER.info(
                                 "Skipping reconfiguration of mTLS channel because the client"
                                 " certificate has not changed."
                             )
+                    except Exception as e:
+                        _LOGGER.warning(
+                            "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                            e,
+                        )
 
                 if response.status_code not in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                     break

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -396,7 +396,13 @@ class AsyncAuthorizedSession:
                         await response.close()
                     else:
                         response.close()
-                await self._credentials.refresh(self._auth_request)
+                try:
+                    await self._credentials.refresh(self._auth_request)
+                except exceptions.RefreshError as e:
+                    _LOGGER.debug(
+                        "Credential refresh failed, returning 401 response. Error: %s", e
+                    )
+                    return response
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1
                 return await self.request(
                     method,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -384,7 +384,9 @@ class AsyncAuthorizedSession:
                                                 and self._mtls_init_task.done()
                                             ):
                                                 self._mtls_init_task = None
-                                            await self.configure_mtls_channel(self._client_cert_callback)
+                                            await self.configure_mtls_channel(
+                                                self._client_cert_callback
+                                            )
                                         except Exception as e:
                                             _LOGGER.error(
                                                 "Failed to reconfigure mTLS channel: %s",

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -162,7 +162,6 @@ class AsyncAuthorizedSession:
         self._mtls_rotation_lock = None  # type: Optional[asyncio.Lock]
         self._mtls_check_counter = 0
 
-
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
 
@@ -332,20 +331,21 @@ class AsyncAuthorizedSession:
         if response.status_code == http_client.UNAUTHORIZED:
             if _auth_retry_count < 2:
                 if max_allowed_time is not None:
-                     elapsed = time.monotonic() - start_time
-                     remaining_time = max(0.0, max_allowed_time - elapsed)
-                     if remaining_time == 0.0:
-                         raise google.auth.exceptions.TimeoutError(
-                             "Timeout exceeded before credential refresh could begin"
-                         )
+                    elapsed = time.monotonic() - start_time
+                    remaining_time = max(0.0, max_allowed_time - elapsed)
+                    if remaining_time == 0.0:
+                        raise google.auth.exceptions.TimeoutError(
+                            "Timeout exceeded before credential refresh could begin"
+                        )
                 else:
-                     remaining_time = None
+                    remaining_time = None
                 is_streaming = data is not None and (
                     isinstance(
                         data, (collections.abc.Iterator, collections.abc.AsyncIterable)
                     )
                     or hasattr(data, "read")
                 )
+
                 async def _recover_auth_state():
                     is_mtls_endpoint = False
                     if getattr(self, "is_mtls", False):
@@ -359,14 +359,14 @@ class AsyncAuthorizedSession:
                         # This represents the cert that caused the 401 rejection.
                         if is_mtls_endpoint:
                             stale_cert = self._cached_cert
-    
+
                             if self._mtls_rotation_lock is None:
                                 self._mtls_rotation_lock = asyncio.Lock()
                             # Snapshot the counter state BEFORE acquiring the lock.
                             check_counter_at_error = self._mtls_check_counter
-    
+
                             async with self._mtls_rotation_lock:
-                                # Check if another coroutine already reconfigured mTLS or 
+                                # Check if another coroutine already reconfigured mTLS or
                                 # ran the validation check.
                                 if self._mtls_check_counter > check_counter_at_error:
                                     pass
@@ -395,7 +395,10 @@ class AsyncAuthorizedSession:
                                         )
                                         return response
                                     else:
-                                        if cached_fingerprint != current_cert_fingerprint:
+                                        if (
+                                            cached_fingerprint
+                                            != current_cert_fingerprint
+                                        ):
                                             try:
                                                 _LOGGER.info(
                                                     "Client certificate has changed, reconfiguring mTLS "
@@ -445,12 +448,14 @@ class AsyncAuthorizedSession:
                             e,
                         )
                         return response
-    
+
                     # Return None to explicitly signal successful recovery
                     return None
 
                 async with timeout_guard(remaining_time) as auth_with_timeout:
-                    early_return_response = await auth_with_timeout(_recover_auth_state())
+                    early_return_response = await auth_with_timeout(
+                        _recover_auth_state()
+                    )
                 # If it returned a response (meaning streaming or error), bail out
                 if early_return_response is not None:
                     return early_return_response
@@ -462,7 +467,9 @@ class AsyncAuthorizedSession:
                         response.close()
 
                 if max_allowed_time is not None:
-                    remaining_time = max(0.0, max_allowed_time - (time.monotonic() - start_time))
+                    remaining_time = max(
+                        0.0, max_allowed_time - (time.monotonic() - start_time)
+                    )
                     if remaining_time == 0.0:
                         raise google.auth.exceptions.TimeoutError(
                             "Timeout exceeded before retrying the request"

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -28,8 +28,6 @@ from google.auth.aio.transport import mtls
 from google.auth.exceptions import TimeoutError
 import google.auth.transport._mtls_helper
 
-_LOGGER = logging.getLogger(__name__)
-
 if TYPE_CHECKING:  # pragma: NO COVER
     import aiohttp
     from aiohttp import ClientTimeout  # type: ignore
@@ -40,6 +38,8 @@ else:
         from aiohttp import ClientTimeout
     except (ImportError, AttributeError):
         ClientTimeout = None
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # Tracks the internal aiohttp installation and usage
@@ -317,13 +317,13 @@ class AsyncAuthorizedSession:
                 if response.status_code == http_client.UNAUTHORIZED:
                     try:
                         (
-                            call_cert_bytes, 
-                            call_key_bytes, 
-                            cached_fingerprint, 
-                            current_cert_fingerprint
+                            call_cert_bytes,
+                            call_key_bytes,
+                            cached_fingerprint,
+                            current_cert_fingerprint,
                         ) = await mtls._run_in_executor(
                             google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                            self._cached_cert
+                            self._cached_cert,
                         )
                         if cached_fingerprint != current_cert_fingerprint:
                             try:
@@ -340,10 +340,10 @@ class AsyncAuthorizedSession:
                             except Exception as e:
                                 _LOGGER.warning(
                                     "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
-                                    e
+                                    e,
                                 )
                         else:
-                             _LOGGER.info(
+                            _LOGGER.info(
                                 "Skipping reconfiguration of mTLS channel because the client"
                                 " certificate has not changed."
                             )

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -20,7 +20,7 @@ import http.client as http_client
 import logging
 import time
 from typing import Mapping, Optional, TYPE_CHECKING, Union
-import urllib
+import urllib.parse
 import warnings
 
 from google.auth import _exponential_backoff, exceptions

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -40,6 +40,7 @@ else:
         ClientTimeout = None
 
 _LOGGER = logging.getLogger(__name__)
+MTLS_URL_PREFIXES = ["mtls.googleapis.com", "mtls.sandbox.googleapis.com"]
 
 
 # Tracks the internal aiohttp installation and usage
@@ -315,43 +316,46 @@ class AsyncAuthorizedSession:
                     )
                 )
                 if response.status_code == http_client.UNAUTHORIZED:
-                    try:
-                        (
-                            call_cert_bytes,
-                            call_key_bytes,
-                            cached_fingerprint,
-                            current_cert_fingerprint,
-                        ) = await mtls._run_in_executor(
-                            google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                            self._cached_cert,
-                        )
-                        if cached_fingerprint != current_cert_fingerprint:
-                            try:
-                                _LOGGER.info(
-                                    "Client certificate has changed, reconfiguring mTLS "
-                                    "channel."
-                                )
-                                if self._mtls_init_task and self._mtls_init_task.done():
-                                    self._mtls_init_task = None
-                                await self.configure_mtls_channel(
-                                    lambda: (call_cert_bytes, call_key_bytes)
-                                )
-                                continue
-                            except Exception as e:
-                                _LOGGER.warning(
-                                    "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
-                                    e,
-                                )
-                        else:
-                            _LOGGER.info(
-                                "Skipping reconfiguration of mTLS channel because the client"
-                                " certificate has not changed."
+                    if getattr(self, "is_mtls", False) and any(
+                        prefix in url for prefix in MTLS_URL_PREFIXES
+                    ):
+                        try:
+                            (
+                                call_cert_bytes,
+                                call_key_bytes,
+                                cached_fingerprint,
+                                current_cert_fingerprint,
+                            ) = await mtls._run_in_executor(
+                                google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
+                                self._cached_cert,
                             )
-                    except Exception as e:
-                        _LOGGER.warning(
-                            "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                            e,
-                        )
+                            if cached_fingerprint != current_cert_fingerprint:
+                                try:
+                                    _LOGGER.info(
+                                        "Client certificate has changed, reconfiguring mTLS "
+                                        "channel."
+                                    )
+                                    if self._mtls_init_task and self._mtls_init_task.done():
+                                        self._mtls_init_task = None
+                                    await self.configure_mtls_channel(
+                                        lambda: (call_cert_bytes, call_key_bytes)
+                                    )
+                                    continue
+                                except Exception as e:
+                                    _LOGGER.warning(
+                                        "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
+                                        e,
+                                    )
+                            else:
+                                _LOGGER.info(
+                                    "Skipping reconfiguration of mTLS channel because the client"
+                                    " certificate has not changed."
+                                )
+                        except Exception as e:
+                            _LOGGER.warning(
+                                "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                e,
+                            )
 
                 if response.status_code not in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                     break

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -297,6 +297,7 @@ class AsyncAuthorizedSession:
         )
         if headers is None:
             headers = {}
+        start_time = time.monotonic()
         async with timeout_guard(max_allowed_time) as with_timeout:
             await with_timeout(
                 # Note: before_request will attempt to refresh credentials if expired.
@@ -417,12 +418,14 @@ class AsyncAuthorizedSession:
                         response.close()
                 
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1
+                elapsed_time = time.monotonic() - start_time
+                remaining_time = max(0.0, max_allowed_time - elapsed_time)
                 return await self.request(
                     method,
                     url,
                     data=data,
                     headers=headers,
-                    max_allowed_time=max_allowed_time,
+                    max_allowed_time=remaining_time,
                     timeout=timeout,
                     total_attempts=total_attempts,
                     **kwargs,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -399,7 +399,7 @@ class AsyncAuthorizedSession:
                     return response
                 try:
                     await self._credentials.refresh(self._auth_request)
-                except exceptions.RefreshError as e:
+                except (exceptions.RefreshError, getattr(exceptions, "InvalidOperation", Exception)) as e:
                     _LOGGER.debug(
                         "Credential refresh failed, returning 401 response. Error: %s",
                         e,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -358,7 +358,6 @@ class AsyncAuthorizedSession:
                         # Snapshot the stale certificate state BEFORE acquiring the lock.
                         # This represents the cert that caused the 401 rejection.
                         if is_mtls_endpoint:
-
                             if self._mtls_rotation_lock is None:
                                 self._mtls_rotation_lock = asyncio.Lock()
                             # Snapshot the counter state BEFORE acquiring the lock.

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -444,6 +444,8 @@ class AsyncAuthorizedSession:
                         return response
                     try:
                         await self._credentials.refresh(self._auth_request)
+                    except NotImplementedError:
+                        _LOGGER.debug("Credentials do not implement refresh().")
                     except (
                         exceptions.RefreshError,
                         getattr(exceptions, "InvalidOperation", Exception),
@@ -454,7 +456,7 @@ class AsyncAuthorizedSession:
                         )
                         return response
 
-                    # Return None to explicitly signal successful recovery
+                    # Return None to explicitly signal successful recovery & trigger retry if needed
                     return None
 
                 async with timeout_guard(remaining_time) as auth_with_timeout:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -328,7 +328,9 @@ class AsyncAuthorizedSession:
         if response.status_code == http_client.UNAUTHORIZED:
             if _auth_retry_count < 2:
                 is_streaming = data is not None and (
-                    isinstance(data, (collections.abc.Iterator, collections.abc.AsyncIterable))
+                    isinstance(
+                        data, (collections.abc.Iterator, collections.abc.AsyncIterable)
+                    )
                     or hasattr(data, "read")
                 )
                 is_mtls_endpoint = False

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -301,14 +301,13 @@ class AsyncAuthorizedSession:
         retries = _exponential_backoff.AsyncExponentialBackoff(
             total_attempts=total_attempts,
         )
-        if headers is None:
-            headers = {}
+        request_headers = dict(headers) if headers is not None else {}
         start_time = time.monotonic()
         async with timeout_guard(max_allowed_time) as with_timeout:
             await with_timeout(
                 # Note: before_request will attempt to refresh credentials if expired.
                 self._credentials.before_request(
-                    self._auth_request, method, url, headers
+                    self._auth_request, method, url, request_headers
                 )
             )
             actual_timeout: float = 0.0
@@ -321,7 +320,7 @@ class AsyncAuthorizedSession:
             async for _ in retries:  # pragma: no branch
                 response = await with_timeout(
                     self._auth_request(
-                        url, method, data, headers, actual_timeout, **kwargs
+                        url, method, data, request_headers, actual_timeout, **kwargs
                     )
                 )
 

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -164,7 +164,6 @@ class AsyncAuthorizedSession:
         self._refresh_lock: Optional[asyncio.Lock] = None
         self._refresh_counter = 0
 
-
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
 
@@ -221,16 +220,18 @@ class AsyncAuthorizedSession:
 
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
-                             while len(self._old_auth_requests) >= 2:
-                                 oldest_auth_request = self._old_auth_requests.pop(0)
-                                 try:
-                                     if hasattr(oldest_auth_request, "close"):
-                                         if asyncio.iscoroutinefunction(oldest_auth_request.close):
-                                             await oldest_auth_request.close()
-                                         else:
-                                             oldest_auth_request.close()
-                                 except Exception:
-                                     pass
+                            while len(self._old_auth_requests) >= 2:
+                                oldest_auth_request = self._old_auth_requests.pop(0)
+                                try:
+                                    if hasattr(oldest_auth_request, "close"):
+                                        if asyncio.iscoroutinefunction(
+                                            oldest_auth_request.close
+                                        ):
+                                            await oldest_auth_request.close()
+                                        else:
+                                            oldest_auth_request.close()
+                                except Exception:
+                                    pass
 
                             self._old_auth_requests.append(old_auth_request)
 
@@ -355,17 +356,20 @@ class AsyncAuthorizedSession:
                         remaining_time = None
                     is_streaming = data is not None and (
                         isinstance(
-                            data, (collections.abc.Iterator, collections.abc.AsyncIterable)
+                            data,
+                            (collections.abc.Iterator, collections.abc.AsyncIterable),
                         )
                         or hasattr(data, "read")
                     )
+
                     async def _recover_auth_state():
                         is_mtls_endpoint = False
                         if getattr(self, "is_mtls", False):
                             hostname = urllib.parse.urlsplit(url).hostname
                             if hostname:
                                 is_mtls_endpoint = any(
-                                    hostname == prefix or hostname.endswith("." + prefix)
+                                    hostname == prefix
+                                    or hostname.endswith("." + prefix)
                                     for prefix in _MTLS_URL_PREFIXES
                                 )
                             # Snapshot the stale certificate state BEFORE acquiring the lock.
@@ -378,7 +382,10 @@ class AsyncAuthorizedSession:
                                 async with self._mtls_rotation_lock:
                                     # Check if another coroutine already reconfigured mTLS or
                                     # ran the validation check.
-                                    if self._mtls_check_counter > check_counter_at_error:
+                                    if (
+                                        self._mtls_check_counter
+                                        > check_counter_at_error
+                                    ):
                                         pass
                                     else:
                                         try:
@@ -409,7 +416,9 @@ class AsyncAuthorizedSession:
                                                 and cached_fingerprint
                                                 != current_cert_fingerprint
                                             ):
-                                                saved_callback = self._client_cert_callback
+                                                saved_callback = (
+                                                    self._client_cert_callback
+                                                )
                                                 try:
                                                     _LOGGER.info(
                                                         "Client certificate has changed, reconfiguring mTLS "
@@ -459,7 +468,9 @@ class AsyncAuthorizedSession:
                                 try:
                                     await self._credentials.refresh(self._auth_request)
                                 except NotImplementedError:
-                                    _LOGGER.debug("Credentials do not implement refresh().")
+                                    _LOGGER.debug(
+                                        "Credentials do not implement refresh()."
+                                    )
                                 except (
                                     exceptions.RefreshError,
                                     getattr(exceptions, "InvalidOperation", Exception),
@@ -476,6 +487,7 @@ class AsyncAuthorizedSession:
                             return response
                         # Return None to explicitly signal successful recovery & trigger retry if needed
                         return None
+
                     async with timeout_guard(remaining_time) as auth_with_timeout:
                         early_return_response = await auth_with_timeout(
                             _recover_auth_state()

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -20,6 +20,7 @@ import http.client as http_client
 import logging
 import time
 from typing import Mapping, Optional, TYPE_CHECKING, Union
+import urllib
 import warnings
 
 from google.auth import _exponential_backoff, exceptions
@@ -149,7 +150,7 @@ class AsyncAuthorizedSession:
         self._is_mtls = False
         self._mtls_init_task = None
         self._cached_cert = None
-        self._client_cert_callback = None 
+        self._client_cert_callback = None
         self._old_auth_requests = []
         if _auth_request is None:
             raise exceptions.TransportError(
@@ -345,7 +346,7 @@ class AsyncAuthorizedSession:
                     # This represents the cert that caused the 401 rejection.
                     if is_mtls_endpoint:
                         stale_cert = self._cached_cert
-                
+
                         if self._mtls_rotation_lock is None:
                             self._mtls_rotation_lock = asyncio.Lock()
 
@@ -384,14 +385,20 @@ class AsyncAuthorizedSession:
                                             ):
                                                 self._mtls_init_task = None
                                             await self.configure_mtls_channel(
-                                                lambda: (call_cert_bytes, call_key_bytes)
+                                                lambda: (
+                                                    call_cert_bytes,
+                                                    call_key_bytes,
+                                                )
                                             )
                                         except Exception as e:
                                             _LOGGER.error(
-                                                "Failed to reconfigure mTLS channel: %s", e
+                                                "Failed to reconfigure mTLS channel: %s",
+                                                e,
                                             )
                                             if hasattr(response, "close"):
-                                                if asyncio.iscoroutinefunction(response.close):
+                                                if asyncio.iscoroutinefunction(
+                                                    response.close
+                                                ):
                                                     await response.close()
                                                 else:
                                                     response.close()
@@ -407,7 +414,10 @@ class AsyncAuthorizedSession:
                     return response
                 try:
                     await self._credentials.refresh(self._auth_request)
-                except (exceptions.RefreshError, getattr(exceptions, "InvalidOperation", Exception)) as e:
+                except (
+                    exceptions.RefreshError,
+                    getattr(exceptions, "InvalidOperation", Exception),
+                ) as e:
                     _LOGGER.debug(
                         "Credential refresh failed, returning 401 response. Error: %s",
                         e,
@@ -419,7 +429,7 @@ class AsyncAuthorizedSession:
                         await response.close()
                     else:
                         response.close()
-                
+
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1
                 elapsed_time = time.monotonic() - start_time
                 remaining_time = max(0.0, max_allowed_time - elapsed_time)

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -17,6 +17,7 @@ import collections.abc
 from contextlib import asynccontextmanager
 import functools
 import http.client as http_client
+import inspect
 import logging
 import time
 from typing import Mapping, Optional, TYPE_CHECKING, Union
@@ -220,17 +221,14 @@ class AsyncAuthorizedSession:
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
                             while len(self._old_auth_requests) >= 2:
-                                oldest_auth_request = self._old_auth_requests.pop(0)
-                                try:
-                                    if hasattr(oldest_auth_request, "close"):
-                                        if asyncio.iscoroutinefunction(
-                                            oldest_auth_request.close
-                                        ):
-                                            await oldest_auth_request.close()
-                                        else:
-                                            oldest_auth_request.close()
-                                except Exception:
-                                    pass
+                                     oldest_auth_request = self._old_auth_requests.pop(0)
+                                     try:
+                                         if hasattr(oldest_auth_request, "close"):
+                                             res = oldest_auth_request.close()
+                                             if inspect.isawaitable(res):
+                                                 await res
+                                     except Exception:
+                                         pass
 
                             self._old_auth_requests.append(old_auth_request)
 
@@ -494,10 +492,9 @@ class AsyncAuthorizedSession:
                 except (Exception, asyncio.CancelledError):
                     if hasattr(response, "close"):
                         try:
-                            if asyncio.iscoroutinefunction(response.close):
-                                await response.close()
-                            else:
-                                response.close()
+                            res = response.close()
+                            if inspect.isawaitable(res):
+                                await res
                         except Exception:
                             pass
                     raise
@@ -505,10 +502,12 @@ class AsyncAuthorizedSession:
                 if early_return_response is not None:
                     return early_return_response
                 if hasattr(response, "close"):
-                    if asyncio.iscoroutinefunction(response.close):
-                        await response.close()
-                    else:
-                        response.close()
+                    try:
+                        res = response.close()
+                        if inspect.isawaitable(res):
+                            await res
+                    except Exception:
+                        pass
                 if max_allowed_time is not None:
                     remaining_time = max(
                         0.0, max_allowed_time - (time.monotonic() - start_time)
@@ -811,11 +810,17 @@ class AsyncAuthorizedSession:
             except asyncio.CancelledError:
                 pass
         try:
-            await self._auth_request.close()
+            if hasattr(self._auth_request, "close"):
+                res = self._auth_request.close()
+                if inspect.isawaitable(res):
+                    await res
         finally:
             for old_request in self._old_auth_requests:
                 try:
-                    await old_request.close()
+                    if hasattr(old_request, "close"):
+                        res = old_request.close()
+                        if inspect.isawaitable(res):
+                            await res
                 except Exception:
                     pass
             self._old_auth_requests.clear()

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -151,13 +151,13 @@ class AsyncAuthorizedSession:
         self._mtls_init_task = None
         self._cached_cert = None
         self._client_cert_callback = None
-        self._old_auth_requests = []
+        self._old_auth_requests = []  # type: list
         if _auth_request is None:
             raise exceptions.TransportError(
                 "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
             )
         self._auth_request = _auth_request
-        self._mtls_rotation_lock = None
+        self._mtls_rotation_lock = None  # type: Optional[asyncio.Lock]
 
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -149,6 +149,7 @@ class AsyncAuthorizedSession:
         self._is_mtls = False
         self._mtls_init_task = None
         self._cached_cert = None
+        self._old_auth_requests = []
         if _auth_request is None:
             raise exceptions.TransportError(
                 "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
@@ -211,12 +212,8 @@ class AsyncAuthorizedSession:
 
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
+                            self._old_auth_requests.append(old_auth_request)
 
-                            try:
-                                await old_auth_request.close()
-                            except Exception:
-                                # Suppress so it doesn't abort the mTLS configuration
-                                pass
                         else:
                             is_mtls = False
                             warnings.warn(
@@ -713,3 +710,10 @@ class AsyncAuthorizedSession:
             except asyncio.CancelledError:
                 pass
         await self._auth_request.close()
+
+        for old_request in self._old_auth_requests:
+            try:
+                await old_request.close()
+            except Exception:
+                pass
+        self._old_auth_requests.clear()

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -221,6 +221,17 @@ class AsyncAuthorizedSession:
 
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
+                             while len(self._old_auth_requests) >= 2:
+                                 oldest_auth_request = self._old_auth_requests.pop(0)
+                                 try:
+                                     if hasattr(oldest_auth_request, "close"):
+                                         if asyncio.iscoroutinefunction(oldest_auth_request.close):
+                                             await oldest_auth_request.close()
+                                         else:
+                                             oldest_auth_request.close()
+                                 except Exception:
+                                     pass
+
                             self._old_auth_requests.append(old_auth_request)
 
                         else:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -15,6 +15,8 @@
 import asyncio
 from contextlib import asynccontextmanager
 import functools
+import http.client as http_client
+import logging
 import time
 from typing import Mapping, Optional, TYPE_CHECKING, Union
 import warnings
@@ -25,6 +27,8 @@ from google.auth.aio.credentials import Credentials
 from google.auth.aio.transport import mtls
 from google.auth.exceptions import TimeoutError
 import google.auth.transport._mtls_helper
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: NO COVER
     import aiohttp
@@ -310,6 +314,32 @@ class AsyncAuthorizedSession:
                         url, method, data, headers, actual_timeout, **kwargs
                     )
                 )
+                if response.status_code == http_client.UNAUTHORIZED:
+                    if self.is_mtls:
+                        call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint = google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response(
+                            self._cached_cert
+                        )
+                        if cached_fingerprint != current_cert_fingerprint:
+                            try:
+                                _LOGGER.info(
+                                    "Client certificate has changed, reconfiguring mTLS "
+                                    "channel."
+                                )
+                                await self.configure_mtls_channel(
+                                    lambda: (call_cert_bytes, call_key_bytes)
+                                )
+                                continue
+                            except Exception as e:
+                                _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
+                                raise exceptions.MutualTLSChannelError(
+                                    "Failed to reconfigure mTLS channel"
+                                ) from e
+                        else:
+                            _LOGGER.info(
+                                "Skipping reconfiguration of mTLS channel because the client"
+                                " certificate has not changed."
+                            )
+
                 if response.status_code not in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                     break
         return response

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -73,6 +73,8 @@ async def timeout_guard(timeout):
     total_timeout = timeout
 
     def _remaining_time():
+        if total_timeout is None:
+            return None
         elapsed = time.monotonic() - start
         remaining = total_timeout - elapsed
         if remaining <= 0:
@@ -327,104 +329,123 @@ class AsyncAuthorizedSession:
 
         if response.status_code == http_client.UNAUTHORIZED:
             if _auth_retry_count < 2:
+                if max_allowed_time is not None:
+                     elapsed = time.monotonic() - start_time
+                     remaining_time = max(0.0, max_allowed_time - elapsed)
+                     if remaining_time == 0.0:
+                         raise google.auth.exceptions.TimeoutError(
+                             "Timeout exceeded before credential refresh could begin"
+                         )
+                else:
+                     remaining_time = None
                 is_streaming = data is not None and (
                     isinstance(
                         data, (collections.abc.Iterator, collections.abc.AsyncIterable)
                     )
                     or hasattr(data, "read")
                 )
-                is_mtls_endpoint = False
-                if getattr(self, "is_mtls", False):
-                    hostname = urllib.parse.urlsplit(url).hostname
-                    if hostname:
-                        is_mtls_endpoint = any(
-                            hostname == prefix or hostname.endswith("." + prefix)
-                            for prefix in MTLS_URL_PREFIXES
-                        )
-                    # Snapshot the stale certificate state BEFORE acquiring the lock.
-                    # This represents the cert that caused the 401 rejection.
-                    if is_mtls_endpoint:
-                        stale_cert = self._cached_cert
-
-                        if self._mtls_rotation_lock is None:
-                            self._mtls_rotation_lock = asyncio.Lock()
-
-                        async with self._mtls_rotation_lock:
-                            # Check Did another coroutine already reconfigure mTLS
-                            if self._cached_cert != stale_cert:
-                                pass
-                            else:
-                                try:
-                                    (
-                                        call_cert_bytes,
-                                        call_key_bytes,
-                                        cached_fingerprint,
-                                        current_cert_fingerprint,
-                                    ) = await mtls._run_in_executor(
-                                        google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
-                                        self._cached_cert,
-                                        self._client_cert_callback,
-                                    )
-                                except (
-                                    exceptions.ClientCertError,
-                                    exceptions.MutualTLSChannelError,
-                                    OSError,
-                                    ValueError,
-                                    ImportError,
-                                ) as e:
-                                    _LOGGER.warning(
-                                        "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                                        e,
-                                    )
-                                    return response
+                async def _recover_auth_state():
+                    is_mtls_endpoint = False
+                    if getattr(self, "is_mtls", False):
+                        hostname = urllib.parse.urlsplit(url).hostname
+                        if hostname:
+                            is_mtls_endpoint = any(
+                                hostname == prefix or hostname.endswith("." + prefix)
+                                for prefix in MTLS_URL_PREFIXES
+                            )
+                        # Snapshot the stale certificate state BEFORE acquiring the lock.
+                        # This represents the cert that caused the 401 rejection.
+                        if is_mtls_endpoint:
+                            stale_cert = self._cached_cert
+    
+                            if self._mtls_rotation_lock is None:
+                                self._mtls_rotation_lock = asyncio.Lock()
+    
+                            async with self._mtls_rotation_lock:
+                                # Check Did another coroutine already reconfigure mTLS
+                                if self._cached_cert != stale_cert:
+                                    pass
                                 else:
-                                    if cached_fingerprint != current_cert_fingerprint:
-                                        try:
-                                            _LOGGER.info(
-                                                "Client certificate has changed, reconfiguring mTLS "
-                                                "channel."
-                                            )
-                                            if (
-                                                self._mtls_init_task
-                                                and self._mtls_init_task.done()
-                                            ):
-                                                self._mtls_init_task = None
-                                            await self.configure_mtls_channel(
-                                                self._client_cert_callback
-                                            )
-                                        except Exception as e:
-                                            _LOGGER.error(
-                                                "Failed to reconfigure mTLS channel: %s",
-                                                e,
-                                            )
-                                            if hasattr(response, "close"):
-                                                if asyncio.iscoroutinefunction(
-                                                    response.close
-                                                ):
-                                                    await response.close()
-                                                else:
-                                                    response.close()
-                                            raise exceptions.MutualTLSChannelError(
-                                                "Failed to reconfigure mTLS channel"
-                                            ) from e
-                                    else:
-                                        _LOGGER.info(
-                                            "Skipping reconfiguration of mTLS channel because the client"
-                                            " certificate has not changed."
+                                    try:
+                                        (
+                                            call_cert_bytes,
+                                            call_key_bytes,
+                                            cached_fingerprint,
+                                            current_cert_fingerprint,
+                                        ) = await mtls._run_in_executor(
+                                            google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
+                                            self._cached_cert,
+                                            self._client_cert_callback,
                                         )
-                if is_streaming:
-                    return response
-                try:
-                    await self._credentials.refresh(self._auth_request)
-                except (
-                    exceptions.RefreshError,
-                    getattr(exceptions, "InvalidOperation", Exception),
-                ) as e:
-                    _LOGGER.debug(
-                        "Credential refresh failed, returning 401 response. Error: %s",
-                        e,
-                    )
-                    return response
+                                    except (
+                                        exceptions.ClientCertError,
+                                        exceptions.MutualTLSChannelError,
+                                        OSError,
+                                        ValueError,
+                                        ImportError,
+                                    ) as e:
+                                        _LOGGER.warning(
+                                            "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                            e,
+                                        )
+                                        return response
+                                    else:
+                                        if cached_fingerprint != current_cert_fingerprint:
+                                            try:
+                                                _LOGGER.info(
+                                                    "Client certificate has changed, reconfiguring mTLS "
+                                                    "channel."
+                                                )
+                                                if (
+                                                    self._mtls_init_task
+                                                    and self._mtls_init_task.done()
+                                                ):
+                                                    self._mtls_init_task = None
+                                                await self.configure_mtls_channel(
+                                                    self._client_cert_callback
+                                                )
+                                            except Exception as e:
+                                                _LOGGER.error(
+                                                    "Failed to reconfigure mTLS channel: %s",
+                                                    e,
+                                                )
+                                                if hasattr(response, "close"):
+                                                    if asyncio.iscoroutinefunction(
+                                                        response.close
+                                                    ):
+                                                        await response.close()
+                                                    else:
+                                                        response.close()
+                                                raise exceptions.MutualTLSChannelError(
+                                                    "Failed to reconfigure mTLS channel"
+                                                ) from e
+                                        else:
+                                            _LOGGER.info(
+                                                "Skipping reconfiguration of mTLS channel because the client"
+                                                " certificate has not changed."
+                                            )
+                    if is_streaming:
+                        return response
+                    try:
+                        await self._credentials.refresh(self._auth_request)
+                    except (
+                        exceptions.RefreshError,
+                        getattr(exceptions, "InvalidOperation", Exception),
+                    ) as e:
+                        _LOGGER.debug(
+                            "Credential refresh failed, returning 401 response. Error: %s",
+                            e,
+                        )
+                        return response
+    
+                    # Return None to explicitly signal successful recovery
+                    return None
+
+                async with timeout_guard(remaining_time) as auth_with_timeout:
+                    early_return_response = await auth_with_timeout(_recover_auth_state())
+                # If it returned a response (meaning streaming or error), bail out
+                if early_return_response is not None:
+                    return early_return_response
 
                 if hasattr(response, "close"):
                     if asyncio.iscoroutinefunction(response.close):
@@ -432,9 +453,14 @@ class AsyncAuthorizedSession:
                     else:
                         response.close()
 
+                if max_allowed_time is not None:
+                    remaining_time = max(0.0, max_allowed_time - (time.monotonic() - start_time))
+                    if remaining_time == 0.0:
+                        raise google.auth.exceptions.TimeoutError(
+                            "Timeout exceeded before retrying the request"
+                        )
+
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1
-                elapsed_time = time.monotonic() - start_time
-                remaining_time = max(0.0, max_allowed_time - elapsed_time)
                 return await self.request(
                     method,
                     url,
@@ -727,11 +753,12 @@ class AsyncAuthorizedSession:
                 await self._mtls_init_task
             except asyncio.CancelledError:
                 pass
-        await self._auth_request.close()
-
-        for old_request in self._old_auth_requests:
-            try:
-                await old_request.close()
-            except Exception:
-                pass
-        self._old_auth_requests.clear()
+        try:
+            await self._auth_request.close()
+        finally:
+            for old_request in self._old_auth_requests:
+                try:
+                    await old_request.close()
+                except Exception:
+                    pass
+            self._old_auth_requests.clear()

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -389,6 +389,11 @@ class AsyncAuthorizedSession:
                                             _LOGGER.error(
                                                 "Failed to reconfigure mTLS channel: %s", e
                                             )
+                                            if hasattr(response, "close"):
+                                                if asyncio.iscoroutinefunction(response.close):
+                                                    await response.close()
+                                                else:
+                                                    response.close()
                                             raise exceptions.MutualTLSChannelError(
                                                 "Failed to reconfigure mTLS channel"
                                             ) from e

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -283,6 +283,8 @@ class AsyncAuthorizedSession:
                 google.auth.exceptions.TimeoutError: If the method does not complete within
                 the configured `max_allowed_time` or the request exceeds the configured
                 `timeout`.
+                google.auth.exceptions.MutualTLSChannelError: If mutual TLS
+                channel reconfiguration fails for any reason during certificate rotation.
         """
         if self._mtls_init_task:
             try:
@@ -354,10 +356,10 @@ class AsyncAuthorizedSession:
                                             )
                                             continue
                                         except Exception as e:
-                                            _LOGGER.warning(
-                                                "Failed to reconfigure mTLS channel: %s. Proceeding with original response.",
-                                                e,
-                                            )
+                                            _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
+                                            raise exceptions.MutualTLSChannelError(
+                                                "Failed to reconfigure mTLS channel"
+                                            ) from e
                                     else:
                                         _LOGGER.info(
                                             "Skipping reconfiguration of mTLS channel because the client"

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -287,6 +287,7 @@ class AsyncAuthorizedSession:
                 google.auth.exceptions.MutualTLSChannelError: If mutual TLS
                 channel reconfiguration fails for any reason during certificate rotation.
         """
+        _auth_retry_count = kwargs.pop("_auth_retry_count", 0)
         if self._mtls_init_task:
             try:
                 await self._mtls_init_task
@@ -324,7 +325,6 @@ class AsyncAuthorizedSession:
                     break
 
         if response.status_code == http_client.UNAUTHORIZED:
-            _auth_retry_count = kwargs.pop("_auth_retry_count", 0)
             if _auth_retry_count < 2:
                 is_streaming = (
                     data is not None

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -46,7 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 _MTLS_URL_PREFIXES = [
     "mtls.googleapis.com",
     "mtls.sandbox.googleapis.com",
-    ".p.googleapis.com",
+    "p.googleapis.com",
 ]
 
 # Tracks the internal aiohttp installation and usage

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -400,7 +400,8 @@ class AsyncAuthorizedSession:
                     await self._credentials.refresh(self._auth_request)
                 except exceptions.RefreshError as e:
                     _LOGGER.debug(
-                        "Credential refresh failed, returning 401 response. Error: %s", e
+                        "Credential refresh failed, returning 401 response. Error: %s",
+                        e,
                     )
                     return response
                 kwargs["_auth_retry_count"] = _auth_retry_count + 1

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -149,6 +149,7 @@ class AsyncAuthorizedSession:
         self._is_mtls = False
         self._mtls_init_task = None
         self._cached_cert = None
+        self._client_cert_callback = None 
         self._old_auth_requests = []
         if _auth_request is None:
             raise exceptions.TransportError(
@@ -183,6 +184,7 @@ class AsyncAuthorizedSession:
                 creation failed for any reason.
         """
         if self._mtls_init_task is None:
+            self._client_cert_callback = client_cert_callback
 
             async def _do_configure():
                 # Run the blocking check in an executor
@@ -361,6 +363,7 @@ class AsyncAuthorizedSession:
                                     ) = await mtls._run_in_executor(
                                         google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
                                         self._cached_cert,
+                                        self._client_cert_callback,
                                     )
                                 except Exception as e:
                                     _LOGGER.warning(

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import collections.abc
 from contextlib import asynccontextmanager
 import functools
 import http.client as http_client
@@ -321,11 +322,17 @@ class AsyncAuthorizedSession:
 
                 if response.status_code not in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                     break
-        
+
         if response.status_code == http_client.UNAUTHORIZED:
             _auth_retry_count = kwargs.pop("_auth_retry_count", 0)
             if _auth_retry_count < 2:
-                is_streaming = data is not None and isinstance(data, (collections.abc.Iterator, collections.abc.AsyncIterable)) or hasattr(data, "read")
+                is_streaming = (
+                    data is not None
+                    and isinstance(
+                        data, (collections.abc.Iterator, collections.abc.AsyncIterable)
+                    )
+                    or hasattr(data, "read")
+                )
                 if getattr(self, "is_mtls", False) and any(
                     prefix in url for prefix in MTLS_URL_PREFIXES
                 ):
@@ -335,7 +342,7 @@ class AsyncAuthorizedSession:
 
                     # Wait in line to acquire the lock
                     async with self._mtls_rotation_lock:
-                        # Check Did another coroutine already reconfigure mTLS 
+                        # Check Did another coroutine already reconfigure mTLS
                         if self._cached_cert != stale_cert:
                             # Yes! Another request already updated the channel
                             pass
@@ -350,19 +357,30 @@ class AsyncAuthorizedSession:
                                     google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response,
                                     self._cached_cert,
                                 )
+                            except Exception as e:
+                                _LOGGER.warning(
+                                    "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                    e,
+                                )
+                            else:
                                 if cached_fingerprint != current_cert_fingerprint:
                                     try:
                                         _LOGGER.info(
                                             "Client certificate has changed, reconfiguring mTLS "
                                             "channel."
                                         )
-                                        if self._mtls_init_task and self._mtls_init_task.done():
+                                        if (
+                                            self._mtls_init_task
+                                            and self._mtls_init_task.done()
+                                        ):
                                             self._mtls_init_task = None
                                         await self.configure_mtls_channel(
                                             lambda: (call_cert_bytes, call_key_bytes)
                                         )
                                     except Exception as e:
-                                        _LOGGER.error("Failed to reconfigure mTLS channel: %s", e)
+                                        _LOGGER.error(
+                                            "Failed to reconfigure mTLS channel: %s", e
+                                        )
                                         raise exceptions.MutualTLSChannelError(
                                             "Failed to reconfigure mTLS channel"
                                         ) from e
@@ -371,11 +389,6 @@ class AsyncAuthorizedSession:
                                         "Skipping reconfiguration of mTLS channel because the client"
                                         " certificate has not changed."
                                     )
-                            except Exception as e:
-                                _LOGGER.warning(
-                                    "Failed to check client certificate parameters: %s. Proceeding with original response.",
-                                    e,
-                                )
                 if is_streaming:
                     return response
                 if hasattr(response, "close"):
@@ -393,7 +406,7 @@ class AsyncAuthorizedSession:
                     max_allowed_time=max_allowed_time,
                     timeout=timeout,
                     total_attempts=total_attempts,
-                    **kwargs
+                    **kwargs,
                 )
         return response
 

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -154,7 +154,7 @@ class AsyncAuthorizedSession:
                 "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
             )
         self._auth_request = _auth_request
-        self._mtls_rotation_lock = asyncio.Lock()
+        self._mtls_rotation_lock = None
 
     async def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
@@ -345,8 +345,10 @@ class AsyncAuthorizedSession:
                     # This represents the cert that caused the 401 rejection.
                     if is_mtls_endpoint:
                         stale_cert = self._cached_cert
-    
-                        # Wait in line to acquire the lock
+                
+                        if self._mtls_rotation_lock is None:
+                            self._mtls_rotation_lock = asyncio.Lock()
+
                         async with self._mtls_rotation_lock:
                             # Check Did another coroutine already reconfigure mTLS
                             if self._cached_cert != stale_cert:

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -260,7 +260,11 @@ class AsyncAuthorizedSession:
 
             self._mtls_init_task = asyncio.create_task(_do_configure())
 
-        return await self._mtls_init_task
+        try:
+            return await self._mtls_init_task
+        except BaseException:
+            self._mtls_init_task = None
+            raise
 
     async def request(
         self,
@@ -308,9 +312,12 @@ class AsyncAuthorizedSession:
                 channel reconfiguration fails for any reason during certificate rotation.
         """
         _auth_retry_count = kwargs.pop("_auth_retry_count", 0)
-        if self._mtls_init_task:
+        if self._mtls_init_task and not self._mtls_init_task.done():
             try:
                 await self._mtls_init_task
+            except asyncio.CancelledError:
+                if not self._mtls_init_task.cancelled():
+                    raise
             except Exception:
                 # Suppress all exceptions from the background mTLS initialization task,
                 # allowing the request to fail naturally elsewhere.
@@ -453,12 +460,18 @@ class AsyncAuthorizedSession:
                                                         saved_callback
                                                     )
                                             else:
-                                                _LOGGER.info(
-                                                    "Skipping reconfiguration of mTLS channel because the client"
-                                                    " certificate has not changed."
-                                                )
-                                            # Always increment so waiting tasks skip the check block
-                                            self._mtls_check_counter += 1
+                                                if current_cert_fingerprint is None:
+                                                    _LOGGER.info(
+                                                        "Skipping reconfiguration of mTLS channel because the client"
+                                                        " certificate does not exist."
+                                                    )
+                                                else:
+                                                    _LOGGER.info(
+                                                        "Skipping reconfiguration of mTLS channel because the client"
+                                                        " certificate has not changed."
+                                                    )
+                                        # Always increment so waiting tasks skip the check block
+                                        self._mtls_check_counter += 1
                         if self._refresh_lock is None:
                             self._refresh_lock = asyncio.Lock()
 

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -367,7 +367,7 @@ class AsyncAuthorizedSession:
 
                     async def _recover_auth_state():
                         is_mtls_endpoint = False
-                        if getattr(self, "is_mtls", False):
+                        if self._is_mtls::
                             hostname = urllib.parse.urlsplit(url).hostname
                             if hostname:
                                 is_mtls_endpoint = any(
@@ -426,16 +426,15 @@ class AsyncAuthorizedSession:
                                                         "Client certificate has changed, reconfiguring mTLS "
                                                         "channel."
                                                     )
-                                                    if (
-                                                        self._mtls_init_task
-                                                        and self._mtls_init_task.done()
-                                                    ):
+                                                    if self._mtls_init_task is not None:
+                                                        if not self._mtls_init_task.done():
+                                                            try:
+                                                                await self._mtls_init_task
+                                                            except Exception:
+                                                                pass
                                                         self._mtls_init_task = None
                                                     await self.configure_mtls_channel(
-                                                        lambda: (
-                                                            call_cert_bytes,
-                                                            call_key_bytes,
-                                                        )
+                                                        lambda: (call_cert_bytes, call_key_bytes)
                                                     )
                                                 except Exception as e:
                                                     _LOGGER.error(

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -224,8 +224,10 @@ class AsyncAuthorizedSession:
 
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
-                            while len(self._old_auth_requests) >= 2:
-                                oldest_auth_request = self._old_auth_requests.pop(0)
+                            self._old_auth_requests.append(old_auth_request)
+
+                            while len(self._old_auth_requests) > 2:
+                                oldest_auth_request = self._old_auth_requests[0]
                                 try:
                                     if hasattr(oldest_auth_request, "close"):
                                         res = oldest_auth_request.close()
@@ -233,8 +235,7 @@ class AsyncAuthorizedSession:
                                             await res
                                 except Exception:
                                     pass
-
-                            self._old_auth_requests.append(old_auth_request)
+                                self._old_auth_requests.pop(0) 
 
                         else:
                             is_mtls = False
@@ -469,9 +470,8 @@ class AsyncAuthorizedSession:
                                 try:
                                     await self._credentials.refresh(self._auth_request)
                                 except NotImplementedError:
-                                    _LOGGER.debug(
-                                        "Credentials do not implement refresh()."
-                                    )
+                                    _LOGGER.debug("Credentials do not implement refresh().")
+                                    return response
                                 except (
                                     exceptions.RefreshError,
                                     getattr(exceptions, "InvalidOperation", Exception),

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -314,10 +314,7 @@ class AsyncAuthorizedSession:
         _auth_retry_count = kwargs.pop("_auth_retry_count", 0)
         if self._mtls_init_task and not self._mtls_init_task.done():
             try:
-                await self._mtls_init_task
-            except asyncio.CancelledError:
-                if not self._mtls_init_task.cancelled():
-                    raise
+                await asyncio.shield(self._mtls_init_task)
             except Exception:
                 # Suppress all exceptions from the background mTLS initialization task,
                 # allowing the request to fail naturally elsewhere.

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -412,7 +412,6 @@ class AsyncAuthorizedSession:
                                                 "Failed to check client certificate parameters: %s. Proceeding with original response.",
                                                 e,
                                             )
-                                            return response
                                         else:
                                             if (
                                                 current_cert_fingerprint is not None

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -235,7 +235,7 @@ class AsyncAuthorizedSession:
                                             await res
                                 except Exception:
                                     pass
-                                self._old_auth_requests.pop(0) 
+                                self._old_auth_requests.pop(0)
 
                         else:
                             is_mtls = False
@@ -426,14 +426,19 @@ class AsyncAuthorizedSession:
                                                         "channel."
                                                     )
                                                     if self._mtls_init_task is not None:
-                                                        if not self._mtls_init_task.done():
+                                                        if (
+                                                            not self._mtls_init_task.done()
+                                                        ):
                                                             try:
                                                                 await self._mtls_init_task
                                                             except Exception:
                                                                 pass
                                                         self._mtls_init_task = None
                                                     await self.configure_mtls_channel(
-                                                        lambda: (call_cert_bytes, call_key_bytes)
+                                                        lambda: (
+                                                            call_cert_bytes,
+                                                            call_key_bytes,
+                                                        )
                                                     )
                                                 except Exception as e:
                                                     _LOGGER.error(
@@ -467,7 +472,9 @@ class AsyncAuthorizedSession:
                                 try:
                                     await self._credentials.refresh(self._auth_request)
                                 except NotImplementedError:
-                                    _LOGGER.debug("Credentials do not implement refresh().")
+                                    _LOGGER.debug(
+                                        "Credentials do not implement refresh()."
+                                    )
                                     return response
                                 except (
                                     exceptions.RefreshError,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -321,6 +321,7 @@ class AsyncAuthorizedSession:
         request_headers = dict(headers) if headers is not None else {}
         start_time = time.monotonic()
         refresh_counter_at_error = self._refresh_counter
+        check_counter_at_error = self._mtls_check_counter
         async with timeout_guard(max_allowed_time) as with_timeout:
             await with_timeout(
                 # Note: before_request will attempt to refresh credentials if expired.
@@ -367,7 +368,7 @@ class AsyncAuthorizedSession:
 
                     async def _recover_auth_state():
                         is_mtls_endpoint = False
-                        if self._is_mtls::
+                        if self._is_mtls:
                             hostname = urllib.parse.urlsplit(url).hostname
                             if hostname:
                                 is_mtls_endpoint = any(
@@ -380,8 +381,6 @@ class AsyncAuthorizedSession:
                             if is_mtls_endpoint:
                                 if self._mtls_rotation_lock is None:
                                     self._mtls_rotation_lock = asyncio.Lock()
-                                # Snapshot the counter state BEFORE acquiring the lock.
-                                check_counter_at_error = self._mtls_check_counter
                                 async with self._mtls_rotation_lock:
                                     # Check if another coroutine already reconfigured mTLS or
                                     # ran the validation check.

--- a/packages/google-auth/google/auth/transport/_mtls_helper.py
+++ b/packages/google-auth/google/auth/transport/_mtls_helper.py
@@ -808,11 +808,13 @@ def check_use_client_cert():
     return False
 
 
-def check_parameters_for_unauthorized_response(cached_cert):
+def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback=None):
     """Returns the cached and current cert fingerprint for reconfiguring mTLS.
 
     Args:
         cached_cert(bytes): The cached client certificate.
+        client_cert_callback(Optional[Callable[[], (bytes, bytes)]]): 
+            The optional callback that returns the client certificate and private key bytes.
 
     Returns:
         bytes: The client callback cert bytes.
@@ -820,7 +822,10 @@ def check_parameters_for_unauthorized_response(cached_cert):
         str: The base64-encoded SHA256 cached fingerprint.
         str: The base64-encoded SHA256 current cert fingerprint.
     """
-    call_cert_bytes, call_key_bytes = call_client_cert_callback()
+    if client_cert_callback:
+        call_cert_bytes, call_key_bytes = client_cert_callback()
+    else:
+        call_cert_bytes, call_key_bytes = call_client_cert_callback()
     cert_obj = _agent_identity_utils.parse_certificate(call_cert_bytes)
     current_cert_fingerprint = _agent_identity_utils.calculate_certificate_fingerprint(
         cert_obj

--- a/packages/google-auth/google/auth/transport/_mtls_helper.py
+++ b/packages/google-auth/google/auth/transport/_mtls_helper.py
@@ -813,7 +813,7 @@ def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback
 
     Args:
         cached_cert(bytes): The cached client certificate.
-        client_cert_callback(Optional[Callable[[], (bytes, bytes)]]): 
+        client_cert_callback(Optional[Callable[[], (bytes, bytes)]]):
             The optional callback that returns the client certificate and private key bytes.
 
     Returns:

--- a/packages/google-auth/google/auth/transport/_mtls_helper.py
+++ b/packages/google-auth/google/auth/transport/_mtls_helper.py
@@ -808,13 +808,11 @@ def check_use_client_cert():
     return False
 
 
-def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback=None):
+def check_parameters_for_unauthorized_response(cached_cert):
     """Returns the cached and current cert fingerprint for reconfiguring mTLS.
 
     Args:
         cached_cert(bytes): The cached client certificate.
-        client_cert_callback(Optional[Callable[[], (bytes, bytes)]]):
-            The optional callback that returns the client certificate and private key bytes.
 
     Returns:
         bytes: The client callback cert bytes.
@@ -822,10 +820,7 @@ def check_parameters_for_unauthorized_response(cached_cert, client_cert_callback
         str: The base64-encoded SHA256 cached fingerprint.
         str: The base64-encoded SHA256 current cert fingerprint.
     """
-    if client_cert_callback:
-        call_cert_bytes, call_key_bytes = client_cert_callback()
-    else:
-        call_cert_bytes, call_key_bytes = call_client_cert_callback()
+    call_cert_bytes, call_key_bytes = call_client_cert_callback()
     cert_obj = _agent_identity_utils.parse_certificate(call_cert_bytes)
     current_cert_fingerprint = _agent_identity_utils.calculate_certificate_fingerprint(
         cert_obj

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -86,27 +86,25 @@ async def test_check_parameters_cert_matched():
     assert cached_fp == "FINGERPRINT_A"
     assert current_fp == "FINGERPRINT_A"
     assert cached_fp == current_fp
-    
+
     # These assertions will now work correctly using the bound mocks
     mock_parse.assert_called_once_with(CERT_BYTES)
     mock_get_cached.assert_called_once_with(CERT_BYTES)
 
 
-
 @pytest.mark.asyncio
 async def test_check_parameters_cert_mismatch_rotation():
     """Test when newly retrieved certificate differs from the cached certificate (rotation occurred)."""
+
     def callback():
         return NEW_CERT_BYTES, NEW_KEY_BYTES
 
     with (
-        # Add `as mock_parse` here
-        mock.patch("google.auth._agent_identity_utils.parse_certificate") as mock_parse, 
+        mock.patch("google.auth._agent_identity_utils.parse_certificate") as mock_parse,
         mock.patch(
             "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
             return_value="FINGERPRINT_NEW",
         ),
-        # Add `as mock_get_cached` here
         mock.patch(
             "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
             return_value="FINGERPRINT_OLD",
@@ -127,8 +125,9 @@ async def test_check_parameters_cert_mismatch_rotation():
     assert current_fp == "FINGERPRINT_NEW"
     assert cached_fp != current_fp
 
-    # Now you can add the assertions requested by the reviewer at the end of the test:
-    mock_parse.assert_called_once_with(CERT_BYTES)
+    # The fix: mock_parse is called with the NEW cert from the callback
+    mock_parse.assert_called_once_with(NEW_CERT_BYTES)
+    # mock_get_cached is called with the old cached cert
     mock_get_cached.assert_called_once_with(CERT_BYTES)
 
 

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import mock
+
 from google.auth import exceptions
 from google.auth.aio.transport import mtls
 import pytest
@@ -52,16 +53,17 @@ async def test_check_parameters_cert_matched():
   def callback():
     return CERT_BYTES, KEY_BYTES
 
-  with mock.patch(
-      "google.auth.transport._agent_identity_utils.parse_certificate"
-  ) as mock_parse, mock.patch(
-      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
-      return_value="FINGERPRINT_A",
-  ), mock.patch(
-      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint",
-      return_value="FINGERPRINT_A",
+  with (
+      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+      mock.patch(
+          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+          return_value="FINGERPRINT_A",
+      ),
+      mock.patch(
+          "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
+          return_value="FINGERPRINT_A",
+      ),
   ):
-
     cert, key, cached_fp, current_fp = (
         await mtls.check_parameters_for_unauthorized_response(
             cached_cert=CERT_BYTES, client_cert_callback=callback
@@ -72,7 +74,7 @@ async def test_check_parameters_cert_matched():
     assert key == KEY_BYTES
     assert cached_fp == "FINGERPRINT_A"
     assert current_fp == "FINGERPRINT_A"
-    assert cached_fp == current_fp  # Indicates no cert rotation needed
+    assert cached_fp == current_fp
 
 
 @pytest.mark.asyncio
@@ -82,16 +84,17 @@ async def test_check_parameters_cert_mismatch_rotation():
   def callback():
     return NEW_CERT_BYTES, NEW_KEY_BYTES
 
-  with mock.patch(
-      "google.auth.transport._agent_identity_utils.parse_certificate"
-  ) as mock_parse, mock.patch(
-      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
-      return_value="FINGERPRINT_NEW",
-  ), mock.patch(
-      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint",
-      return_value="FINGERPRINT_OLD",
+  with (
+      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+      mock.patch(
+          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+          return_value="FINGERPRINT_NEW",
+      ),
+      mock.patch(
+          "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
+          return_value="FINGERPRINT_OLD",
+      ),
   ):
-
     cert, key, cached_fp, current_fp = (
         await mtls.check_parameters_for_unauthorized_response(
             cached_cert=CERT_BYTES, client_cert_callback=callback
@@ -102,7 +105,7 @@ async def test_check_parameters_cert_mismatch_rotation():
     assert key == NEW_KEY_BYTES
     assert cached_fp == "FINGERPRINT_OLD"
     assert current_fp == "FINGERPRINT_NEW"
-    assert cached_fp != current_fp  # Indicates cert rotation required
+    assert cached_fp != current_fp
 
 
 @pytest.mark.asyncio
@@ -112,15 +115,16 @@ async def test_check_parameters_without_cached_cert():
   def callback():
     return CERT_BYTES, KEY_BYTES
 
-  with mock.patch(
-      "google.auth.transport._agent_identity_utils.parse_certificate"
-  ), mock.patch(
-      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
-      return_value="FINGERPRINT_CURRENT",
-  ), mock.patch(
-      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint"
-  ) as mock_get_cached:
-
+  with (
+      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+      mock.patch(
+          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+          return_value="FINGERPRINT_CURRENT",
+      ),
+      mock.patch(
+          "google.auth._agent_identity_utils.get_cached_cert_fingerprint"
+      ) as mock_get_cached,
+  ):
     cert, key, cached_fp, current_fp = (
         await mtls.check_parameters_for_unauthorized_response(
             cached_cert=None, client_cert_callback=callback
@@ -131,7 +135,6 @@ async def test_check_parameters_without_cached_cert():
     assert key == KEY_BYTES
     assert cached_fp == "FINGERPRINT_CURRENT"
     assert current_fp == "FINGERPRINT_CURRENT"
-    # Should not attempt to parse a None cached cert
     mock_get_cached.assert_not_called()
 
 
@@ -142,18 +145,20 @@ async def test_check_parameters_executor_fingerprint_computation():
   def callback():
     return CERT_BYTES, KEY_BYTES
 
-  with mock.patch.object(
-      mtls, "_run_in_executor", wraps=mtls._run_in_executor
-  ) as mock_run_in_executor, mock.patch(
-      "google.auth.transport._agent_identity_utils.parse_certificate"
-  ), mock.patch(
-      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
-      return_value="FP_CURRENT",
-  ), mock.patch(
-      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint",
-      return_value="FP_CACHED",
+  with (
+      mock.patch.object(
+          mtls, "_run_in_executor", wraps=mtls._run_in_executor
+      ) as mock_run_in_executor,
+      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+      mock.patch(
+          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+          return_value="FP_CURRENT",
+      ),
+      mock.patch(
+          "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
+          return_value="FP_CACHED",
+      ),
   ):
-
     cert, key, cached_fp, current_fp = (
         await mtls.check_parameters_for_unauthorized_response(
             cached_cert=CERT_BYTES, client_cert_callback=callback

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+from google.auth import exceptions
+from google.auth.aio.transport import mtls
+import pytest
+
+CERT_BYTES = b"-----BEGIN CERTIFICATE-----\nMIID...CERT1...=\n-----END CERTIFICATE-----\n"
+KEY_BYTES = (
+    b"-----BEGIN PRIVATE KEY-----\nMIIE...KEY1...==\n-----END PRIVATE KEY-----\n"
+)
+NEW_CERT_BYTES = b"-----BEGIN CERTIFICATE-----\nMIID...CERT2...=\n-----END CERTIFICATE-----\n"
+NEW_KEY_BYTES = (
+    b"-----BEGIN PRIVATE KEY-----\nMIIE...KEY2...==\n-----END PRIVATE KEY-----\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_no_client_cert():
+  """Test when no certificate is discovered (has_cert is False)."""
+  with mock.patch.object(
+      mtls, "get_client_cert_and_key", return_value=(False, None, None)
+  ):
+    cert, key, cached_fp, current_fp = (
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=b"stale_cert", client_cert_callback=None
+        )
+    )
+
+    assert cert is None
+    assert key is None
+    assert cached_fp is None
+    assert current_fp is None
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_cert_matched():
+  """Test when newly retrieved certificate matches the cached certificate."""
+
+  def callback():
+    return CERT_BYTES, KEY_BYTES
+
+  with mock.patch(
+      "google.auth.transport._agent_identity_utils.parse_certificate"
+  ) as mock_parse, mock.patch(
+      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
+      return_value="FINGERPRINT_A",
+  ), mock.patch(
+      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint",
+      return_value="FINGERPRINT_A",
+  ):
+
+    cert, key, cached_fp, current_fp = (
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=CERT_BYTES, client_cert_callback=callback
+        )
+    )
+
+    assert cert == CERT_BYTES
+    assert key == KEY_BYTES
+    assert cached_fp == "FINGERPRINT_A"
+    assert current_fp == "FINGERPRINT_A"
+    assert cached_fp == current_fp  # Indicates no cert rotation needed
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_cert_mismatch_rotation():
+  """Test when newly retrieved certificate differs from the cached certificate (rotation occurred)."""
+
+  def callback():
+    return NEW_CERT_BYTES, NEW_KEY_BYTES
+
+  with mock.patch(
+      "google.auth.transport._agent_identity_utils.parse_certificate"
+  ) as mock_parse, mock.patch(
+      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
+      return_value="FINGERPRINT_NEW",
+  ), mock.patch(
+      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint",
+      return_value="FINGERPRINT_OLD",
+  ):
+
+    cert, key, cached_fp, current_fp = (
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=CERT_BYTES, client_cert_callback=callback
+        )
+    )
+
+    assert cert == NEW_CERT_BYTES
+    assert key == NEW_KEY_BYTES
+    assert cached_fp == "FINGERPRINT_OLD"
+    assert current_fp == "FINGERPRINT_NEW"
+    assert cached_fp != current_fp  # Indicates cert rotation required
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_without_cached_cert():
+  """Test when cached_cert is None."""
+
+  def callback():
+    return CERT_BYTES, KEY_BYTES
+
+  with mock.patch(
+      "google.auth.transport._agent_identity_utils.parse_certificate"
+  ), mock.patch(
+      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
+      return_value="FINGERPRINT_CURRENT",
+  ), mock.patch(
+      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint"
+  ) as mock_get_cached:
+
+    cert, key, cached_fp, current_fp = (
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=None, client_cert_callback=callback
+        )
+    )
+
+    assert cert == CERT_BYTES
+    assert key == KEY_BYTES
+    assert cached_fp == "FINGERPRINT_CURRENT"
+    assert current_fp == "FINGERPRINT_CURRENT"
+    # Should not attempt to parse a None cached cert
+    mock_get_cached.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_executor_fingerprint_computation():
+  """Test that fingerprint computation is properly offloaded to the executor."""
+
+  def callback():
+    return CERT_BYTES, KEY_BYTES
+
+  with mock.patch.object(
+      mtls, "_run_in_executor", wraps=mtls._run_in_executor
+  ) as mock_run_in_executor, mock.patch(
+      "google.auth.transport._agent_identity_utils.parse_certificate"
+  ), mock.patch(
+      "google.auth.transport._agent_identity_utils.calculate_certificate_fingerprint",
+      return_value="FP_CURRENT",
+  ), mock.patch(
+      "google.auth.transport._agent_identity_utils.get_cached_cert_fingerprint",
+      return_value="FP_CACHED",
+  ):
+
+    cert, key, cached_fp, current_fp = (
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=CERT_BYTES, client_cert_callback=callback
+        )
+    )
+
+    assert mock_run_in_executor.called
+    assert cert == CERT_BYTES
+    assert cached_fp == "FP_CACHED"
+    assert current_fp == "FP_CURRENT"
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_callback_exception_propagation():
+  """Test that exceptions raised by client_cert_callback propagate cleanly."""
+
+  def failing_callback():
+    raise exceptions.ClientCertError("Client cert provider failed")
+
+  with pytest.raises(
+      exceptions.ClientCertError, match="Client cert provider failed"
+  ):
+    await mtls.check_parameters_for_unauthorized_response(
+        cached_cert=CERT_BYTES, client_cert_callback=failing_callback
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_parameters_async_callback_exception_propagation():
+  """Test that exceptions raised in an async client_cert_callback propagate cleanly."""
+
+  async def failing_async_callback():
+    raise OSError("Disk read error while loading certificates")
+
+  with pytest.raises(
+      OSError, match="Disk read error while loading certificates"
+  ):
+    await mtls.check_parameters_for_unauthorized_response(
+        cached_cert=CERT_BYTES, client_cert_callback=failing_async_callback
+    )

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -62,7 +62,7 @@ async def test_check_parameters_cert_matched():
         return CERT_BYTES, KEY_BYTES
 
     with (
-        mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+        mock.patch("google.auth._agent_identity_utils.parse_certificate") as mock_parse,
         mock.patch(
             "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
             return_value="FINGERPRINT_A",
@@ -70,7 +70,7 @@ async def test_check_parameters_cert_matched():
         mock.patch(
             "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
             return_value="FINGERPRINT_A",
-        ),
+        ) as mock_get_cached,
     ):
         (
             cert,
@@ -81,30 +81,36 @@ async def test_check_parameters_cert_matched():
             cached_cert=CERT_BYTES, client_cert_callback=callback
         )
 
-        assert cert == CERT_BYTES
-        assert key == KEY_BYTES
-        assert cached_fp == "FINGERPRINT_A"
-        assert current_fp == "FINGERPRINT_A"
-        assert cached_fp == current_fp
+    assert cert == CERT_BYTES
+    assert key == KEY_BYTES
+    assert cached_fp == "FINGERPRINT_A"
+    assert current_fp == "FINGERPRINT_A"
+    assert cached_fp == current_fp
+    
+    # These assertions will now work correctly using the bound mocks
+    mock_parse.assert_called_once_with(CERT_BYTES)
+    mock_get_cached.assert_called_once_with(CERT_BYTES)
+
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_cert_mismatch_rotation():
     """Test when newly retrieved certificate differs from the cached certificate (rotation occurred)."""
-
     def callback():
         return NEW_CERT_BYTES, NEW_KEY_BYTES
 
     with (
-        mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+        # Add `as mock_parse` here
+        mock.patch("google.auth._agent_identity_utils.parse_certificate") as mock_parse, 
         mock.patch(
             "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
             return_value="FINGERPRINT_NEW",
         ),
+        # Add `as mock_get_cached` here
         mock.patch(
             "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
             return_value="FINGERPRINT_OLD",
-        ),
+        ) as mock_get_cached,
     ):
         (
             cert,
@@ -115,11 +121,15 @@ async def test_check_parameters_cert_mismatch_rotation():
             cached_cert=CERT_BYTES, client_cert_callback=callback
         )
 
-        assert cert == NEW_CERT_BYTES
-        assert key == NEW_KEY_BYTES
-        assert cached_fp == "FINGERPRINT_OLD"
-        assert current_fp == "FINGERPRINT_NEW"
-        assert cached_fp != current_fp
+    assert cert == NEW_CERT_BYTES
+    assert key == NEW_KEY_BYTES
+    assert cached_fp == "FINGERPRINT_OLD"
+    assert current_fp == "FINGERPRINT_NEW"
+    assert cached_fp != current_fp
+
+    # Now you can add the assertions requested by the reviewer at the end of the test:
+    mock_parse.assert_called_once_with(CERT_BYTES)
+    mock_get_cached.assert_called_once_with(CERT_BYTES)
 
 
 @pytest.mark.asyncio

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -14,15 +14,20 @@
 
 from unittest import mock
 
-from google.auth import exceptions
-from google.auth.aio.transport import mtls
 import pytest
 
-CERT_BYTES = b"-----BEGIN CERTIFICATE-----\nMIID...CERT1...=\n-----END CERTIFICATE-----\n"
+from google.auth import exceptions
+from google.auth.aio.transport import mtls
+
+CERT_BYTES = (
+    b"-----BEGIN CERTIFICATE-----\nMIID...CERT1...=\n-----END CERTIFICATE-----\n"
+)
 KEY_BYTES = (
     b"-----BEGIN PRIVATE KEY-----\nMIIE...KEY1...==\n-----END PRIVATE KEY-----\n"
 )
-NEW_CERT_BYTES = b"-----BEGIN CERTIFICATE-----\nMIID...CERT2...=\n-----END CERTIFICATE-----\n"
+NEW_CERT_BYTES = (
+    b"-----BEGIN CERTIFICATE-----\nMIID...CERT2...=\n-----END CERTIFICATE-----\n"
+)
 NEW_KEY_BYTES = (
     b"-----BEGIN PRIVATE KEY-----\nMIIE...KEY2...==\n-----END PRIVATE KEY-----\n"
 )
@@ -30,172 +35,183 @@ NEW_KEY_BYTES = (
 
 @pytest.mark.asyncio
 async def test_check_parameters_no_client_cert():
-  """Test when no certificate is discovered (has_cert is False)."""
-  with mock.patch.object(
-      mtls, "get_client_cert_and_key", return_value=(False, None, None)
-  ):
-    cert, key, cached_fp, current_fp = (
-        await mtls.check_parameters_for_unauthorized_response(
+    """Test when no certificate is discovered (has_cert is False)."""
+    with mock.patch.object(
+        mtls, "get_client_cert_and_key", return_value=(False, None, None)
+    ):
+        (
+            cert,
+            key,
+            cached_fp,
+            current_fp,
+        ) = await mtls.check_parameters_for_unauthorized_response(
             cached_cert=b"stale_cert", client_cert_callback=None
         )
-    )
 
-    assert cert is None
-    assert key is None
-    assert cached_fp is None
-    assert current_fp is None
+        assert cert is None
+        assert key is None
+        assert cached_fp is None
+        assert current_fp is None
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_cert_matched():
-  """Test when newly retrieved certificate matches the cached certificate."""
+    """Test when newly retrieved certificate matches the cached certificate."""
 
-  def callback():
-    return CERT_BYTES, KEY_BYTES
+    def callback():
+        return CERT_BYTES, KEY_BYTES
 
-  with (
-      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
-      mock.patch(
-          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
-          return_value="FINGERPRINT_A",
-      ),
-      mock.patch(
-          "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
-          return_value="FINGERPRINT_A",
-      ),
-  ):
-    cert, key, cached_fp, current_fp = (
-        await mtls.check_parameters_for_unauthorized_response(
+    with (
+        mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+        mock.patch(
+            "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+            return_value="FINGERPRINT_A",
+        ),
+        mock.patch(
+            "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
+            return_value="FINGERPRINT_A",
+        ),
+    ):
+        (
+            cert,
+            key,
+            cached_fp,
+            current_fp,
+        ) = await mtls.check_parameters_for_unauthorized_response(
             cached_cert=CERT_BYTES, client_cert_callback=callback
         )
-    )
 
-    assert cert == CERT_BYTES
-    assert key == KEY_BYTES
-    assert cached_fp == "FINGERPRINT_A"
-    assert current_fp == "FINGERPRINT_A"
-    assert cached_fp == current_fp
+        assert cert == CERT_BYTES
+        assert key == KEY_BYTES
+        assert cached_fp == "FINGERPRINT_A"
+        assert current_fp == "FINGERPRINT_A"
+        assert cached_fp == current_fp
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_cert_mismatch_rotation():
-  """Test when newly retrieved certificate differs from the cached certificate (rotation occurred)."""
+    """Test when newly retrieved certificate differs from the cached certificate (rotation occurred)."""
 
-  def callback():
-    return NEW_CERT_BYTES, NEW_KEY_BYTES
+    def callback():
+        return NEW_CERT_BYTES, NEW_KEY_BYTES
 
-  with (
-      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
-      mock.patch(
-          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
-          return_value="FINGERPRINT_NEW",
-      ),
-      mock.patch(
-          "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
-          return_value="FINGERPRINT_OLD",
-      ),
-  ):
-    cert, key, cached_fp, current_fp = (
-        await mtls.check_parameters_for_unauthorized_response(
+    with (
+        mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+        mock.patch(
+            "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+            return_value="FINGERPRINT_NEW",
+        ),
+        mock.patch(
+            "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
+            return_value="FINGERPRINT_OLD",
+        ),
+    ):
+        (
+            cert,
+            key,
+            cached_fp,
+            current_fp,
+        ) = await mtls.check_parameters_for_unauthorized_response(
             cached_cert=CERT_BYTES, client_cert_callback=callback
         )
-    )
 
-    assert cert == NEW_CERT_BYTES
-    assert key == NEW_KEY_BYTES
-    assert cached_fp == "FINGERPRINT_OLD"
-    assert current_fp == "FINGERPRINT_NEW"
-    assert cached_fp != current_fp
+        assert cert == NEW_CERT_BYTES
+        assert key == NEW_KEY_BYTES
+        assert cached_fp == "FINGERPRINT_OLD"
+        assert current_fp == "FINGERPRINT_NEW"
+        assert cached_fp != current_fp
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_without_cached_cert():
-  """Test when cached_cert is None."""
+    """Test when cached_cert is None."""
 
-  def callback():
-    return CERT_BYTES, KEY_BYTES
+    def callback():
+        return CERT_BYTES, KEY_BYTES
 
-  with (
-      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
-      mock.patch(
-          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
-          return_value="FINGERPRINT_CURRENT",
-      ),
-      mock.patch(
-          "google.auth._agent_identity_utils.get_cached_cert_fingerprint"
-      ) as mock_get_cached,
-  ):
-    cert, key, cached_fp, current_fp = (
-        await mtls.check_parameters_for_unauthorized_response(
+    with (
+        mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+        mock.patch(
+            "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+            return_value="FINGERPRINT_CURRENT",
+        ),
+        mock.patch(
+            "google.auth._agent_identity_utils.get_cached_cert_fingerprint"
+        ) as mock_get_cached,
+    ):
+        (
+            cert,
+            key,
+            cached_fp,
+            current_fp,
+        ) = await mtls.check_parameters_for_unauthorized_response(
             cached_cert=None, client_cert_callback=callback
         )
-    )
 
-    assert cert == CERT_BYTES
-    assert key == KEY_BYTES
-    assert cached_fp == "FINGERPRINT_CURRENT"
-    assert current_fp == "FINGERPRINT_CURRENT"
-    mock_get_cached.assert_not_called()
+        assert cert == CERT_BYTES
+        assert key == KEY_BYTES
+        assert cached_fp == "FINGERPRINT_CURRENT"
+        assert current_fp == "FINGERPRINT_CURRENT"
+        mock_get_cached.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_executor_fingerprint_computation():
-  """Test that fingerprint computation is properly offloaded to the executor."""
+    """Test that fingerprint computation is properly offloaded to the executor."""
 
-  def callback():
-    return CERT_BYTES, KEY_BYTES
+    def callback():
+        return CERT_BYTES, KEY_BYTES
 
-  with (
-      mock.patch.object(
-          mtls, "_run_in_executor", wraps=mtls._run_in_executor
-      ) as mock_run_in_executor,
-      mock.patch("google.auth._agent_identity_utils.parse_certificate"),
-      mock.patch(
-          "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
-          return_value="FP_CURRENT",
-      ),
-      mock.patch(
-          "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
-          return_value="FP_CACHED",
-      ),
-  ):
-    cert, key, cached_fp, current_fp = (
-        await mtls.check_parameters_for_unauthorized_response(
+    with (
+        mock.patch.object(
+            mtls, "_run_in_executor", wraps=mtls._run_in_executor
+        ) as mock_run_in_executor,
+        mock.patch("google.auth._agent_identity_utils.parse_certificate"),
+        mock.patch(
+            "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+            return_value="FP_CURRENT",
+        ),
+        mock.patch(
+            "google.auth._agent_identity_utils.get_cached_cert_fingerprint",
+            return_value="FP_CACHED",
+        ),
+    ):
+        (
+            cert,
+            key,
+            cached_fp,
+            current_fp,
+        ) = await mtls.check_parameters_for_unauthorized_response(
             cached_cert=CERT_BYTES, client_cert_callback=callback
         )
-    )
 
-    assert mock_run_in_executor.called
-    assert cert == CERT_BYTES
-    assert cached_fp == "FP_CACHED"
-    assert current_fp == "FP_CURRENT"
+        assert mock_run_in_executor.called
+        assert cert == CERT_BYTES
+        assert cached_fp == "FP_CACHED"
+        assert current_fp == "FP_CURRENT"
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_callback_exception_propagation():
-  """Test that exceptions raised by client_cert_callback propagate cleanly."""
+    """Test that exceptions raised by client_cert_callback propagate cleanly."""
 
-  def failing_callback():
-    raise exceptions.ClientCertError("Client cert provider failed")
+    def failing_callback():
+        raise exceptions.ClientCertError("Client cert provider failed")
 
-  with pytest.raises(
-      exceptions.ClientCertError, match="Client cert provider failed"
-  ):
-    await mtls.check_parameters_for_unauthorized_response(
-        cached_cert=CERT_BYTES, client_cert_callback=failing_callback
-    )
+    with pytest.raises(exceptions.ClientCertError, match="Client cert provider failed"):
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=CERT_BYTES, client_cert_callback=failing_callback
+        )
 
 
 @pytest.mark.asyncio
 async def test_check_parameters_async_callback_exception_propagation():
-  """Test that exceptions raised in an async client_cert_callback propagate cleanly."""
+    """Test that exceptions raised in an async client_cert_callback propagate cleanly."""
 
-  async def failing_async_callback():
-    raise OSError("Disk read error while loading certificates")
+    async def failing_async_callback():
+        raise OSError("Disk read error while loading certificates")
 
-  with pytest.raises(
-      OSError, match="Disk read error while loading certificates"
-  ):
-    await mtls.check_parameters_for_unauthorized_response(
-        cached_cert=CERT_BYTES, client_cert_callback=failing_async_callback
-    )
+    with pytest.raises(OSError, match="Disk read error while loading certificates"):
+        await mtls.check_parameters_for_unauthorized_response(
+            cached_cert=CERT_BYTES, client_cert_callback=failing_async_callback
+        )

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -159,8 +159,9 @@ async def test_check_parameters_without_cached_cert():
 
         assert cert == CERT_BYTES
         assert key == KEY_BYTES
-        assert cached_fp == "FINGERPRINT_CURRENT"
+        assert cached_fp is None
         assert current_fp == "FINGERPRINT_CURRENT"
+        assert cached_fp != current_fp
         mock_get_cached.assert_not_called()
 
 

--- a/packages/google-auth/tests/transport/aio/test_sessions.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions.py
@@ -255,7 +255,7 @@ class TestAsyncAuthorizedSession(object):
     async def test_request_max_allowed_time_exceeded_error(self):
         auth_request = MockRequest(side_effect=TransportError)
         authed_session = sessions.AsyncAuthorizedSession(self.credentials, auth_request)
-        with patch("time.monotonic", side_effect=[0, 1, 1]):
+        with patch("time.monotonic", side_effect=[0, 1, 1, 1, 1, 1, 1, 1]):
             with pytest.raises(TimeoutError):
                 await authed_session.request("GET", self.TEST_URL, max_allowed_time=1)
 

--- a/packages/google-auth/tests/transport/aio/test_sessions.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions.py
@@ -105,7 +105,9 @@ class TestTimeoutGuard(object):
         self, simple_async_task
     ):
         task = False
-        with patch("time.monotonic", side_effect=[0, 0.25, 0.75]):
+        with patch(
+            "time.monotonic", side_effect=lambda it=iter([0, 0.25]): next(it, 0.75)
+        ):
             with patch("asyncio.wait_for", lambda coro, _: coro):
                 async with self.make_timeout_guard(
                     timeout=self.default_timeout
@@ -255,7 +257,7 @@ class TestAsyncAuthorizedSession(object):
     async def test_request_max_allowed_time_exceeded_error(self):
         auth_request = MockRequest(side_effect=TransportError)
         authed_session = sessions.AsyncAuthorizedSession(self.credentials, auth_request)
-        with patch("time.monotonic", side_effect=[0, 1, 1, 1, 1, 1, 1, 1]):
+        with patch("time.monotonic", side_effect=[0, 0] + [2] * 10):
             with pytest.raises(TimeoutError):
                 await authed_session.request("GET", self.TEST_URL, max_allowed_time=1)
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -346,7 +346,7 @@ class TestSessionsMtls:
             await session.close()
 
     @pytest.mark.asyncio
-    async def test_cert_rotation_failure_raises_error(self):
+    async def test_cert_rotation_failure_logs(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
 
@@ -369,8 +369,8 @@ class TestSessionsMtls:
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
             mock_conf.side_effect = Exception("Failed to reconfigure")
 
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.request("GET", "http://example.com")
+            resp = await session.request("GET", "http://example.com")
+            assert resp == mock_resp
 
             mock_check.assert_called_once()
             mock_conf.assert_called_once()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 
 from google.auth import exceptions
+from google.auth.exceptions import TimeoutError
 from google.auth.aio import credentials
 from google.auth.aio import transport
 from google.auth.aio.transport import sessions
@@ -423,10 +424,17 @@ class TestSessionsMtls:
     async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
 
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+
+        # 401 on initial request, 200 on retry after refresh
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
 
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
@@ -443,16 +451,19 @@ class TestSessionsMtls:
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
-            # Matching fingerprints mean no layout rotation is needed
+            # Matching fingerprints mean no mTLS rotation is needed
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
 
             resp = await session.request(
                 "GET", "https://pubsub.mtls.googleapis.com/test"
             )
 
-            assert resp == mock_resp
-            assert mock_check.call_count >= 1
+            assert resp == mock_resp_200
+            mock_check.assert_called_once()
             mock_conf.assert_not_called()
+            mock_creds.refresh.assert_called_once()
+            assert mock_auth_req.call_count == 2
+            mock_resp_401.close.assert_awaited_once()
 
         await session.close()
 
@@ -793,3 +804,115 @@ class TestSessionsMtls:
         mock_old_req_3_fails.close.assert_called_once()
         # Ensure the list was cleared
         assert len(session._old_auth_requests) == 0
+
+    @pytest.mark.asyncio
+    async def test_request_401_closes_response_on_timeout_before_recovery(session):
+        """Verifies that response is closed and TimeoutError raised when max_allowed_time elapses before refresh."""
+        mock_resp_401 = mock.AsyncMock()
+        mock_resp_401.status_code = 401
+
+        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+
+        # Set max_allowed_time to 0 so remaining_time == 0.0 immediately
+        with pytest.raises(
+            TimeoutError, match="Timeout exceeded before credential refresh"
+        ):
+            await session.request("GET", "https://example.com", max_allowed_time=0.0)
+
+        mock_resp_401.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_request_401_closes_response_on_timeout_during_recovery(session):
+        """Verifies that response is closed when auth_with_timeout times out during _recover_auth_state."""
+        mock_resp_401 = mock.AsyncMock()
+        mock_resp_401.status_code = 401
+        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+
+        async def slow_refresh(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        session._credentials.refresh = mock.AsyncMock(side_effect=slow_refresh)
+
+        # Set short max_allowed_time so timeout_guard triggers during credentials.refresh
+        with pytest.raises(TimeoutError):
+            await session.request("GET", "https://example.com", max_allowed_time=0.01)
+
+        mock_resp_401.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_request_401_closes_response_on_cancellation(session):
+        """Verifies that response is closed and CancelledError propagated if task is cancelled during recovery."""
+        mock_resp_401 = mock.AsyncMock()
+        mock_resp_401.status_code = 401
+        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+
+        refresh_started = asyncio.Event()
+
+        async def cancel_on_refresh(*args, **kwargs):
+            refresh_started.set()
+            await asyncio.sleep(10)
+
+        session._credentials.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
+
+        task = asyncio.create_task(session.request("GET", "https://example.com"))
+        await refresh_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        mock_resp_401.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
+        session,
+    ):
+        """Verifies that streaming requests refresh credentials but return the unclosed response to the caller."""
+        mock_resp_401 = mock.AsyncMock()
+        mock_resp_401.status_code = 401
+        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+        session._credentials.refresh = mock.AsyncMock()
+
+        # Generator simulating streaming body
+        streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
+
+        response = await session.request(
+            "POST", "https://example.com", data=streaming_data
+        )
+
+        assert response is mock_resp_401
+        session._credentials.refresh.assert_awaited_once()
+        # Response must NOT be closed so caller can consume the body
+        mock_resp_401.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_request_401_concurrent_refreshes_are_deduplicated(session):
+        """Verifies that concurrent 401s execute only one credentials.refresh call."""
+        mock_resp_401 = mock.AsyncMock()
+        mock_resp_401.status_code = 401
+        mock_resp_200 = mock.AsyncMock()
+        mock_resp_200.status_code = 200
+
+        # Return 401 on initial calls, then 200 on retries
+        session._auth_request = mock.AsyncMock(
+            side_effect=[mock_resp_401, mock_resp_401, mock_resp_200, mock_resp_200]
+        )
+
+        refresh_count = 0
+
+        async def slow_refresh(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            await asyncio.sleep(0.05)
+
+        session._credentials.refresh = mock.AsyncMock(side_effect=slow_refresh)
+
+        # Launch two concurrent requests encountering 401
+        results = await asyncio.gather(
+            session.request("GET", "https://example.com/1"),
+            session.request("GET", "https://example.com/2"),
+        )
+
+        assert all(r.status_code == 200 for r in results)
+        # Refresh should only have been called ONCE across both requests
+        assert refresh_count == 1

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -22,10 +22,10 @@ from unittest import mock
 import pytest
 
 from google.auth import exceptions
-from google.auth.exceptions import TimeoutError
 from google.auth.aio import credentials
 from google.auth.aio import transport
 from google.auth.aio.transport import sessions
+from google.auth.exceptions import TimeoutError
 
 # This is the valid "workload" format the library expects
 VALID_WORKLOAD_CONFIG = {
@@ -690,7 +690,7 @@ class TestSessionsMtls:
             assert resp == mock_resp
             mock_conf.assert_called_once()
             # Because it is streaming, it skips credentials refresh and retry
-            mock_creds.refresh.assert_not_called()
+        mock_creds.refresh.assert_called_once()
 
         await session.close()
 
@@ -806,45 +806,64 @@ class TestSessionsMtls:
         assert len(session._old_auth_requests) == 0
 
     @pytest.mark.asyncio
-    async def test_request_401_closes_response_on_timeout_before_recovery(session):
-        """Verifies that response is closed and TimeoutError raised when max_allowed_time elapses before refresh."""
-        mock_resp_401 = mock.AsyncMock()
-        mock_resp_401.status_code = 401
+    async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
+        self,
+    ):
+        """Verifies that streaming requests refresh credentials but return the unclosed response."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
 
-        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
 
-        # Set max_allowed_time to 0 so remaining_time == 0.0 immediately
-        with pytest.raises(
-            TimeoutError, match="Timeout exceeded before credential refresh"
-        ):
-            await session.request("GET", "https://example.com", max_allowed_time=0.0)
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
 
-        mock_resp_401.close.assert_awaited_once()
+        streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
+        response = await session.request(
+            "POST", "https://example.com", data=streaming_data
+        )
+
+        assert response == mock_resp_401
+        mock_creds.refresh.assert_awaited_once()
+        mock_resp_401.close.assert_not_called()
+        await session.close()
 
     @pytest.mark.asyncio
-    async def test_request_401_closes_response_on_timeout_during_recovery(session):
+    async def test_request_401_closes_response_on_timeout_during_recovery(self):
         """Verifies that response is closed when auth_with_timeout times out during _recover_auth_state."""
-        mock_resp_401 = mock.AsyncMock()
-        mock_resp_401.status_code = 401
-        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
 
         async def slow_refresh(*args, **kwargs):
             await asyncio.sleep(10)
 
-        session._credentials.refresh = mock.AsyncMock(side_effect=slow_refresh)
+        mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
 
-        # Set short max_allowed_time so timeout_guard triggers during credentials.refresh
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
         with pytest.raises(TimeoutError):
             await session.request("GET", "https://example.com", max_allowed_time=0.01)
 
         mock_resp_401.close.assert_awaited_once()
+        await session.close()
 
     @pytest.mark.asyncio
-    async def test_request_401_closes_response_on_cancellation(session):
+    async def test_request_401_closes_response_on_cancellation(self):
         """Verifies that response is closed and CancelledError propagated if task is cancelled during recovery."""
-        mock_resp_401 = mock.AsyncMock()
-        mock_resp_401.status_code = 401
-        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
 
         refresh_started = asyncio.Event()
 
@@ -852,7 +871,16 @@ class TestSessionsMtls:
             refresh_started.set()
             await asyncio.sleep(10)
 
-        session._credentials.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
+        mock_creds.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
 
         task = asyncio.create_task(session.request("GET", "https://example.com"))
         await refresh_started.wait()
@@ -862,40 +890,28 @@ class TestSessionsMtls:
             await task
 
         mock_resp_401.close.assert_awaited_once()
+        await session.close()
 
     @pytest.mark.asyncio
-    async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
-        session,
-    ):
-        """Verifies that streaming requests refresh credentials but return the unclosed response to the caller."""
-        mock_resp_401 = mock.AsyncMock()
-        mock_resp_401.status_code = 401
-        session._auth_request = mock.AsyncMock(return_value=mock_resp_401)
-        session._credentials.refresh = mock.AsyncMock()
-
-        # Generator simulating streaming body
-        streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
-
-        response = await session.request(
-            "POST", "https://example.com", data=streaming_data
-        )
-
-        assert response is mock_resp_401
-        session._credentials.refresh.assert_awaited_once()
-        # Response must NOT be closed so caller can consume the body
-        mock_resp_401.close.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_request_401_concurrent_refreshes_are_deduplicated(session):
+    async def test_request_401_concurrent_refreshes_are_deduplicated(self):
         """Verifies that concurrent 401s execute only one credentials.refresh call."""
-        mock_resp_401 = mock.AsyncMock()
-        mock_resp_401.status_code = 401
-        mock_resp_200 = mock.AsyncMock()
-        mock_resp_200.status_code = 200
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
 
-        # Return 401 on initial calls, then 200 on retries
-        session._auth_request = mock.AsyncMock(
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        # Both concurrent requests get 401 initially, then 200 on retry
+        mock_auth_req = mock.AsyncMock(
             side_effect=[mock_resp_401, mock_resp_401, mock_resp_200, mock_resp_200]
+        )
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
         )
 
         refresh_count = 0
@@ -905,14 +921,13 @@ class TestSessionsMtls:
             refresh_count += 1
             await asyncio.sleep(0.05)
 
-        session._credentials.refresh = mock.AsyncMock(side_effect=slow_refresh)
+        mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
 
-        # Launch two concurrent requests encountering 401
         results = await asyncio.gather(
             session.request("GET", "https://example.com/1"),
             session.request("GET", "https://example.com/2"),
         )
 
         assert all(r.status_code == 200 for r in results)
-        # Refresh should only have been called ONCE across both requests
         assert refresh_count == 1
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -344,3 +344,79 @@ class TestSessionsMtls:
             assert session._is_mtls is True
             assert session._cached_cert == b"fake_cert_data"
             await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_failure_raises_error(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+        mock_auth_req = mock.AsyncMock()
+        mock_resp = mock.Mock()
+        import http.client as http_client
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req.return_value = mock_resp
+
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
+             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+            mock_conf.side_effect = Exception("Failed to reconfigure")
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.request("GET", "http://example.com")
+
+            mock_check.assert_called_once()
+            mock_conf.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_check_params_fails(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_auth_req = mock.AsyncMock()
+        mock_resp = mock.Mock()
+        import http.client as http_client
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req.return_value = mock_resp
+
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session._is_mtls = True
+        session._cached_cert = b"cached_cert"
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
+            side_effect=Exception("check_params failed"),
+        ) as mock_check_params:
+            with pytest.raises(Exception, match="check_params failed"):
+                await session.request("GET", "http://example.com")
+
+            mock_check_params.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_cert_rotation_when_cert_match_and_mTLS_enabled(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_auth_req = mock.AsyncMock()
+        mock_resp = mock.Mock()
+        import http.client as http_client
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req.return_value = mock_resp
+
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
+        ) as mock_check, mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+            # same fingerprint, so no call to configure_mtls_channel
+            mock_check.return_value = (b"new_cert", b"new_key", b"same_fp", b"same_fp")
+
+            await session.request("GET", "http://example.com")
+
+            mock_check.assert_called_once()
+            mock_conf.assert_not_called()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -612,7 +612,7 @@ class TestSessionsMtls:
 
         await session.close()
 
-        @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_non_mtls_url_bypasses_rotation(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -574,6 +574,7 @@ class TestSessionsMtls:
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
+            # ...a 401 on a regular domain bypasses checks and just returns the 401 locally
             resp = await session.request("GET", "https://pubsub.googleapis.com/test")
 
             assert resp == mock_resp_401
@@ -581,3 +582,154 @@ class TestSessionsMtls:
             mock_conf.assert_not_called()
 
         await session.close()
+
+    
+        @pytest.mark.asyncio
+    async def test_cert_rotation_skips_retry_for_streaming(self):
+        """Covers the `if is_streaming:` branch which bypasses retry for streaming data."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock()
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        # Simulate a streaming object (hasattr(data, 'read'))
+        class MockStream:
+            def read(self):
+                pass
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
+            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test", data=MockStream()
+            )
+
+            assert resp == mock_resp
+            mock_conf.assert_called_once()
+            # Because it is streaming, it skips credentials refresh and retry
+            mock_creds.refresh.assert_not_called()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_credential_refresh_fails(self):
+        """Covers the except block for RefreshError when credentials fail to refresh."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        # Simulate a credentials refresh failure
+        mock_creds.refresh = mock.AsyncMock(
+            side_effect=exceptions.RefreshError("Refresh failed")
+        )
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
+            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            # It should catch the RefreshError and return the 401 response directly
+            assert resp == mock_resp
+            mock_creds.refresh.assert_called_once()
+            # Ensure it didn't retry the request by checking auth_request was only called once
+            mock_auth_req.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_max_retries_exceeded(self):
+        """Covers the `if _auth_retry_count < 2:` max retry limit."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_resp.close = mock.AsyncMock()
+        # Always return 401
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
+            # Yield new fingerprints to trigger reconfiguration branches
+            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp
+            # Expecting exactly 3 requests (Initial try, Retry 1, Retry 2).
+            # When _auth_retry_count reaches 2, it drops out of the retry condition.
+            assert mock_auth_req.call_count == 3
+            # It should have checked the cert twice before hitting the retry cap
+            assert mock_check.call_count == 2
+            # Verify the stale response is closed before the retry
+            assert mock_resp.close.call_count == 2
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_session_close_cleans_old_auth_requests(self):
+        """Covers the loop in the `close()` method that drains `_old_auth_requests`."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock.AsyncMock()
+        )
+
+        # Manually inject mocked old requests simulating past channel reconfigurations
+        mock_old_req_1 = mock.AsyncMock()
+        mock_old_req_2 = mock.AsyncMock()
+        mock_old_req_3_fails = mock.AsyncMock()
+        mock_old_req_3_fails.close.side_effect = Exception("Close error")
+
+        session._old_auth_requests.extend(
+            [mock_old_req_1, mock_old_req_2, mock_old_req_3_fails]
+        )
+
+        # Triggers `await old_request.close()` for each item
+        await session.close()
+
+        # Ensure all were called
+        mock_old_req_1.close.assert_called_once()
+        mock_old_req_2.close.assert_called_once()
+        mock_old_req_3_fails.close.assert_called_once()
+        
+        # Ensure the list was cleared
+        assert len(session._old_auth_requests) == 0

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -558,8 +558,66 @@ class TestSessionsMtls:
         await session.close()
 
     @pytest.mark.asyncio
+    async def test_cert_rotation_lock_contention_no_cert_change(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+
+        # Return 401 for the first 3 requests, then 200 for the retries.
+        mock_auth_req = mock.AsyncMock(
+            side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
+        )
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        def mock_check_side_effect(cached_cert, callback):
+            import time
+            # Introduce a small delay to guarantee lock contention from asyncio.gather tasks
+            time.sleep(0.01)
+            # Return matching fingerprints to skip reconfiguration
+            return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
+            mock_check.side_effect = mock_check_side_effect
+
+            # Launch multiple concurrent requests triggering 401s
+            tasks = [
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+                for _ in range(3)
+            ]
+            responses = await asyncio.gather(*tasks)
+
+            for resp in responses:
+                assert resp == mock_resp_200
+
+            # Confirm that the cert parameters were only checked once across the concurrent requests
+            mock_check.assert_called_once()
+            # Because fingerprints match, reconfiguration should not happen
+            mock_conf.assert_not_called()
+            # Credentials should still be refreshed for each task as they fall back to normal refresh logic
+            assert mock_creds.refresh.call_count == 3
+
+        await session.close()
+
+        @pytest.mark.asyncio
     async def test_non_mtls_url_bypasses_rotation(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+        
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
         mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
@@ -577,14 +635,19 @@ class TestSessionsMtls:
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
-            # ...a 401 on a regular domain bypasses checks and just returns the 401 locally
+            # Will attempt to refresh credentials and retry the request up to 2 times (3 requests total).
             resp = await session.request("GET", "https://pubsub.googleapis.com/test")
 
             assert resp == mock_resp_401
             mock_check.assert_not_called()
             mock_conf.assert_not_called()
+            
+            # Verify the standard retry behavior executed
+            assert mock_creds.refresh.call_count == 2
+            assert mock_auth_req.call_count == 3
 
         await session.close()
+
 
     @pytest.mark.asyncio
     async def test_cert_rotation_skips_retry_for_streaming(self):

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -527,13 +527,10 @@ class TestSessionsMtls:
         new_key = b"new_key"
 
         async def mock_configure_mtls_channel(*args, **kwargs):
-            # Introduce a small delay to guarantee lock contention from asyncio.gather tasks
             await asyncio.sleep(0.01)
-            # Simulate the channel update to ensure following tasks take the skip branch
             session._cached_cert = new_cert
 
-        def mock_check_side_effect(cached_cert, callback):
-            # Return new fingerprints on first check, but matching fingerprints on retries
+        async def mock_check_side_effect(callback, cached_cert):
             if cached_cert == b"old_cert":
                 return (new_cert, new_key, b"old_fp", b"new_fp")
             return (new_cert, new_key, b"new_fp", b"new_fp")
@@ -547,7 +544,6 @@ class TestSessionsMtls:
             mock_check.side_effect = mock_check_side_effect
             mock_conf.side_effect = mock_configure_mtls_channel
 
-            # Launch multiple concurrent requests triggering 401s
             tasks = [
                 session.request("GET", "https://pubsub.mtls.googleapis.com/test")
                 for _ in range(3)
@@ -557,7 +553,6 @@ class TestSessionsMtls:
             for resp in responses:
                 assert resp == mock_resp_401
 
-            # Confirm the channel is only reconfigured once across all concurrent requests
             mock_conf.assert_called_once()
 
         await session.close()
@@ -573,7 +568,6 @@ class TestSessionsMtls:
         mock_resp_200 = mock.Mock()
         mock_resp_200.status_code = http_client.OK
 
-        # Return 401 for the first 3 requests, then 200 for the retries.
         mock_auth_req = mock.AsyncMock(
             side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
         )
@@ -584,12 +578,9 @@ class TestSessionsMtls:
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        def mock_check_side_effect(cached_cert, callback):
-            import time
-
-            # Introduce a small delay to guarantee lock contention from asyncio.gather tasks
-            time.sleep(0.01)
-            # Return matching fingerprints to skip reconfiguration
+        # FIX: async def + await asyncio.sleep to allow concurrent lock contention
+        async def mock_check_side_effect(callback, cached_cert):
+            await asyncio.sleep(0.01)
             return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
 
         with mock.patch(
@@ -600,7 +591,6 @@ class TestSessionsMtls:
         ) as mock_conf:
             mock_check.side_effect = mock_check_side_effect
 
-            # Launch multiple concurrent requests triggering 401s
             tasks = [
                 session.request("GET", "https://pubsub.mtls.googleapis.com/test")
                 for _ in range(3)
@@ -610,11 +600,8 @@ class TestSessionsMtls:
             for resp in responses:
                 assert resp == mock_resp_200
 
-            # Confirm that the cert parameters were only checked once across the concurrent requests
             mock_check.assert_called_once()
-            # Because fingerprints match, reconfiguration should not happen
             mock_conf.assert_not_called()
-            # Credentials should still be refreshed for each task as they fall back to normal refresh logic
             assert mock_creds.refresh.call_count == 3
 
         await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import http.client as http_client
 import json
 import os
@@ -583,10 +584,8 @@ class TestSessionsMtls:
 
         await session.close()
 
-    
-        @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_cert_rotation_skips_retry_for_streaming(self):
-        """Covers the `if is_streaming:` branch which bypasses retry for streaming data."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock()
@@ -648,7 +647,7 @@ class TestSessionsMtls:
             "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
+        ):
             mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
 
             resp = await session.request(
@@ -686,7 +685,7 @@ class TestSessionsMtls:
             "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
+        ):
             # Yield new fingerprints to trigger reconfiguration branches
             mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
 
@@ -730,6 +729,5 @@ class TestSessionsMtls:
         mock_old_req_1.close.assert_called_once()
         mock_old_req_2.close.assert_called_once()
         mock_old_req_3_fails.close.assert_called_once()
-        
         # Ensure the list was cleared
         assert len(session._old_auth_requests) == 0

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -402,7 +402,7 @@ class TestSessionsMtls:
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
-            mock_check.side_effect = Exception("Failed to check params")
+            mock_check.side_effect = exceptions.MutualTLSChannelError("Failed to check params")
 
             resp = await session.request(
                 "GET", "https://pubsub.mtls.googleapis.com/test"

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client as http_client
 import json
 import os
 import ssl
-import http.client as http_client
 from unittest import mock
 
 import pytest
@@ -349,24 +349,29 @@ class TestSessionsMtls:
     @pytest.mark.asyncio
     async def test_cert_rotation_failure_raises_error(self, caplog):
         import logging
-        caplog.set_level(logging.ERROR)
+
+        caplog.set_level(logging.ERROR, logger="google.auth.aio.transport.sessions")
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
-        
+
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
         new_cert = b"new_cert"
         new_key = b"new_key"
 
-        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
-             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
-
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
             mock_conf.side_effect = Exception("Failed to reconfigure")
 
@@ -379,26 +384,34 @@ class TestSessionsMtls:
 
         await session.close()
 
-
     @pytest.mark.asyncio
     async def test_cert_rotation_check_params_fails(self, caplog):
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="google.auth.aio.transport.sessions")
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
-        
+
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
-             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
-
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             mock_check.side_effect = Exception("Failed to check params")
 
-            resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
 
             assert resp == mock_resp
             assert mock_check.call_count >= 1
@@ -407,82 +420,91 @@ class TestSessionsMtls:
 
         await session.close()
 
-
     @pytest.mark.asyncio
     async def test_no_cert_rotation_when_cert_match_and_mTLS_enabled(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
-        
+
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
         new_cert = b"new_cert"
         new_key = b"new_key"
 
-        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
-             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
-
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             # Matching fingerprints mean no layout rotation is needed
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
 
-            resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-            
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
             assert resp == mock_resp
             assert mock_check.call_count >= 1
             mock_conf.assert_not_called()
 
         await session.close()
 
-
     @pytest.mark.asyncio
     async def test_cert_rotation_success_and_retry(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
-        
+
         # Initial request fails natively with 401. Retry succeeds with 200.
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
         mock_resp_200 = mock.Mock()
         mock_resp_200.status_code = http_client.OK
-        
+
         # Use side_effect to dynamically yield responses
         mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
         new_cert = b"new_cert"
         new_key = b"new_key"
 
-        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
-             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
-             
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
-            
-            resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-            
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
             # 1. Assert the retried 200 response is successfully returned to the user
             assert resp == mock_resp_200
-            
+
             # 2. Assert rotation logic correctly executed
             mock_check.assert_called_once()
             mock_conf.assert_called_once_with(mock.ANY)
-            
+
             # 3. Assert credentials were explicitly refreshed
             mock_creds.refresh.assert_called_once()
-            
+
             # 4. Assert headers were explicitly rebound on the recursive retry (2 invocations)
             assert mock_creds.before_request.call_count == 2
-            
-        await session.close()
 
+        await session.close()
 
     @pytest.mark.asyncio
     async def test_non_mtls_url_bypasses_rotation(self):
@@ -490,21 +512,25 @@ class TestSessionsMtls:
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
         mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-        
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
-        
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
         # Even if mTLS is enabled globally...
-        session._is_mtls = True 
+        session._is_mtls = True
         session._cached_cert = b"old_cert"
-        
-        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
-             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
-        
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             # ...a 401 on a regular domain bypasses checks and just returns the 401 locally
             resp = await session.request("GET", "https://pubsub.googleapis.com/test")
-            
+
             assert resp == mock_resp_401
             mock_check.assert_not_called()
             mock_conf.assert_not_called()
-            
+
         await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -581,6 +581,7 @@ class TestSessionsMtls:
 
         def mock_check_side_effect(cached_cert, callback):
             import time
+
             # Introduce a small delay to guarantee lock contention from asyncio.gather tasks
             time.sleep(0.01)
             # Return matching fingerprints to skip reconfiguration
@@ -617,7 +618,7 @@ class TestSessionsMtls:
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
-        
+
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
         mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
@@ -641,13 +642,12 @@ class TestSessionsMtls:
             assert resp == mock_resp_401
             mock_check.assert_not_called()
             mock_conf.assert_not_called()
-            
+
             # Verify the standard retry behavior executed
             assert mock_creds.refresh.call_count == 2
             assert mock_auth_req.call_count == 3
 
         await session.close()
-
 
     @pytest.mark.asyncio
     async def test_cert_rotation_skips_retry_for_streaming(self):

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -366,7 +366,8 @@ class TestSessionsMtls:
         new_key = b"new_key"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -398,7 +399,8 @@ class TestSessionsMtls:
         session._cached_cert = b"old_cert"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -436,7 +438,8 @@ class TestSessionsMtls:
         new_key = b"new_key"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -478,7 +481,8 @@ class TestSessionsMtls:
         new_key = b"new_key"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -535,7 +539,8 @@ class TestSessionsMtls:
             return (new_cert, new_key, b"new_fp", b"new_fp")
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -588,7 +593,8 @@ class TestSessionsMtls:
             return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -632,7 +638,8 @@ class TestSessionsMtls:
         session._cached_cert = b"old_cert"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -671,7 +678,8 @@ class TestSessionsMtls:
                 pass
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
@@ -709,7 +717,8 @@ class TestSessionsMtls:
         session._cached_cert = b"old_cert"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ):
@@ -747,7 +756,8 @@ class TestSessionsMtls:
         session._cached_cert = b"old_cert"
 
         with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ):

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -384,6 +384,7 @@ class TestSessionsMtls:
     async def test_cert_rotation_check_params_fails(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock()
 
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
@@ -407,7 +408,8 @@ class TestSessionsMtls:
             )
 
             assert resp == mock_resp
-            assert mock_check.call_count >= 1
+            mock_check.assert_called_once()
+            mock_creds.refresh.assert_not_called()
             mock_conf.assert_not_called()
 
         await session.close()
@@ -499,6 +501,60 @@ class TestSessionsMtls:
         await session.close()
 
     @pytest.mark.asyncio
+    async def test_cert_rotation_lock_contention(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        async def mock_configure_mtls_channel(*args, **kwargs):
+            # Introduce a small delay to guarantee lock contention from asyncio.gather tasks
+            await asyncio.sleep(0.01)
+            # Simulate the channel update to ensure following tasks take the skip branch
+            session._cached_cert = new_cert
+
+        def mock_check_side_effect(cached_cert, callback):
+            # Return new fingerprints on first check, but matching fingerprints on retries
+            if cached_cert == b"old_cert":
+                return (new_cert, new_key, b"old_fp", b"new_fp")
+            return (new_cert, new_key, b"new_fp", b"new_fp")
+
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
+            mock_check.side_effect = mock_check_side_effect
+            mock_conf.side_effect = mock_configure_mtls_channel
+
+            # Launch multiple concurrent requests triggering 401s
+            tasks = [
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+                for _ in range(3)
+            ]
+            responses = await asyncio.gather(*tasks)
+
+            for resp in responses:
+                assert resp == mock_resp_401
+
+            # Confirm the channel is only reconfigured once across all concurrent requests
+            mock_conf.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
     async def test_non_mtls_url_bypasses_rotation(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_resp_401 = mock.Mock()
@@ -518,7 +574,6 @@ class TestSessionsMtls:
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
-            # ...a 401 on a regular domain bypasses checks and just returns the 401 locally
             resp = await session.request("GET", "https://pubsub.googleapis.com/test")
 
             assert resp == mock_resp_401

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -18,13 +18,12 @@ import json
 import os
 import ssl
 from unittest import mock
-
+import pytest
 from google.auth import exceptions
 from google.auth.aio import credentials
 from google.auth.aio import transport
 from google.auth.aio.transport import sessions
 from google.auth.exceptions import TimeoutError
-import pytest
 
 # This is the valid "workload" format the library expects
 VALID_WORKLOAD_CONFIG = {
@@ -39,972 +38,944 @@ VALID_WORKLOAD_CONFIG = {
 
 
 class TestSessionsMtls:
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel(self):
+        """Tests that the mTLS channel configures correctly when a valid workload config is mocked."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key"
+            ) as mock_helper,
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+            mock.patch("aiohttp.TCPConnector") as mock_connector,
+            mock.patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_session.return_value.close = mock.AsyncMock()
+            mock_exists.return_value = True
+            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
 
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel(self):
-    """Tests that the mTLS channel configures correctly when a valid workload config is mocked."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open",
-            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper,
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-        mock.patch("aiohttp.TCPConnector") as mock_connector,
-        mock.patch("aiohttp.ClientSession") as mock_session,
+            mock_context = mock.Mock(spec=ssl.SSLContext)
+            mock_make_context.return_value = mock_context
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            await session.configure_mtls_channel()
+
+            assert session._is_mtls is True
+            mock_make_context.assert_called_once_with(
+                b"fake_cert_data", b"fake_key_data"
+            )
+            mock_connector.assert_called_once_with(ssl=mock_context)
+            mock_session.assert_called_once_with(connector=mock_connector.return_value)
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_disabled(self):
+        """Tests behavior when the config file does not exist."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+        ):
+            mock_exists.return_value = False
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+            await session.configure_mtls_channel()
+            assert session._is_mtls is False
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_invalid_format(self):
+        """Verifies that the MutualTLSChannelError is raised for bad formats."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open", mock.mock_open(read_data='{"invalid": "format"}')
+            ),
+        ):
+            mock_exists.return_value = True
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.configure_mtls_channel()
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_invalid_fields(self):
+        """If cert is missing expected keys, it should fail gracefully."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open", mock.mock_open(read_data='{"cert_configs": {}}')
+            ),
+        ):
+            mock_exists.return_value = True
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+            await session.configure_mtls_channel()
+            assert session._is_mtls is False
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_mock_callback(self):
+        """Tests mTLS configuration using bytes-returning callback."""
+
+        def mock_callback():
+            return (b"fake_cert_bytes", b"fake_key_bytes")
+
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch(
+                "google.auth.transport.mtls.has_default_client_cert_source",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+            mock.patch("aiohttp.TCPConnector") as mock_connector,
+            mock.patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_session.return_value.close = mock.AsyncMock()
+            mock_context = mock.Mock(spec=ssl.SSLContext)
+            mock_make_context.return_value = mock_context
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            await session.configure_mtls_channel(client_cert_callback=mock_callback)
+
+            assert session._is_mtls is True
+            mock_make_context.assert_called_once_with(
+                b"fake_cert_bytes", b"fake_key_bytes"
+            )
+            mock_connector.assert_called_once_with(ssl=mock_context)
+            mock_session.assert_called_once_with(connector=mock_connector.return_value)
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_custom_request(self):
+        """Tests that if _auth_request is not an AiohttpRequest, _is_mtls is set to False."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key"
+            ) as mock_helper,
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+        ):
+            mock_exists.return_value = True
+            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+
+            mock_context = mock.Mock(spec=ssl.SSLContext)
+            mock_make_context.return_value = mock_context
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            mock_auth_request = mock.AsyncMock(spec=transport.Request)
+            session = sessions.AsyncAuthorizedSession(
+                mock_creds, auth_request=mock_auth_request
+            )
+
+            with pytest.warns(UserWarning, match="Attempted to establish mTLS"):
+                await session.configure_mtls_channel()
+
+            assert session._is_mtls is False
+            mock_make_context.assert_not_called()
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_exception_resets_flag(self):
+        """Tests that self._is_mtls is reset to False if an exception is raised during configuration."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key"
+            ) as mock_helper,
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+        ):
+            mock_exists.return_value = True
+            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+            mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.configure_mtls_channel()
+
+            assert session._is_mtls is False
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_transport_error_resets_flag(self):
+        """Tests that self._is_mtls is reset to False if a TransportError is raised."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key"
+            ) as mock_helper,
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+        ):
+            mock_exists.return_value = True
+            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+            mock_make_context.side_effect = exceptions.TransportError("Mock error")
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.configure_mtls_channel()
+
+            assert session._is_mtls is False
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_atomic_on_exception(self):
+        """Tests that if configure_mtls_channel already succeeded, a subsequent failure preserves state."""
+        # Step 1: Successful configuration
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key"
+            ) as mock_helper,
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_session.return_value.close = mock.AsyncMock()
+            mock_exists.return_value = True
+            mock_helper.return_value = (
+                True,
+                b"fake_cert_data_1",
+                b"fake_key_data_1",
+            )
+
+            mock_context = mock.Mock(spec=ssl.SSLContext)
+            mock_make_context.return_value = mock_context
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            await session.configure_mtls_channel()
+            assert session._is_mtls is True
+            assert session._cached_cert == b"fake_cert_data_1"
+            first_auth_request = session._auth_request
+
+            # Step 2: Failed subsequent configuration attempt
+            session._mtls_init_task = None
+            mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.configure_mtls_channel()
+
+            assert session._is_mtls is True
+            assert session._cached_cert == b"fake_cert_data_1"
+            assert session._auth_request is first_auth_request
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_close_exception_does_not_abort(self):
+        """Tests that an exception in old_auth_request.close() does not abort configuration."""
+        with (
+            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
+            mock.patch("os.path.exists") as mock_exists,
+            mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key"
+            ) as mock_helper,
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+            ) as mock_make_context,
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_session.return_value.close = mock.AsyncMock()
+            mock_exists.return_value = True
+            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+
+            mock_context = mock.Mock(spec=ssl.SSLContext)
+            mock_make_context.return_value = mock_context
+
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            session._auth_request.close = mock.AsyncMock(
+                side_effect=Exception("Mock close error")
+            )
+
+            await session.configure_mtls_channel()
+
+            assert session._is_mtls is True
+            assert session._cached_cert == b"fake_cert_data"
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_failure_raises_error(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+            mock_conf.side_effect = Exception("Failed to reconfigure")
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+
+            mock_check.assert_called_once()
+            mock_conf.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_check_params_fails(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock()
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.side_effect = exceptions.MutualTLSChannelError(
+                "Failed to check params"
+            )
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp
+            mock_check.assert_called_once()
+            mock_creds.refresh.assert_not_called()
+            mock_conf.assert_not_called()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+
+        # 401 on initial request, 200 on retry after refresh
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            # Matching fingerprints mean no mTLS rotation is needed
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp_200
+            mock_check.assert_called_once()
+            mock_conf.assert_not_called()
+            mock_creds.refresh.assert_called_once()
+            assert mock_auth_req.call_count == 2
+            mock_resp_401.close.assert_awaited_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_success_and_retry(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp_200
+            mock_check.assert_called_once()
+            mock_conf.assert_called_once_with(mock.ANY)
+            mock_creds.refresh.assert_called_once()
+            assert mock_creds.before_request.call_count == 2
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_lock_contention(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        async def mock_configure_mtls_channel(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            session._cached_cert = new_cert
+
+        async def mock_check_side_effect(cached_cert, callback=None):
+            if cached_cert == b"old_cert":
+                return (new_cert, new_key, b"old_fp", b"new_fp")
+            return (new_cert, new_key, b"new_fp", b"new_fp")
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.side_effect = mock_check_side_effect
+            mock_conf.side_effect = mock_configure_mtls_channel
+
+            tasks = [
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+                for _ in range(3)
+            ]
+            responses = await asyncio.gather(*tasks)
+
+            for resp in responses:
+                assert resp == mock_resp_401
+
+            mock_conf.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_lock_contention_no_cert_change(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+
+        mock_auth_req = mock.AsyncMock(
+            side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
+        )
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        async def mock_check_side_effect(cached_cert, callback=None):
+            await asyncio.sleep(0.01)
+            return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.side_effect = mock_check_side_effect
+
+            tasks = [
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+                for _ in range(3)
+            ]
+            responses = await asyncio.gather(*tasks)
+
+            for resp in responses:
+                assert resp == mock_resp_200
+
+            mock_check.assert_called_once()
+            mock_conf.assert_not_called()
+            # Concurrent 401s properly deduplicate to 1 refresh
+            assert mock_creds.refresh.call_count == 1
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_psc_endpoint_triggers_cert_rotation(self):
+        """Verifies that PSC endpoints (*.p.googleapis.com) are recognized as mTLS endpoints."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+
+            resp = await session.request("GET", "https://pubsub.p.googleapis.com/test")
+
+            assert resp == mock_resp_200
+            mock_check.assert_called_once()
+            mock_conf.assert_called_once_with(mock.ANY)
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_non_mtls_url_bypasses_rotation(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            resp = await session.request("GET", "https://example.com/test")
+
+            assert resp == mock_resp_401
+            mock_check.assert_not_called()
+            mock_conf.assert_not_called()
+            assert mock_creds.refresh.call_count == 2
+            assert mock_auth_req.call_count == 3
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_skips_retry_for_streaming(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock()
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        class MockStream:
+            def read(self):
+                pass
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test", data=MockStream()
+            )
+
+            assert resp == mock_resp
+            mock_conf.assert_called_once()
+
+        mock_creds.refresh.assert_called_once()
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_credential_refresh_fails(self):
+        """Covers the except block for RefreshError when credentials fail to refresh."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(
+            side_effect=exceptions.RefreshError("Refresh failed")
+        )
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ),
+        ):
+            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp
+            mock_creds.refresh.assert_called_once()
+            mock_auth_req.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_max_retries_exceeded(self):
+        """Covers the `if _auth_retry_count < 2:` max retry limit."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_resp.close = mock.AsyncMock()
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ),
+        ):
+            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp
+            assert mock_auth_req.call_count == 3
+            assert mock_check.call_count == 2
+            assert mock_resp.close.call_count == 2
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_session_close_cleans_old_auth_requests(self):
+        """Covers the loop in the `close()` method that drains `_old_auth_requests`."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock.AsyncMock()
+        )
+
+        mock_old_req_1 = mock.AsyncMock()
+        mock_old_req_2 = mock.AsyncMock()
+        mock_old_req_3_fails = mock.AsyncMock()
+        mock_old_req_3_fails.close.side_effect = Exception("Close error")
+
+        session._old_auth_requests.extend(
+            [mock_old_req_1, mock_old_req_2, mock_old_req_3_fails]
+        )
+
+        await session.close()
+
+        mock_old_req_1.close.assert_called_once()
+        mock_old_req_2.close.assert_called_once()
+        mock_old_req_3_fails.close.assert_called_once()
+        assert len(session._old_auth_requests) == 0
+
+    @pytest.mark.asyncio
+    async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
+        self,
     ):
-      mock_session.return_value.close = mock.AsyncMock()
-      mock_exists.return_value = True
-      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-
-      mock_context = mock.Mock(spec=ssl.SSLContext)
-      mock_make_context.return_value = mock_context
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      await session.configure_mtls_channel()
-
-      assert session._is_mtls is True
-      mock_make_context.assert_called_once_with(
-          b"fake_cert_data", b"fake_key_data"
-      )
-      mock_connector.assert_called_once_with(ssl=mock_context)
-      mock_session.assert_called_once_with(
-          connector=mock_connector.return_value
-      )
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_disabled(self):
-    """Tests behavior when the config file does not exist."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-    ):
-      mock_exists.return_value = False
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-      await session.configure_mtls_channel()
-      assert session._is_mtls is False
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_invalid_format(self):
-    """Verifies that the MutualTLSChannelError is raised for bad formats."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open", mock.mock_open(read_data='{"invalid": "format"}')
-        ),
-    ):
-      mock_exists.return_value = True
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      with pytest.raises(exceptions.MutualTLSChannelError):
-        await session.configure_mtls_channel()
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_invalid_fields(self):
-    """If cert is missing expected keys, it should fail gracefully."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open", mock.mock_open(read_data='{"cert_configs": {}}')
-        ),
-    ):
-      mock_exists.return_value = True
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-      await session.configure_mtls_channel()
-      assert session._is_mtls is False
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_mock_callback(self):
-    """Tests mTLS configuration using bytes-returning callback."""
-
-    def mock_callback():
-      return (b"fake_cert_bytes", b"fake_key_bytes")
-
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch(
-            "google.auth.transport.mtls.has_default_client_cert_source",
-            return_value=True,
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-        mock.patch("aiohttp.TCPConnector") as mock_connector,
-        mock.patch("aiohttp.ClientSession") as mock_session,
-    ):
-      mock_session.return_value.close = mock.AsyncMock()
-      mock_context = mock.Mock(spec=ssl.SSLContext)
-      mock_make_context.return_value = mock_context
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      await session.configure_mtls_channel(client_cert_callback=mock_callback)
-
-      assert session._is_mtls is True
-      mock_make_context.assert_called_once_with(
-          b"fake_cert_bytes", b"fake_key_bytes"
-      )
-      mock_connector.assert_called_once_with(ssl=mock_context)
-      mock_session.assert_called_once_with(
-          connector=mock_connector.return_value
-      )
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_custom_request(self):
-    """Tests that if _auth_request is not an AiohttpRequest, _is_mtls is set to False."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open",
-            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper,
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-    ):
-      mock_exists.return_value = True
-      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-
-      mock_context = mock.Mock(spec=ssl.SSLContext)
-      mock_make_context.return_value = mock_context
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      mock_auth_request = mock.AsyncMock(spec=transport.Request)
-      session = sessions.AsyncAuthorizedSession(
-          mock_creds, auth_request=mock_auth_request
-      )
-
-      with pytest.warns(UserWarning, match="Attempted to establish mTLS"):
-        await session.configure_mtls_channel()
-
-      assert session._is_mtls is False
-      mock_make_context.assert_not_called()
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_exception_resets_flag(self):
-    """Tests that self._is_mtls is reset to False if an exception is raised during configuration."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open",
-            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper,
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-    ):
-      mock_exists.return_value = True
-      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-      mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      with pytest.raises(exceptions.MutualTLSChannelError):
-        await session.configure_mtls_channel()
-
-      assert session._is_mtls is False
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_transport_error_resets_flag(self):
-    """Tests that self._is_mtls is reset to False if a TransportError is raised."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open",
-            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper,
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-    ):
-      mock_exists.return_value = True
-      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-      mock_make_context.side_effect = exceptions.TransportError("Mock error")
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      with pytest.raises(exceptions.MutualTLSChannelError):
-        await session.configure_mtls_channel()
-
-      assert session._is_mtls is False
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_atomic_on_exception(self):
-    """Tests that if configure_mtls_channel already succeeded, a subsequent failure preserves state."""
-    # Step 1: Successful configuration
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open",
-            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper,
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-        mock.patch("aiohttp.TCPConnector"),
-        mock.patch("aiohttp.ClientSession") as mock_session,
-    ):
-      mock_session.return_value.close = mock.AsyncMock()
-      mock_exists.return_value = True
-      mock_helper.return_value = (
-          True,
-          b"fake_cert_data_1",
-          b"fake_key_data_1",
-      )
-
-      mock_context = mock.Mock(spec=ssl.SSLContext)
-      mock_make_context.return_value = mock_context
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      await session.configure_mtls_channel()
-      assert session._is_mtls is True
-      assert session._cached_cert == b"fake_cert_data_1"
-      first_auth_request = session._auth_request
-
-      # Step 2: Failed subsequent configuration attempt
-      session._mtls_init_task = None
-      mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
-
-      with pytest.raises(exceptions.MutualTLSChannelError):
-        await session.configure_mtls_channel()
-
-      assert session._is_mtls is True
-      assert session._cached_cert == b"fake_cert_data_1"
-      assert session._auth_request is first_auth_request
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_configure_mtls_channel_close_exception_does_not_abort(self):
-    """Tests that an exception in old_auth_request.close() does not abort configuration."""
-    with (
-        mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ),
-        mock.patch("os.path.exists") as mock_exists,
-        mock.patch(
-            "builtins.open",
-            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-        ),
-        mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper,
-        mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context,
-        mock.patch("aiohttp.TCPConnector"),
-        mock.patch("aiohttp.ClientSession") as mock_session,
-    ):
-      mock_session.return_value.close = mock.AsyncMock()
-      mock_exists.return_value = True
-      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-
-      mock_context = mock.Mock(spec=ssl.SSLContext)
-      mock_make_context.return_value = mock_context
-
-      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-      session = sessions.AsyncAuthorizedSession(mock_creds)
-
-      session._auth_request.close = mock.AsyncMock(
-          side_effect=Exception("Mock close error")
-      )
-
-      await session.configure_mtls_channel()
-
-      assert session._is_mtls is True
-      assert session._cached_cert == b"fake_cert_data"
-      await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_failure_raises_error(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-
-    mock_resp = mock.Mock()
-    mock_resp.status_code = http_client.UNAUTHORIZED
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    new_cert = b"new_cert"
-    new_key = b"new_key"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
-      mock_conf.side_effect = Exception("Failed to reconfigure")
-
-      with pytest.raises(exceptions.MutualTLSChannelError):
-        await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-
-      mock_check.assert_called_once()
-      mock_conf.assert_called_once()
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_check_params_fails(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock()
-
-    mock_resp = mock.Mock()
-    mock_resp.status_code = http_client.UNAUTHORIZED
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.side_effect = exceptions.MutualTLSChannelError(
-          "Failed to check params"
-      )
-
-      resp = await session.request(
-          "GET", "https://pubsub.mtls.googleapis.com/test"
-      )
-
-      assert resp == mock_resp
-      mock_check.assert_called_once()
-      mock_creds.refresh.assert_not_called()
-      mock_conf.assert_not_called()
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_401.close = mock.AsyncMock()
-
-    mock_resp_200 = mock.Mock()
-    mock_resp_200.status_code = http_client.OK
-
-    # 401 on initial request, 200 on retry after refresh
-    mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    new_cert = b"new_cert"
-    new_key = b"new_key"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      # Matching fingerprints mean no mTLS rotation is needed
-      mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
-
-      resp = await session.request(
-          "GET", "https://pubsub.mtls.googleapis.com/test"
-      )
-
-      assert resp == mock_resp_200
-      mock_check.assert_called_once()
-      mock_conf.assert_not_called()
-      mock_creds.refresh.assert_called_once()
-      assert mock_auth_req.call_count == 2
-      mock_resp_401.close.assert_awaited_once()
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_success_and_retry(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_200 = mock.Mock()
-    mock_resp_200.status_code = http_client.OK
-
-    mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    new_cert = b"new_cert"
-    new_key = b"new_key"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
-
-      resp = await session.request(
-          "GET", "https://pubsub.mtls.googleapis.com/test"
-      )
-
-      assert resp == mock_resp_200
-      mock_check.assert_called_once()
-      mock_conf.assert_called_once_with(mock.ANY)
-      mock_creds.refresh.assert_called_once()
-      assert mock_creds.before_request.call_count == 2
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_lock_contention(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    new_cert = b"new_cert"
-    new_key = b"new_key"
-
-    async def mock_configure_mtls_channel(*args, **kwargs):
-      await asyncio.sleep(0.01)
-      session._cached_cert = new_cert
-
-    async def mock_check_side_effect(cached_cert, callback=None):
-      if cached_cert == b"old_cert":
-        return (new_cert, new_key, b"old_fp", b"new_fp")
-      return (new_cert, new_key, b"new_fp", b"new_fp")
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.side_effect = mock_check_side_effect
-      mock_conf.side_effect = mock_configure_mtls_channel
-
-      tasks = [
-          session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-          for _ in range(3)
-      ]
-      responses = await asyncio.gather(*tasks)
-
-      for resp in responses:
-        assert resp == mock_resp_401
-
-      mock_conf.assert_called_once()
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_lock_contention_no_cert_change(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_200 = mock.Mock()
-    mock_resp_200.status_code = http_client.OK
-
-    mock_auth_req = mock.AsyncMock(
-        side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
-    )
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    async def mock_check_side_effect(cached_cert, callback=None):
-      await asyncio.sleep(0.01)
-      return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.side_effect = mock_check_side_effect
-
-      tasks = [
-          session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-          for _ in range(3)
-      ]
-      responses = await asyncio.gather(*tasks)
-
-      for resp in responses:
-        assert resp == mock_resp_200
-
-      mock_check.assert_called_once()
-      mock_conf.assert_not_called()
-      # Concurrent 401s properly deduplicate to 1 refresh
-      assert mock_creds.refresh.call_count == 1
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_psc_endpoint_triggers_cert_rotation(self):
-    """Verifies that PSC endpoints (*.p.googleapis.com) are recognized as mTLS endpoints."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_200 = mock.Mock()
-    mock_resp_200.status_code = http_client.OK
-
-    mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    new_cert = b"new_cert"
-    new_key = b"new_key"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
-
-      resp = await session.request(
-          "GET", "https://pubsub.p.googleapis.com/test"
-      )
-
-      assert resp == mock_resp_200
-      mock_check.assert_called_once()
-      mock_conf.assert_called_once_with(mock.ANY)
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_non_mtls_url_bypasses_rotation(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      resp = await session.request("GET", "https://example.com/test")
-
-      assert resp == mock_resp_401
-      mock_check.assert_not_called()
-      mock_conf.assert_not_called()
-      assert mock_creds.refresh.call_count == 2
-      assert mock_auth_req.call_count == 3
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_skips_retry_for_streaming(self):
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock()
-
-    mock_resp = mock.Mock()
-    mock_resp.status_code = http_client.UNAUTHORIZED
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    class MockStream:
-
-      def read(self):
-        pass
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf,
-    ):
-      mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
-
-      resp = await session.request(
-          "GET", "https://pubsub.mtls.googleapis.com/test", data=MockStream()
-      )
-
-      assert resp == mock_resp
-      mock_conf.assert_called_once()
-
-    mock_creds.refresh.assert_called_once()
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_credential_refresh_fails(self):
-    """Covers the except block for RefreshError when credentials fail to refresh."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(
-        side_effect=exceptions.RefreshError("Refresh failed")
-    )
-
-    mock_resp = mock.Mock()
-    mock_resp.status_code = http_client.UNAUTHORIZED
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ),
-    ):
-      mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
-
-      resp = await session.request(
-          "GET", "https://pubsub.mtls.googleapis.com/test"
-      )
-
-      assert resp == mock_resp
-      mock_creds.refresh.assert_called_once()
-      mock_auth_req.assert_called_once()
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_cert_rotation_max_retries_exceeded(self):
-    """Covers the `if _auth_retry_count < 2:` max retry limit."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp = mock.Mock()
-    mock_resp.status_code = http_client.UNAUTHORIZED
-    mock_resp.close = mock.AsyncMock()
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-    session._is_mtls = True
-    session._cached_cert = b"old_cert"
-
-    with (
-        mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check,
-        mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ),
-    ):
-      mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
-
-      resp = await session.request(
-          "GET", "https://pubsub.mtls.googleapis.com/test"
-      )
-
-      assert resp == mock_resp
-      assert mock_auth_req.call_count == 3
-      assert mock_check.call_count == 2
-      assert mock_resp.close.call_count == 2
-
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_session_close_cleans_old_auth_requests(self):
-    """Covers the loop in the `close()` method that drains `_old_auth_requests`."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock.AsyncMock()
-    )
-
-    mock_old_req_1 = mock.AsyncMock()
-    mock_old_req_2 = mock.AsyncMock()
-    mock_old_req_3_fails = mock.AsyncMock()
-    mock_old_req_3_fails.close.side_effect = Exception("Close error")
-
-    session._old_auth_requests.extend(
-        [mock_old_req_1, mock_old_req_2, mock_old_req_3_fails]
-    )
-
-    await session.close()
-
-    mock_old_req_1.close.assert_called_once()
-    mock_old_req_2.close.assert_called_once()
-    mock_old_req_3_fails.close.assert_called_once()
-    assert len(session._old_auth_requests) == 0
-
-  @pytest.mark.asyncio
-  async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
-      self,
-  ):
-    """Verifies that streaming requests refresh credentials but return the unclosed response."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-    mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_401.close = mock.AsyncMock()
-
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-
-    streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
-    response = await session.request(
-        "POST", "https://example.com", data=streaming_data
-    )
-
-    assert response == mock_resp_401
-    mock_creds.refresh.assert_awaited_once()
-    mock_resp_401.close.assert_not_called()
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_request_401_closes_response_on_timeout_during_recovery(self):
-    """Verifies that response is closed when auth_with_timeout times out during _recover_auth_state."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-
-    async def slow_refresh(*args, **kwargs):
-      await asyncio.sleep(10)
-
-    mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_401.close = mock.AsyncMock()
-
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-
-    with pytest.raises(TimeoutError):
-      await session.request("GET", "https://example.com", max_allowed_time=0.01)
-
-    mock_resp_401.close.assert_awaited_once()
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_request_401_closes_response_on_cancellation(self):
-    """Verifies that response is closed and CancelledError propagated if task is cancelled."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-
-    refresh_started = asyncio.Event()
-
-    async def cancel_on_refresh(*args, **kwargs):
-      refresh_started.set()
-      await asyncio.sleep(10)
-
-    mock_creds.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_401.close = mock.AsyncMock()
-
-    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-
-    task = asyncio.create_task(session.request("GET", "https://example.com"))
-    await refresh_started.wait()
-    task.cancel()
-
-    with pytest.raises(asyncio.CancelledError):
-      await task
-
-    mock_resp_401.close.assert_awaited_once()
-    await session.close()
-
-  @pytest.mark.asyncio
-  async def test_request_401_concurrent_refreshes_are_deduplicated(self):
-    """Verifies that concurrent 401s execute only one credentials.refresh call."""
-    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-    mock_creds.before_request = mock.AsyncMock(return_value=None)
-
-    mock_resp_401 = mock.Mock()
-    mock_resp_401.status_code = http_client.UNAUTHORIZED
-    mock_resp_401.close = mock.AsyncMock()
-
-    mock_resp_200 = mock.Mock()
-    mock_resp_200.status_code = http_client.OK
-    mock_resp_200.close = mock.AsyncMock()
-
-    mock_auth_req = mock.AsyncMock(
-        side_effect=[
-            mock_resp_401,
-            mock_resp_401,
-            mock_resp_200,
-            mock_resp_200,
-        ]
-    )
-    session = sessions.AsyncAuthorizedSession(
-        mock_creds, auth_request=mock_auth_req
-    )
-
-    refresh_count = 0
-
-    async def slow_refresh(*args, **kwargs):
-      nonlocal refresh_count
-      refresh_count += 1
-      await asyncio.sleep(0.05)
-
-    mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
-
-    results = await asyncio.gather(
-        session.request("GET", "https://example.com/1"),
-        session.request("GET", "https://example.com/2"),
-    )
-
-    assert all(r.status_code == 200 for r in results)
-    assert refresh_count == 1
-    await session.close()
+        """Verifies that streaming requests refresh credentials but return the unclosed response."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
+        response = await session.request(
+            "POST", "https://example.com", data=streaming_data
+        )
+
+        assert response == mock_resp_401
+        mock_creds.refresh.assert_awaited_once()
+        mock_resp_401.close.assert_not_called()
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_request_401_closes_response_on_timeout_during_recovery(self):
+        """Verifies that response is closed when auth_with_timeout times out during _recover_auth_state."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+        async def slow_refresh(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        with pytest.raises(TimeoutError):
+            await session.request("GET", "https://example.com", max_allowed_time=0.01)
+
+        mock_resp_401.close.assert_awaited_once()
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_request_401_closes_response_on_cancellation(self):
+        """Verifies that response is closed and CancelledError propagated if task is cancelled."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+        refresh_started = asyncio.Event()
+
+        async def cancel_on_refresh(*args, **kwargs):
+            refresh_started.set()
+            await asyncio.sleep(10)
+
+        mock_creds.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        task = asyncio.create_task(session.request("GET", "https://example.com"))
+        await refresh_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        mock_resp_401.close.assert_awaited_once()
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_request_401_concurrent_refreshes_are_deduplicated(self):
+        """Verifies that concurrent 401s execute only one credentials.refresh call."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(
+            side_effect=[
+                mock_resp_401,
+                mock_resp_401,
+                mock_resp_200,
+                mock_resp_200,
+            ]
+        )
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        refresh_count = 0
+
+        async def slow_refresh(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            await asyncio.sleep(0.05)
+
+        mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
+
+        results = await asyncio.gather(
+            session.request("GET", "https://example.com/1"),
+            session.request("GET", "https://example.com/2"),
+        )
+
+        assert all(r.status_code == 200 for r in results)
+        assert refresh_count == 1
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -18,7 +18,9 @@ import json
 import os
 import ssl
 from unittest import mock
+
 import pytest
+
 from google.auth import exceptions
 from google.auth.aio import credentials
 from google.auth.aio import transport

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -347,10 +347,7 @@ class TestSessionsMtls:
             await session.close()
 
     @pytest.mark.asyncio
-    async def test_cert_rotation_failure_raises_error(self, caplog):
-        import logging
-
-        caplog.set_level(logging.ERROR, logger="google.auth.aio.transport.sessions")
+    async def test_cert_rotation_failure_raises_error(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
 
@@ -380,15 +377,11 @@ class TestSessionsMtls:
 
             mock_check.assert_called_once()
             mock_conf.assert_called_once()
-            assert "Failed to reconfigure mTLS channel" in caplog.text
 
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_cert_rotation_check_params_fails(self, caplog):
-        import logging
-
-        caplog.set_level(logging.WARNING, logger="google.auth.aio.transport.sessions")
+    async def test_cert_rotation_check_params_fails(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
 
@@ -416,7 +409,6 @@ class TestSessionsMtls:
             assert resp == mock_resp
             assert mock_check.call_count >= 1
             mock_conf.assert_not_called()
-            assert "Failed to check client certificate parameters" in caplog.text
 
         await session.close()
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -402,7 +402,9 @@ class TestSessionsMtls:
         ) as mock_check, mock.patch.object(
             session, "configure_mtls_channel", new_callable=mock.AsyncMock
         ) as mock_conf:
-            mock_check.side_effect = exceptions.MutualTLSChannelError("Failed to check params")
+            mock_check.side_effect = exceptions.MutualTLSChannelError(
+                "Failed to check params"
+            )
 
             resp = await session.request(
                 "GET", "https://pubsub.mtls.googleapis.com/test"

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -416,7 +416,7 @@ class TestSessionsMtls:
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_no_cert_rotation_when_cert_match_and_mTLS_enabled(self):
+    async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -531,7 +531,13 @@ class TestSessionsMtls:
 
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        
+        mock_auth_req = mock.AsyncMock(
+            side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
+        )
 
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
@@ -569,10 +575,12 @@ class TestSessionsMtls:
             ]
             responses = await asyncio.gather(*tasks)
 
-            for resp in responses:
-                assert resp == mock_resp_401
+        for resp in responses:
+            assert resp == mock_resp_200
 
-            mock_conf.assert_called_once()
+        mock_check.assert_called_once()
+        mock_conf.assert_called_once()
+        assert mock_creds.refresh.call_count == 1
 
         await session.close()
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -15,6 +15,7 @@
 import json
 import os
 import ssl
+import http.client as http_client
 from unittest import mock
 
 import pytest
@@ -346,89 +347,162 @@ class TestSessionsMtls:
             await session.close()
 
     @pytest.mark.asyncio
-    async def test_cert_rotation_failure_logs(self):
+    async def test_cert_rotation_failure_raises_error(self, caplog):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
-
-        mock_auth_req = mock.AsyncMock()
+        
         mock_resp = mock.Mock()
-        import http.client as http_client
-
         mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req.return_value = mock_resp
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
         new_cert = b"new_cert"
         new_key = b"new_key"
 
-        with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
+        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
+             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
             mock_conf.side_effect = Exception("Failed to reconfigure")
 
-            resp = await session.request("GET", "http://example.com")
-            assert resp == mock_resp
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
 
             mock_check.assert_called_once()
             mock_conf.assert_called_once()
+            assert "Failed to reconfigure mTLS channel" in caplog.text
+
+        await session.close()
+
 
     @pytest.mark.asyncio
-    async def test_cert_rotation_check_params_fails(self):
+    async def test_cert_rotation_check_params_fails(self, caplog):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_auth_req = mock.AsyncMock()
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        
         mock_resp = mock.Mock()
-        import http.client as http_client
-
         mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req.return_value = mock_resp
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
         session._is_mtls = True
-        session._cached_cert = b"cached_cert"
+        session._cached_cert = b"old_cert"
 
-        with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
-            side_effect=Exception("check_params failed"),
-        ) as mock_check_params:
-            resp = await session.request("GET", "http://example.com")
+        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
+             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+
+            mock_check.side_effect = Exception("Failed to check params")
+
+            resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+
             assert resp == mock_resp
-            mock_check_params.assert_called_once()
+            mock_check.assert_called_once()
+            mock_conf.assert_not_called()
+            assert "Failed to check client certificate parameters" in caplog.text
+
+        await session.close()
+
 
     @pytest.mark.asyncio
     async def test_no_cert_rotation_when_cert_match_and_mTLS_enabled(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_auth_req = mock.AsyncMock()
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        
         mock_resp = mock.Mock()
-        import http.client as http_client
-
         mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req.return_value = mock_resp
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            # same fingerprint, so no call to configure_mtls_channel
-            mock_check.return_value = (b"new_cert", b"new_key", b"same_fp", b"same_fp")
+        new_cert = b"new_cert"
+        new_key = b"new_key"
 
-            await session.request("GET", "http://example.com")
+        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
+             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
 
+            # Matching fingerprints mean no layout rotation is needed
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
+
+            resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+            
+            assert resp == mock_resp
             mock_check.assert_called_once()
             mock_conf.assert_not_called()
+
+        await session.close()
+
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_success_and_retry(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+        
+        # Initial request fails natively with 401. Retry succeeds with 200.
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        
+        # Use side_effect to dynamically yield responses
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+
+        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
+             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+             
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+            
+            resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+            
+            # 1. Assert the retried 200 response is successfully returned to the user
+            assert resp == mock_resp_200
+            
+            # 2. Assert rotation logic correctly executed
+            mock_check.assert_called_once()
+            mock_conf.assert_called_once_with(mock.ANY)
+            
+            # 3. Assert credentials were explicitly refreshed
+            mock_creds.refresh.assert_called_once()
+            
+            # 4. Assert headers were explicitly rebound on the recursive retry (2 invocations)
+            assert mock_creds.before_request.call_count == 2
+            
+        await session.close()
+
+
+    @pytest.mark.asyncio
+    async def test_non_mtls_url_bypasses_rotation(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        
+        # Even if mTLS is enabled globally...
+        session._is_mtls = True 
+        session._cached_cert = b"old_cert"
+        
+        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
+             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+        
+            # ...a 401 on a regular domain bypasses checks and just returns the 401 locally
+            resp = await session.request("GET", "https://pubsub.googleapis.com/test")
+            
+            assert resp == mock_resp_401
+            mock_check.assert_not_called()
+            mock_conf.assert_not_called()
+            
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -348,6 +348,8 @@ class TestSessionsMtls:
 
     @pytest.mark.asyncio
     async def test_cert_rotation_failure_raises_error(self, caplog):
+        import logging
+        caplog.set_level(logging.ERROR)
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         
@@ -399,7 +401,7 @@ class TestSessionsMtls:
             resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
 
             assert resp == mock_resp
-            mock_check.assert_called_once()
+            assert mock_check.call_count >= 1
             mock_conf.assert_not_called()
             assert "Failed to check client certificate parameters" in caplog.text
 
@@ -431,7 +433,7 @@ class TestSessionsMtls:
             resp = await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
             
             assert resp == mock_resp
-            mock_check.assert_called_once()
+            assert mock_check.call_count >= 1
             mock_conf.assert_not_called()
 
         await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -19,915 +19,992 @@ import os
 import ssl
 from unittest import mock
 
-import pytest
-
 from google.auth import exceptions
 from google.auth.aio import credentials
 from google.auth.aio import transport
 from google.auth.aio.transport import sessions
 from google.auth.exceptions import TimeoutError
+import pytest
 
 # This is the valid "workload" format the library expects
 VALID_WORKLOAD_CONFIG = {
     "version": 1,
     "cert_configs": {
-        "workload": {"cert_path": "/tmp/mock_cert.pem", "key_path": "/tmp/mock_key.pem"}
+        "workload": {
+            "cert_path": "/tmp/mock_cert.pem",
+            "key_path": "/tmp/mock_key.pem",
+        }
     },
 }
 
 
 class TestSessionsMtls:
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel(self):
-        """
-        Tests that the mTLS channel configures correctly when a
-        valid workload config is mocked.
-        """
-        with mock.patch.dict(
+
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel(self):
+    """Tests that the mTLS channel configures correctly when a valid workload config is mocked."""
+    with (
+        mock.patch.dict(
             os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG))
-        ), mock.patch(
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+        ),
+        mock.patch(
             "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper, mock.patch(
+        ) as mock_helper,
+        mock.patch(
             "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context, mock.patch(
-            "aiohttp.TCPConnector"
-        ) as mock_connector, mock.patch(
-            "aiohttp.ClientSession"
-        ) as mock_session:
-            mock_session.return_value.close = mock.AsyncMock()
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+        ) as mock_make_context,
+        mock.patch("aiohttp.TCPConnector") as mock_connector,
+        mock.patch("aiohttp.ClientSession") as mock_session,
+    ):
+      mock_session.return_value.close = mock.AsyncMock()
+      mock_exists.return_value = True
+      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
 
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
+      mock_context = mock.Mock(spec=ssl.SSLContext)
+      mock_make_context.return_value = mock_context
 
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-            await session.configure_mtls_channel()
+      await session.configure_mtls_channel()
 
-            assert session._is_mtls is True
-            mock_make_context.assert_called_once_with(
-                b"fake_cert_data", b"fake_key_data"
-            )
-            mock_connector.assert_called_once_with(ssl=mock_context)
-            mock_session.assert_called_once_with(connector=mock_connector.return_value)
-            await session.close()
+      assert session._is_mtls is True
+      mock_make_context.assert_called_once_with(
+          b"fake_cert_data", b"fake_key_data"
+      )
+      mock_connector.assert_called_once_with(ssl=mock_context)
+      mock_session.assert_called_once_with(
+          connector=mock_connector.return_value
+      )
+      await session.close()
 
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_disabled(self):
-        """
-        Tests behavior when the config file does not exist.
-        """
-        with mock.patch.dict(
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_disabled(self):
+    """Tests behavior when the config file does not exist."""
+    with (
+        mock.patch.dict(
             os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists:
-            mock_exists.return_value = False
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-            await session.configure_mtls_channel()
-            assert session._is_mtls is False
-            await session.close()
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+    ):
+      mock_exists.return_value = False
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
+      await session.configure_mtls_channel()
+      assert session._is_mtls is False
+      await session.close()
 
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_invalid_format(self):
-        """
-        Verifies that the MutualTLSChannelError is raised for bad formats.
-        """
-        with mock.patch.dict(
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_invalid_format(self):
+    """Verifies that the MutualTLSChannelError is raised for bad formats."""
+    with (
+        mock.patch.dict(
             os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
             "builtins.open", mock.mock_open(read_data='{"invalid": "format"}')
-        ):
-            mock_exists.return_value = True
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
+        ),
+    ):
+      mock_exists.return_value = True
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-            await session.close()
+      with pytest.raises(exceptions.MutualTLSChannelError):
+        await session.configure_mtls_channel()
+      await session.close()
 
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_invalud_fields(self):
-        """
-        If cert is missing expected keys, it should fail gracefully
-        """
-        with mock.patch.dict(
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_invalid_fields(self):
+    """If cert is missing expected keys, it should fail gracefully."""
+    with (
+        mock.patch.dict(
             os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
             "builtins.open", mock.mock_open(read_data='{"cert_configs": {}}')
-        ):
-            mock_exists.return_value = True
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-            await session.configure_mtls_channel()
-            assert session._is_mtls is False
-            await session.close()
+        ),
+    ):
+      mock_exists.return_value = True
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
+      await session.configure_mtls_channel()
+      assert session._is_mtls is False
+      await session.close()
 
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_mock_callback(self):
-        """
-        Tests mTLS configuration using bytes-returning callback.
-        """
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_mock_callback(self):
+    """Tests mTLS configuration using bytes-returning callback."""
 
-        def mock_callback():
-            return (b"fake_cert_bytes", b"fake_key_bytes")
+    def mock_callback():
+      return (b"fake_cert_bytes", b"fake_key_bytes")
 
-        with mock.patch.dict(
+    with (
+        mock.patch.dict(
             os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch(
+        ),
+        mock.patch(
             "google.auth.transport.mtls.has_default_client_cert_source",
             return_value=True,
-        ), mock.patch(
+        ),
+        mock.patch(
             "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context, mock.patch(
-            "aiohttp.TCPConnector"
-        ) as mock_connector, mock.patch(
-            "aiohttp.ClientSession"
-        ) as mock_session:
-            mock_session.return_value.close = mock.AsyncMock()
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            await session.configure_mtls_channel(client_cert_callback=mock_callback)
-
-            assert session._is_mtls is True
-            mock_make_context.assert_called_once_with(
-                b"fake_cert_bytes", b"fake_key_bytes"
-            )
-            mock_connector.assert_called_once_with(ssl=mock_context)
-            mock_session.assert_called_once_with(connector=mock_connector.return_value)
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_custom_request(self):
-        """Tests that if _auth_request is not an AiohttpRequest, _is_mtls is set to False
-        because we can't configure the custom request with mTLS.
-        """
-        with mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG))
-        ), mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper, mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context:
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            mock_auth_request = mock.AsyncMock(spec=transport.Request)
-            session = sessions.AsyncAuthorizedSession(
-                mock_creds, auth_request=mock_auth_request
-            )
-
-            with pytest.warns(UserWarning, match="Attempted to establish mTLS"):
-                await session.configure_mtls_channel()
-
-            # If the request handler is not an AiohttpRequest, the library cannot configure
-            # the connection to use mTLS, so _is_mtls must be False to reflect this unconfigured state.
-            assert session._is_mtls is False
-            mock_make_context.assert_not_called()
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_exception_resets_flag(self):
-        """
-        Tests that self._is_mtls is reset to False if an exception is raised
-        during configuration.
-        """
-        with mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG))
-        ), mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper, mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context:
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-            mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-
-            assert session._is_mtls is False
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_transport_error_resets_flag(self):
-        """
-        Tests that self._is_mtls is reset to False if a TransportError is raised
-        during configuration.
-        """
-        with mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG))
-        ), mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper, mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context:
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-            mock_make_context.side_effect = exceptions.TransportError("Mock error")
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-
-            assert session._is_mtls is False
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_atomic_on_exception(self):
-        """
-        Tests that if configure_mtls_channel has already successfully configured mTLS,
-        a subsequent attempt that raises an exception will preserve the original mTLS state.
-        """
-        # Step 1: Successful configuration
-        with mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG))
-        ), mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper, mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context, mock.patch(
-            "aiohttp.TCPConnector"
-        ), mock.patch(
-            "aiohttp.ClientSession"
-        ) as mock_session:
-            mock_session.return_value.close = mock.AsyncMock()
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data_1", b"fake_key_data_1")
-
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            await session.configure_mtls_channel()
-            assert session._is_mtls is True
-            assert session._cached_cert == b"fake_cert_data_1"
-            first_auth_request = session._auth_request
-
-            # Step 2: Failed subsequent configuration attempt
-            # Reset task so we trigger a new configuration run
-            session._mtls_init_task = None
-
-            # Patch context generator to fail this time
-            mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
-
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-
-            # Verify that the state remains unchanged from the first successful configuration
-            assert session._is_mtls is True
-            assert session._cached_cert == b"fake_cert_data_1"
-            assert session._auth_request is first_auth_request
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_close_exception_does_not_abort(self):
-        """
-        Tests that if old_auth_request.close() raises an exception, the mTLS
-        configuration is still considered successful, and is_mtls remains True
-        without raising MutualTLSChannelError.
-        """
-        with mock.patch.dict(
-            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
-        ), mock.patch("os.path.exists") as mock_exists, mock.patch(
-            "builtins.open", mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG))
-        ), mock.patch(
-            "google.auth.aio.transport.mtls.get_client_cert_and_key"
-        ) as mock_helper, mock.patch(
-            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-        ) as mock_make_context, mock.patch(
-            "aiohttp.TCPConnector"
-        ), mock.patch(
-            "aiohttp.ClientSession"
-        ) as mock_session:
-            mock_session.return_value.close = mock.AsyncMock()
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            # Mock close() of the initial self._auth_request to raise an exception
-            session._auth_request.close = mock.AsyncMock(
-                side_effect=Exception("Mock close error")
-            )
-
-            # Should complete successfully without raising MutualTLSChannelError
-            await session.configure_mtls_channel()
-
-            assert session._is_mtls is True
-            assert session._cached_cert == b"fake_cert_data"
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_failure_raises_error(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        new_cert = b"new_cert"
-        new_key = b"new_key"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
-            mock_conf.side_effect = Exception("Failed to reconfigure")
-
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-
-            mock_check.assert_called_once()
-            mock_conf.assert_called_once()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_check_params_fails(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock()
-
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            mock_check.side_effect = exceptions.MutualTLSChannelError(
-                "Failed to check params"
-            )
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
-
-            assert resp == mock_resp
-            mock_check.assert_called_once()
-            mock_creds.refresh.assert_not_called()
-            mock_conf.assert_not_called()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_401.close = mock.AsyncMock()
-
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
-
-        # 401 on initial request, 200 on retry after refresh
-        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        new_cert = b"new_cert"
-        new_key = b"new_key"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            # Matching fingerprints mean no mTLS rotation is needed
-            mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
-
-            assert resp == mock_resp_200
-            mock_check.assert_called_once()
-            mock_conf.assert_not_called()
-            mock_creds.refresh.assert_called_once()
-            assert mock_auth_req.call_count == 2
-            mock_resp_401.close.assert_awaited_once()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_success_and_retry(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        # Initial request fails natively with 401. Retry succeeds with 200.
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
-
-        # Use side_effect to dynamically yield responses
-        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        new_cert = b"new_cert"
-        new_key = b"new_key"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
-
-            # 1. Assert the retried 200 response is successfully returned to the user
-            assert resp == mock_resp_200
-
-            # 2. Assert rotation logic correctly executed
-            mock_check.assert_called_once()
-            mock_conf.assert_called_once_with(mock.ANY)
-
-            # 3. Assert credentials were explicitly refreshed
-            mock_creds.refresh.assert_called_once()
-
-            # 4. Assert headers were explicitly rebound on the recursive retry (2 invocations)
-            assert mock_creds.before_request.call_count == 2
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_lock_contention(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        new_cert = b"new_cert"
-        new_key = b"new_key"
-
-        async def mock_configure_mtls_channel(*args, **kwargs):
-            await asyncio.sleep(0.01)
-            session._cached_cert = new_cert
-
-        async def mock_check_side_effect(callback, cached_cert):
-            if cached_cert == b"old_cert":
-                return (new_cert, new_key, b"old_fp", b"new_fp")
-            return (new_cert, new_key, b"new_fp", b"new_fp")
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            mock_check.side_effect = mock_check_side_effect
-            mock_conf.side_effect = mock_configure_mtls_channel
-
-            tasks = [
-                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-                for _ in range(3)
-            ]
-            responses = await asyncio.gather(*tasks)
-
-            for resp in responses:
-                assert resp == mock_resp_401
-
-            mock_conf.assert_called_once()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_lock_contention_no_cert_change(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
-
-        mock_auth_req = mock.AsyncMock(
-            side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
-        )
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        # FIX: async def + await asyncio.sleep to allow concurrent lock contention
-        async def mock_check_side_effect(callback, cached_cert):
-            await asyncio.sleep(0.01)
-            return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            mock_check.side_effect = mock_check_side_effect
-
-            tasks = [
-                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-                for _ in range(3)
-            ]
-            responses = await asyncio.gather(*tasks)
-
-            for resp in responses:
-                assert resp == mock_resp_200
-
-            mock_check.assert_called_once()
-            mock_conf.assert_not_called()
-            assert mock_creds.refresh.call_count == 3
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_non_mtls_url_bypasses_rotation(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-
-        # Even if mTLS is enabled globally...
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            # Will attempt to refresh credentials and retry the request up to 2 times (3 requests total).
-            resp = await session.request("GET", "https://pubsub.googleapis.com/test")
-
-            assert resp == mock_resp_401
-            mock_check.assert_not_called()
-            mock_conf.assert_not_called()
-
-            # Verify the standard retry behavior executed
-            assert mock_creds.refresh.call_count == 2
-            assert mock_auth_req.call_count == 3
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_skips_retry_for_streaming(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock()
-
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        # Simulate a streaming object (hasattr(data, 'read'))
-        class MockStream:
-            def read(self):
-                pass
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ) as mock_conf:
-            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test", data=MockStream()
-            )
-
-            assert resp == mock_resp
-            mock_conf.assert_called_once()
-            # Because it is streaming, it skips credentials refresh and retry
-        mock_creds.refresh.assert_called_once()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_credential_refresh_fails(self):
-        """Covers the except block for RefreshError when credentials fail to refresh."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        # Simulate a credentials refresh failure
-        mock_creds.refresh = mock.AsyncMock(
-            side_effect=exceptions.RefreshError("Refresh failed")
-        )
-
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ):
-            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
-
-            # It should catch the RefreshError and return the 401 response directly
-            assert resp == mock_resp
-            mock_creds.refresh.assert_called_once()
-            # Ensure it didn't retry the request by checking auth_request was only called once
-            mock_auth_req.assert_called_once()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_max_retries_exceeded(self):
-        """Covers the `if _auth_retry_count < 2:` max retry limit."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_resp.close = mock.AsyncMock()
-        # Always return 401
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        with mock.patch(
-            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-            new_callable=mock.AsyncMock,
-        ) as mock_check, mock.patch.object(
-            session, "configure_mtls_channel", new_callable=mock.AsyncMock
-        ):
-            # Yield new fingerprints to trigger reconfiguration branches
-            mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
-
-            assert resp == mock_resp
-            # Expecting exactly 3 requests (Initial try, Retry 1, Retry 2).
-            # When _auth_retry_count reaches 2, it drops out of the retry condition.
-            assert mock_auth_req.call_count == 3
-            # It should have checked the cert twice before hitting the retry cap
-            assert mock_check.call_count == 2
-            # Verify the stale response is closed before the retry
-            assert mock_resp.close.call_count == 2
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_session_close_cleans_old_auth_requests(self):
-        """Covers the loop in the `close()` method that drains `_old_auth_requests`."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock.AsyncMock()
-        )
-
-        # Manually inject mocked old requests simulating past channel reconfigurations
-        mock_old_req_1 = mock.AsyncMock()
-        mock_old_req_2 = mock.AsyncMock()
-        mock_old_req_3_fails = mock.AsyncMock()
-        mock_old_req_3_fails.close.side_effect = Exception("Close error")
-
-        session._old_auth_requests.extend(
-            [mock_old_req_1, mock_old_req_2, mock_old_req_3_fails]
-        )
-
-        # Triggers `await old_request.close()` for each item
-        await session.close()
-
-        # Ensure all were called
-        mock_old_req_1.close.assert_called_once()
-        mock_old_req_2.close.assert_called_once()
-        mock_old_req_3_fails.close.assert_called_once()
-        # Ensure the list was cleared
-        assert len(session._old_auth_requests) == 0
-
-    @pytest.mark.asyncio
-    async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
-        self,
+        ) as mock_make_context,
+        mock.patch("aiohttp.TCPConnector") as mock_connector,
+        mock.patch("aiohttp.ClientSession") as mock_session,
     ):
-        """Verifies that streaming requests refresh credentials but return the unclosed response."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
+      mock_session.return_value.close = mock.AsyncMock()
+      mock_context = mock.Mock(spec=ssl.SSLContext)
+      mock_make_context.return_value = mock_context
 
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_401.close = mock.AsyncMock()
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+      await session.configure_mtls_channel(client_cert_callback=mock_callback)
 
-        streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
-        response = await session.request(
-            "POST", "https://example.com", data=streaming_data
-        )
+      assert session._is_mtls is True
+      mock_make_context.assert_called_once_with(
+          b"fake_cert_bytes", b"fake_key_bytes"
+      )
+      mock_connector.assert_called_once_with(ssl=mock_context)
+      mock_session.assert_called_once_with(
+          connector=mock_connector.return_value
+      )
+      await session.close()
 
-        assert response == mock_resp_401
-        mock_creds.refresh.assert_awaited_once()
-        mock_resp_401.close.assert_not_called()
-        await session.close()
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_custom_request(self):
+    """Tests that if _auth_request is not an AiohttpRequest, _is_mtls is set to False."""
+    with (
+        mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+        ),
+        mock.patch(
+            "google.auth.aio.transport.mtls.get_client_cert_and_key"
+        ) as mock_helper,
+        mock.patch(
+            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+        ) as mock_make_context,
+    ):
+      mock_exists.return_value = True
+      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
 
-    @pytest.mark.asyncio
-    async def test_request_401_closes_response_on_timeout_during_recovery(self):
-        """Verifies that response is closed when auth_with_timeout times out during _recover_auth_state."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
+      mock_context = mock.Mock(spec=ssl.SSLContext)
+      mock_make_context.return_value = mock_context
 
-        async def slow_refresh(*args, **kwargs):
-            await asyncio.sleep(10)
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      mock_auth_request = mock.AsyncMock(spec=transport.Request)
+      session = sessions.AsyncAuthorizedSession(
+          mock_creds, auth_request=mock_auth_request
+      )
 
-        mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
+      with pytest.warns(UserWarning, match="Attempted to establish mTLS"):
+        await session.configure_mtls_channel()
 
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_401.close = mock.AsyncMock()
+      assert session._is_mtls is False
+      mock_make_context.assert_not_called()
+      await session.close()
 
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_exception_resets_flag(self):
+    """Tests that self._is_mtls is reset to False if an exception is raised during configuration."""
+    with (
+        mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+        ),
+        mock.patch(
+            "google.auth.aio.transport.mtls.get_client_cert_and_key"
+        ) as mock_helper,
+        mock.patch(
+            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+        ) as mock_make_context,
+    ):
+      mock_exists.return_value = True
+      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+      mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
 
-        with pytest.raises(TimeoutError):
-            await session.request("GET", "https://example.com", max_allowed_time=0.01)
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-        mock_resp_401.close.assert_awaited_once()
-        await session.close()
+      with pytest.raises(exceptions.MutualTLSChannelError):
+        await session.configure_mtls_channel()
 
-    @pytest.mark.asyncio
-    async def test_request_401_closes_response_on_cancellation(self):
-        """Verifies that response is closed and CancelledError propagated if task is cancelled during recovery."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
+      assert session._is_mtls is False
+      await session.close()
 
-        refresh_started = asyncio.Event()
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_transport_error_resets_flag(self):
+    """Tests that self._is_mtls is reset to False if a TransportError is raised."""
+    with (
+        mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+        ),
+        mock.patch(
+            "google.auth.aio.transport.mtls.get_client_cert_and_key"
+        ) as mock_helper,
+        mock.patch(
+            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+        ) as mock_make_context,
+    ):
+      mock_exists.return_value = True
+      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+      mock_make_context.side_effect = exceptions.TransportError("Mock error")
 
-        async def cancel_on_refresh(*args, **kwargs):
-            refresh_started.set()
-            await asyncio.sleep(10)
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-        mock_creds.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
+      with pytest.raises(exceptions.MutualTLSChannelError):
+        await session.configure_mtls_channel()
 
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_401.close = mock.AsyncMock()
+      assert session._is_mtls is False
+      await session.close()
 
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_atomic_on_exception(self):
+    """Tests that if configure_mtls_channel already succeeded, a subsequent failure preserves state."""
+    # Step 1: Successful configuration
+    with (
+        mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+        ),
+        mock.patch(
+            "google.auth.aio.transport.mtls.get_client_cert_and_key"
+        ) as mock_helper,
+        mock.patch(
+            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+        ) as mock_make_context,
+        mock.patch("aiohttp.TCPConnector"),
+        mock.patch("aiohttp.ClientSession") as mock_session,
+    ):
+      mock_session.return_value.close = mock.AsyncMock()
+      mock_exists.return_value = True
+      mock_helper.return_value = (
+          True,
+          b"fake_cert_data_1",
+          b"fake_key_data_1",
+      )
 
-        task = asyncio.create_task(session.request("GET", "https://example.com"))
-        await refresh_started.wait()
-        task.cancel()
+      mock_context = mock.Mock(spec=ssl.SSLContext)
+      mock_make_context.return_value = mock_context
 
-        with pytest.raises(asyncio.CancelledError):
-            await task
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-        mock_resp_401.close.assert_awaited_once()
-        await session.close()
+      await session.configure_mtls_channel()
+      assert session._is_mtls is True
+      assert session._cached_cert == b"fake_cert_data_1"
+      first_auth_request = session._auth_request
 
-    @pytest.mark.asyncio
-    async def test_request_401_concurrent_refreshes_are_deduplicated(self):
-        """Verifies that concurrent 401s execute only one credentials.refresh call."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
+      # Step 2: Failed subsequent configuration attempt
+      session._mtls_init_task = None
+      mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
 
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_401.close = mock.AsyncMock()
+      with pytest.raises(exceptions.MutualTLSChannelError):
+        await session.configure_mtls_channel()
 
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
-        mock_resp_200.close = mock.AsyncMock()
+      assert session._is_mtls is True
+      assert session._cached_cert == b"fake_cert_data_1"
+      assert session._auth_request is first_auth_request
+      await session.close()
 
-        # Both concurrent requests get 401 initially, then 200 on retry
-        mock_auth_req = mock.AsyncMock(
-            side_effect=[mock_resp_401, mock_resp_401, mock_resp_200, mock_resp_200]
-        )
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
+  @pytest.mark.asyncio
+  async def test_configure_mtls_channel_close_exception_does_not_abort(self):
+    """Tests that an exception in old_auth_request.close() does not abort configuration."""
+    with (
+        mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}
+        ),
+        mock.patch("os.path.exists") as mock_exists,
+        mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
+        ),
+        mock.patch(
+            "google.auth.aio.transport.mtls.get_client_cert_and_key"
+        ) as mock_helper,
+        mock.patch(
+            "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
+        ) as mock_make_context,
+        mock.patch("aiohttp.TCPConnector"),
+        mock.patch("aiohttp.ClientSession") as mock_session,
+    ):
+      mock_session.return_value.close = mock.AsyncMock()
+      mock_exists.return_value = True
+      mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
 
-        refresh_count = 0
+      mock_context = mock.Mock(spec=ssl.SSLContext)
+      mock_make_context.return_value = mock_context
 
-        async def slow_refresh(*args, **kwargs):
-            nonlocal refresh_count
-            refresh_count += 1
-            await asyncio.sleep(0.05)
+      mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+      session = sessions.AsyncAuthorizedSession(mock_creds)
 
-        mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
+      session._auth_request.close = mock.AsyncMock(
+          side_effect=Exception("Mock close error")
+      )
 
-        results = await asyncio.gather(
-            session.request("GET", "https://example.com/1"),
-            session.request("GET", "https://example.com/2"),
-        )
+      await session.configure_mtls_channel()
 
-        assert all(r.status_code == 200 for r in results)
-        assert refresh_count == 1
-        await session.close()
+      assert session._is_mtls is True
+      assert session._cached_cert == b"fake_cert_data"
+      await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_failure_raises_error(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = http_client.UNAUTHORIZED
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    new_cert = b"new_cert"
+    new_key = b"new_key"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+      mock_conf.side_effect = Exception("Failed to reconfigure")
+
+      with pytest.raises(exceptions.MutualTLSChannelError):
+        await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+
+      mock_check.assert_called_once()
+      mock_conf.assert_called_once()
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_check_params_fails(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock()
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = http_client.UNAUTHORIZED
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.side_effect = exceptions.MutualTLSChannelError(
+          "Failed to check params"
+      )
+
+      resp = await session.request(
+          "GET", "https://pubsub.mtls.googleapis.com/test"
+      )
+
+      assert resp == mock_resp
+      mock_check.assert_called_once()
+      mock_creds.refresh.assert_not_called()
+      mock_conf.assert_not_called()
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_401.close = mock.AsyncMock()
+
+    mock_resp_200 = mock.Mock()
+    mock_resp_200.status_code = http_client.OK
+
+    # 401 on initial request, 200 on retry after refresh
+    mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    new_cert = b"new_cert"
+    new_key = b"new_key"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      # Matching fingerprints mean no mTLS rotation is needed
+      mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
+
+      resp = await session.request(
+          "GET", "https://pubsub.mtls.googleapis.com/test"
+      )
+
+      assert resp == mock_resp_200
+      mock_check.assert_called_once()
+      mock_conf.assert_not_called()
+      mock_creds.refresh.assert_called_once()
+      assert mock_auth_req.call_count == 2
+      mock_resp_401.close.assert_awaited_once()
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_success_and_retry(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_200 = mock.Mock()
+    mock_resp_200.status_code = http_client.OK
+
+    mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    new_cert = b"new_cert"
+    new_key = b"new_key"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+
+      resp = await session.request(
+          "GET", "https://pubsub.mtls.googleapis.com/test"
+      )
+
+      assert resp == mock_resp_200
+      mock_check.assert_called_once()
+      mock_conf.assert_called_once_with(mock.ANY)
+      mock_creds.refresh.assert_called_once()
+      assert mock_creds.before_request.call_count == 2
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_lock_contention(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    new_cert = b"new_cert"
+    new_key = b"new_key"
+
+    async def mock_configure_mtls_channel(*args, **kwargs):
+      await asyncio.sleep(0.01)
+      session._cached_cert = new_cert
+
+    async def mock_check_side_effect(cached_cert, callback=None):
+      if cached_cert == b"old_cert":
+        return (new_cert, new_key, b"old_fp", b"new_fp")
+      return (new_cert, new_key, b"new_fp", b"new_fp")
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.side_effect = mock_check_side_effect
+      mock_conf.side_effect = mock_configure_mtls_channel
+
+      tasks = [
+          session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+          for _ in range(3)
+      ]
+      responses = await asyncio.gather(*tasks)
+
+      for resp in responses:
+        assert resp == mock_resp_401
+
+      mock_conf.assert_called_once()
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_lock_contention_no_cert_change(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_200 = mock.Mock()
+    mock_resp_200.status_code = http_client.OK
+
+    mock_auth_req = mock.AsyncMock(
+        side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
+    )
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    async def mock_check_side_effect(cached_cert, callback=None):
+      await asyncio.sleep(0.01)
+      return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.side_effect = mock_check_side_effect
+
+      tasks = [
+          session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+          for _ in range(3)
+      ]
+      responses = await asyncio.gather(*tasks)
+
+      for resp in responses:
+        assert resp == mock_resp_200
+
+      mock_check.assert_called_once()
+      mock_conf.assert_not_called()
+      # Concurrent 401s properly deduplicate to 1 refresh
+      assert mock_creds.refresh.call_count == 1
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_psc_endpoint_triggers_cert_rotation(self):
+    """Verifies that PSC endpoints (*.p.googleapis.com) are recognized as mTLS endpoints."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_200 = mock.Mock()
+    mock_resp_200.status_code = http_client.OK
+
+    mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    new_cert = b"new_cert"
+    new_key = b"new_key"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+
+      resp = await session.request(
+          "GET", "https://pubsub.p.googleapis.com/test"
+      )
+
+      assert resp == mock_resp_200
+      mock_check.assert_called_once()
+      mock_conf.assert_called_once_with(mock.ANY)
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_non_mtls_url_bypasses_rotation(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      resp = await session.request("GET", "https://example.com/test")
+
+      assert resp == mock_resp_401
+      mock_check.assert_not_called()
+      mock_conf.assert_not_called()
+      assert mock_creds.refresh.call_count == 2
+      assert mock_auth_req.call_count == 3
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_skips_retry_for_streaming(self):
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock()
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = http_client.UNAUTHORIZED
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    class MockStream:
+
+      def read(self):
+        pass
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf,
+    ):
+      mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+      resp = await session.request(
+          "GET", "https://pubsub.mtls.googleapis.com/test", data=MockStream()
+      )
+
+      assert resp == mock_resp
+      mock_conf.assert_called_once()
+
+    mock_creds.refresh.assert_called_once()
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_credential_refresh_fails(self):
+    """Covers the except block for RefreshError when credentials fail to refresh."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(
+        side_effect=exceptions.RefreshError("Refresh failed")
+    )
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = http_client.UNAUTHORIZED
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ),
+    ):
+      mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+      resp = await session.request(
+          "GET", "https://pubsub.mtls.googleapis.com/test"
+      )
+
+      assert resp == mock_resp
+      mock_creds.refresh.assert_called_once()
+      mock_auth_req.assert_called_once()
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_cert_rotation_max_retries_exceeded(self):
+    """Covers the `if _auth_retry_count < 2:` max retry limit."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = http_client.UNAUTHORIZED
+    mock_resp.close = mock.AsyncMock()
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+    session._is_mtls = True
+    session._cached_cert = b"old_cert"
+
+    with (
+        mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check,
+        mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ),
+    ):
+      mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
+
+      resp = await session.request(
+          "GET", "https://pubsub.mtls.googleapis.com/test"
+      )
+
+      assert resp == mock_resp
+      assert mock_auth_req.call_count == 3
+      assert mock_check.call_count == 2
+      assert mock_resp.close.call_count == 2
+
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_session_close_cleans_old_auth_requests(self):
+    """Covers the loop in the `close()` method that drains `_old_auth_requests`."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock.AsyncMock()
+    )
+
+    mock_old_req_1 = mock.AsyncMock()
+    mock_old_req_2 = mock.AsyncMock()
+    mock_old_req_3_fails = mock.AsyncMock()
+    mock_old_req_3_fails.close.side_effect = Exception("Close error")
+
+    session._old_auth_requests.extend(
+        [mock_old_req_1, mock_old_req_2, mock_old_req_3_fails]
+    )
+
+    await session.close()
+
+    mock_old_req_1.close.assert_called_once()
+    mock_old_req_2.close.assert_called_once()
+    mock_old_req_3_fails.close.assert_called_once()
+    assert len(session._old_auth_requests) == 0
+
+  @pytest.mark.asyncio
+  async def test_request_401_streaming_refreshes_creds_and_returns_open_response(
+      self,
+  ):
+    """Verifies that streaming requests refresh credentials but return the unclosed response."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+    mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_401.close = mock.AsyncMock()
+
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+
+    streaming_data = (chunk for chunk in [b"chunk1", b"chunk2"])
+    response = await session.request(
+        "POST", "https://example.com", data=streaming_data
+    )
+
+    assert response == mock_resp_401
+    mock_creds.refresh.assert_awaited_once()
+    mock_resp_401.close.assert_not_called()
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_request_401_closes_response_on_timeout_during_recovery(self):
+    """Verifies that response is closed when auth_with_timeout times out during _recover_auth_state."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+    async def slow_refresh(*args, **kwargs):
+      await asyncio.sleep(10)
+
+    mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_401.close = mock.AsyncMock()
+
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+
+    with pytest.raises(TimeoutError):
+      await session.request("GET", "https://example.com", max_allowed_time=0.01)
+
+    mock_resp_401.close.assert_awaited_once()
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_request_401_closes_response_on_cancellation(self):
+    """Verifies that response is closed and CancelledError propagated if task is cancelled."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+    refresh_started = asyncio.Event()
+
+    async def cancel_on_refresh(*args, **kwargs):
+      refresh_started.set()
+      await asyncio.sleep(10)
+
+    mock_creds.refresh = mock.AsyncMock(side_effect=cancel_on_refresh)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_401.close = mock.AsyncMock()
+
+    mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+
+    task = asyncio.create_task(session.request("GET", "https://example.com"))
+    await refresh_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+      await task
+
+    mock_resp_401.close.assert_awaited_once()
+    await session.close()
+
+  @pytest.mark.asyncio
+  async def test_request_401_concurrent_refreshes_are_deduplicated(self):
+    """Verifies that concurrent 401s execute only one credentials.refresh call."""
+    mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+    mock_creds.before_request = mock.AsyncMock(return_value=None)
+
+    mock_resp_401 = mock.Mock()
+    mock_resp_401.status_code = http_client.UNAUTHORIZED
+    mock_resp_401.close = mock.AsyncMock()
+
+    mock_resp_200 = mock.Mock()
+    mock_resp_200.status_code = http_client.OK
+    mock_resp_200.close = mock.AsyncMock()
+
+    mock_auth_req = mock.AsyncMock(
+        side_effect=[
+            mock_resp_401,
+            mock_resp_401,
+            mock_resp_200,
+            mock_resp_200,
+        ]
+    )
+    session = sessions.AsyncAuthorizedSession(
+        mock_creds, auth_request=mock_auth_req
+    )
+
+    refresh_count = 0
+
+    async def slow_refresh(*args, **kwargs):
+      nonlocal refresh_count
+      refresh_count += 1
+      await asyncio.sleep(0.05)
+
+    mock_creds.refresh = mock.AsyncMock(side_effect=slow_refresh)
+
+    results = await asyncio.gather(
+        session.request("GET", "https://example.com/1"),
+        session.request("GET", "https://example.com/2"),
+    )
+
+    assert all(r.status_code == 200 for r in results)
+    assert refresh_count == 1
+    await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -531,10 +531,10 @@ class TestSessionsMtls:
 
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
-        
+
         mock_resp_200 = mock.Mock()
         mock_resp_200.status_code = http_client.OK
-        
+
         mock_auth_req = mock.AsyncMock(
             side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
         )

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -353,19 +353,24 @@ class TestSessionsMtls:
         mock_auth_req = mock.AsyncMock()
         mock_resp = mock.Mock()
         import http.client as http_client
+
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_auth_req.return_value = mock_resp
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
         new_cert = b"new_cert"
         new_key = b"new_key"
 
-        with mock.patch("google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response") as mock_check, \
-             mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
-
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response"
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
             mock_conf.side_effect = Exception("Failed to reconfigure")
 
@@ -381,10 +386,13 @@ class TestSessionsMtls:
         mock_auth_req = mock.AsyncMock()
         mock_resp = mock.Mock()
         import http.client as http_client
+
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_auth_req.return_value = mock_resp
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"cached_cert"
 
@@ -402,16 +410,21 @@ class TestSessionsMtls:
         mock_auth_req = mock.AsyncMock()
         mock_resp = mock.Mock()
         import http.client as http_client
+
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_auth_req.return_value = mock_resp
 
-        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=mock_auth_req)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
         with mock.patch(
             "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
-        ) as mock_check, mock.patch.object(session, "configure_mtls_channel", new_callable=mock.AsyncMock) as mock_conf:
+        ) as mock_check, mock.patch.object(
+            session, "configure_mtls_channel", new_callable=mock.AsyncMock
+        ) as mock_conf:
             # same fingerprint, so no call to configure_mtls_channel
             mock_check.return_value = (b"new_cert", b"new_key", b"same_fp", b"same_fp")
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -392,9 +392,8 @@ class TestSessionsMtls:
             "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
             side_effect=Exception("check_params failed"),
         ) as mock_check_params:
-            with pytest.raises(Exception, match="check_params failed"):
-                await session.request("GET", "http://example.com")
-
+            resp = await session.request("GET", "http://example.com")
+            assert resp == mock_resp
             mock_check_params.assert_called_once()
 
     @pytest.mark.asyncio

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -132,87 +132,8 @@ class TestSessionsMtls:
             await session.close()
 
     @pytest.mark.asyncio
-    async def test_configure_mtls_channel_mock_callback(self):
-        """Tests that passing a direct callback configures mTLS without metadata config file."""
-
-        def custom_callback():
-            return b"custom_cert", b"custom_key"
-
-        with (
-            mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key",
-                return_value=(True, b"custom_cert", b"custom_key"),
-            ),
-            mock.patch(
-                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-            ) as mock_make_context,
-            mock.patch("aiohttp.TCPConnector") as mock_connector,
-            mock.patch("aiohttp.ClientSession") as mock_session,
-        ):
-            mock_session.return_value.close = mock.AsyncMock()
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-            await session.configure_mtls_channel(client_cert_callback=custom_callback)
-            assert session._is_mtls is True
-            assert session._cached_cert == b"custom_cert"
-            mock_make_context.assert_called_once_with(b"custom_cert", b"custom_key")
-            mock_connector.assert_called_once_with(ssl=mock_context)
-            mock_session.assert_called_once_with(connector=mock_connector.return_value)
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_custom_request(self):
-        """Tests that a custom auth_request is properly initialized with mTLS."""
-        mock_custom_request = mock.AsyncMock(spec=transport.Request)
-        mock_custom_request.configure_mtls_channel = mock.AsyncMock()
-        mock_custom_request.close = mock.AsyncMock()
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_custom_request
-        )
-
-        def custom_callback():
-            return b"custom_cert", b"custom_key"
-
-        await session.configure_mtls_channel(client_cert_callback=custom_callback)
-        assert session._is_mtls is True
-        mock_custom_request.configure_mtls_channel.assert_called_once_with(
-            custom_callback
-        )
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_transport_error_resets_flag(self):
-        """Tests that if custom auth_request raises an error, _is_mtls stays False."""
-        mock_custom_request = mock.AsyncMock(spec=transport.Request)
-        mock_custom_request.configure_mtls_channel = mock.AsyncMock(
-            side_effect=exceptions.TransportError("Boom!")
-        )
-        mock_custom_request.close = mock.AsyncMock()
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_custom_request
-        )
-
-        def custom_callback():
-            return b"custom_cert", b"custom_key"
-
-        with pytest.raises(exceptions.TransportError):
-            await session.configure_mtls_channel(client_cert_callback=custom_callback)
-        assert session._is_mtls is False
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_atomic_on_exception(self):
-        """Tests that an exception during channel creation leaves the previous auth_request intact."""
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_original_auth_request = mock.AsyncMock(spec=transport.Request)
-        mock_original_auth_request.close = mock.AsyncMock()
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_original_auth_request
-        )
+    async def test_configure_mtls_channel_close_exception_does_not_abort(self):
+        """Tests that an exception in old_auth_request.close() during eviction does not abort configuration."""
         with (
             mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
             mock.patch("os.path.exists", return_value=True),
@@ -226,48 +147,25 @@ class TestSessionsMtls:
             ),
             mock.patch(
                 "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
-                side_effect=Exception("Failed to make SSL context"),
+                return_value=mock.Mock(spec=ssl.SSLContext),
             ),
-        ):
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-            assert session._is_mtls is False
-            assert session._auth_request is mock_original_auth_request
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_close_exception_does_not_abort(self):
-        """Tests that an exception in old_auth_request.close() during eviction does not abort configuration."""
-        with (
-            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch("os.path.exists") as mock_exists,
-            mock.patch(
-                "builtins.open",
-                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-            ),
-            mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key",
-                return_value=(True, b"fake_cert_data", b"fake_key_data"),
-            ),
-            mock.patch(
-                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-            ) as mock_make_context,
             mock.patch("aiohttp.TCPConnector"),
             mock.patch("aiohttp.ClientSession") as mock_session,
         ):
             mock_session.return_value.close = mock.AsyncMock()
-            mock_exists.return_value = True
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
+
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
-            # Pre-populate _old_auth_requests with failing transports to trigger and test eviction (maxlen >= 2)
-            failing_req_1 = mock.AsyncMock(spec=transport.Request)
-            failing_req_1.close.side_effect = Exception("Close error 1")
-            failing_req_2 = mock.AsyncMock(spec=transport.Request)
-            failing_req_2.close.side_effect = Exception("Close error 2")
+
+            # Pre-populate _old_auth_requests with failing transports to test eviction (maxlen >= 2)
+            failing_req_1 = mock.AsyncMock()
+            failing_req_1.close.side_effect = Exception("Close failure 1")
+            failing_req_2 = mock.AsyncMock()
+            failing_req_2.close.side_effect = Exception("Close failure 2")
             session._old_auth_requests.extend([failing_req_1, failing_req_2])
+
             await session.configure_mtls_channel()
+
             assert session._is_mtls is True
             assert session._cached_cert == b"fake_cert_data"
             await session.close()
@@ -317,46 +215,57 @@ class TestSessionsMtls:
 
     @pytest.mark.asyncio
     async def test_cert_rotation_check_params_fails(self):
-        """Verifies that a failure during parameter checking falls back to the original response."""
+        """Verifies that a failure during parameter checking falls back to credential refresh and retries."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
-        mock_auth_req = mock.AsyncMock()
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_resp.close = mock.AsyncMock()
-        mock_auth_req.return_value = mock_resp
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
         )
         session._is_mtls = True
         session._cached_cert = b"cached_cert"
+
         with mock.patch(
             "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
             new_callable=mock.AsyncMock,
             side_effect=exceptions.ClientCertError("check_params failed"),
         ) as mock_check_params:
-            # Use mTLS URL so is_mtls_endpoint evaluates to True
             resp = await session.request(
                 "GET", "https://pubsub.mtls.googleapis.com/test"
             )
-            assert resp == mock_resp
+            assert resp == mock_resp_200
             mock_check_params.assert_called_once()
             mock_creds.refresh.assert_called_once()
+
         await session.close()
 
     @pytest.mark.asyncio
     async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
-        """Verifies that if the fingerprint has not changed, reconfiguration is skipped."""
+        """Verifies that if the fingerprint has not changed, reconfiguration is skipped and retry succeeds."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
 
-        mock_auth_req = mock.AsyncMock()
-        mock_resp = mock.Mock()
-        mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_resp.close = mock.AsyncMock()
-        mock_auth_req.return_value = mock_resp
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
 
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
@@ -384,7 +293,7 @@ class TestSessionsMtls:
                 "GET", "https://pubsub.mtls.googleapis.com/test"
             )
 
-            assert resp == mock_resp
+            assert resp == mock_resp_200
             mock_check.assert_called_once()
             mock_conf.assert_not_called()
             mock_creds.refresh.assert_called_once()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1096,17 +1096,17 @@ class TestSessionsMtls:
         session = sessions.AsyncAuthorizedSession(mock_creds)
         init_started = asyncio.Event()
         init_can_finish = asyncio.Event()
+
         async def slow_mtls_init():
             init_started.set()
             await init_can_finish.wait()
             session._is_mtls = True
+
         # Simulate an in-progress mTLS initialization task
         mtls_task = asyncio.create_task(slow_mtls_init())
         session._mtls_init_task = mtls_task
         # Launch an in-flight request that awaits the shielded mTLS task
-        req_task = asyncio.create_task(
-            session.request("GET", "https://example.com")
-        )
+        req_task = asyncio.create_task(session.request("GET", "https://example.com"))
         # Ensure the mTLS task has started and the request is waiting on it
         await init_started.wait()
         # Yield to event loop to guarantee session.request has reached await asyncio.shield(...)

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -853,3 +853,109 @@ class TestSessionsMtls:
         assert all(r.status_code == 200 for r in results)
         assert refresh_count == 1
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_with_completed_mtls_init_task():
+        """
+        Verifies that when _mtls_init_task is already completed, the
+        _mtls_init_task.done() reset branch in configure_mtls_channel() is exercised.
+        """
+        old_cert = b"old_cert_data"
+        new_cert = b"new_cert_data"
+        new_key = b"new_key_data"
+    
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        
+        # Mock a completed initial task
+        async def dummy_init():
+            return None
+        completed_task = asyncio.create_task(dummy_init())
+        await completed_task
+    
+        # Mock response returning 401 first, then 200 after rotation
+        mock_auth_request = mock.AsyncMock(spec=transport.Request)
+        mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
+        mock_resp_200 = mock.Mock(spec=transport.Response, status_code=200)
+        mock_auth_request.side_effect = [mock_resp_401, mock_resp_200]
+    
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_request
+        )
+        session._is_mtls = True
+        session._cached_cert = old_cert
+        session._mtls_init_task = completed_task  # Pre-populate completed task
+    
+        with mock.patch(
+            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
+            return_value=(new_cert, new_key, "old_fp", "new_fp"),
+        ), mock.patch.object(
+            session, "configure_mtls_channel", wraps=session.configure_mtls_channel
+        ) as spy_configure:
+            resp = await session.request("GET", "https://example.com")
+            
+            assert resp.status_code == 200
+            assert spy_configure.called
+            # Verify the previous task was replaced and new configuration completed
+            assert session._mtls_init_task is not completed_task
+            assert session._mtls_init_task.done()
+    
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_retry_raises_timeout_before_refresh():
+        """
+        Tests that TimeoutError is raised if max_allowed_time expires before
+        credentials.refresh can be executed following a 401.
+        """
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_auth_request = mock.AsyncMock(spec=transport.Request)
+        mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
+        mock_auth_request.return_value = mock_resp_401
+    
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_request
+        )
+    
+        # Initial monotonic call: start (0), before_request (0.2), request (0.4)
+        # Then monotonic advances to 10.0 (exceeding max_allowed_time=1.0) before refresh
+        with mock.patch("time.monotonic", side_effect=[0, 0.2, 0.4, 10.0, 10.0, 10.0]):
+            with pytest.raises(exceptions.TimeoutError):
+                await session.request("GET", "https://example.com", max_allowed_time=1.0)
+    
+        # Assert refresh was never called because timeout expired beforehand
+        mock_creds.refresh.assert_not_called()
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_retry_raises_timeout_before_subsequent_retry():
+        """
+        Tests that TimeoutError is raised if credentials.refresh succeeds on 401,
+        but remaining time expires before the retry request can complete.
+        """
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_auth_request = mock.AsyncMock(spec=transport.Request)
+        mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
+        mock_auth_request.return_value = mock_resp_401
+    
+        async def mock_refresh(auth_request):
+            # Refresh takes time
+            return None
+    
+        mock_creds.refresh = mock.AsyncMock(side_effect=mock_refresh)
+    
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_request
+        )
+    
+        # Simulate monotonic advancing so refresh completes but remaining time <= 0 for the retry
+        with mock.patch(
+            "time.monotonic",
+            side_effect=[0.0, 0.1, 0.2, 0.3, 0.4, 5.0, 5.0, 5.0],
+        ):
+            with pytest.raises(exceptions.TimeoutError):
+                await session.request("GET", "https://example.com", max_allowed_time=1.0)
+    
+        # Assert refresh was called once, but the subsequent request aborted on timeout
+        assert mock_creds.refresh.call_count == 1
+        assert mock_auth_request.call_count == 1
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -23,6 +23,7 @@ import pytest
 
 from google.auth import exceptions
 from google.auth.aio import credentials
+from google.auth.aio import transport
 from google.auth.aio.transport import sessions
 from google.auth.exceptions import TimeoutError
 
@@ -855,107 +856,118 @@ class TestSessionsMtls:
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_cert_rotation_with_completed_mtls_init_task():
+    async def test_cert_rotation_with_completed_mtls_init_task(self):
         """
-        Verifies that when _mtls_init_task is already completed, the
-        _mtls_init_task.done() reset branch in configure_mtls_channel() is exercised.
+        Verifies that when _mtls_init_task is already completed, receiving a 401
+        with rotated certificates properly resets _mtls_init_task and reconfigures mTLS.
         """
-        old_cert = b"old_cert_data"
-        new_cert = b"new_cert_data"
-        new_key = b"new_key_data"
-    
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        
-        # Mock a completed initial task
-        async def dummy_init():
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        # 1. Pre-populate _mtls_init_task with an already completed task
+        async def dummy_completed():
             return None
-        completed_task = asyncio.create_task(dummy_init())
-        await completed_task
-    
-        # Mock response returning 401 first, then 200 after rotation
-        mock_auth_request = mock.AsyncMock(spec=transport.Request)
-        mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
-        mock_resp_200 = mock.Mock(spec=transport.Response, status_code=200)
-        mock_auth_request.side_effect = [mock_resp_401, mock_resp_200]
-    
+
+        initial_task = asyncio.create_task(dummy_completed())
+        await initial_task
+        assert initial_task.done()
+        # 2. Mock 401 then 200 responses
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
         session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_request
+            mock_creds, auth_request=mock_auth_req
         )
         session._is_mtls = True
-        session._cached_cert = old_cert
-        session._mtls_init_task = completed_task  # Pre-populate completed task
-    
-        with mock.patch(
-            "google.auth.transport._mtls_helper.check_parameters_for_unauthorized_response",
-            return_value=(new_cert, new_key, "old_fp", "new_fp"),
-        ), mock.patch.object(
-            session, "configure_mtls_channel", wraps=session.configure_mtls_channel
-        ) as spy_configure:
-            resp = await session.request("GET", "https://example.com")
-            
-            assert resp.status_code == 200
-            assert spy_configure.called
-            # Verify the previous task was replaced and new configuration completed
-            assert session._mtls_init_task is not completed_task
-            assert session._mtls_init_task.done()
-    
+        session._cached_cert = b"old_cert"
+        session._mtls_init_task = initial_task  # Pre-populate completed task
+        new_cert = b"new_cert"
+        new_key = b"new_key"
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
+            # Must use a hostname matching _MTLS_URL_PREFIXES (e.g. *.mtls.googleapis.com)
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+            assert resp == mock_resp_200
+            mock_conf.assert_called_once()
+            # Verify the previous completed task was cleared during rotation
+            assert session._mtls_init_task is not initial_task
+            mock_creds.refresh.assert_called_once()
+            assert mock_auth_req.call_count == 2
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_401_retry_raises_timeout_before_refresh():
+    async def test_401_retry_raises_timeout_before_refresh(self):
         """
         Tests that TimeoutError is raised if max_allowed_time expires before
-        credentials.refresh can be executed following a 401.
+        credentials.refresh can be executed following a 401 response.
         """
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_auth_request = mock.AsyncMock(spec=transport.Request)
         mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
-        mock_auth_request.return_value = mock_resp_401
-    
+        current_time = 0.0
+
+        # When the 401 request completes, advance time past max_allowed_time
+        async def fake_auth_request(*args, **kwargs):
+            nonlocal current_time
+            current_time = 100.0  # Expire timeout before refresh starts
+            return mock_resp_401
+
+        mock_auth_request.side_effect = fake_auth_request
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_request
         )
-    
-        # Initial monotonic call: start (0), before_request (0.2), request (0.4)
-        # Then monotonic advances to 10.0 (exceeding max_allowed_time=1.0) before refresh
-        with mock.patch("time.monotonic", side_effect=[0, 0.2, 0.4, 10.0, 10.0, 10.0]):
+        with mock.patch("time.monotonic", side_effect=lambda: current_time):
             with pytest.raises(exceptions.TimeoutError):
-                await session.request("GET", "https://example.com", max_allowed_time=1.0)
-    
-        # Assert refresh was never called because timeout expired beforehand
+                await session.request(
+                    "GET", "https://example.com", max_allowed_time=1.0
+                )
+        # Confirm credentials.refresh was never called
         mock_creds.refresh.assert_not_called()
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_401_retry_raises_timeout_before_subsequent_retry():
+    async def test_401_retry_raises_timeout_before_subsequent_retry(self):
         """
         Tests that TimeoutError is raised if credentials.refresh succeeds on 401,
-        but remaining time expires before the retry request can complete.
+        but elapsed time exceeds max_allowed_time before the retried request can execute.
         """
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_auth_request = mock.AsyncMock(spec=transport.Request)
         mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
         mock_auth_request.return_value = mock_resp_401
-    
-        async def mock_refresh(auth_request):
-            # Refresh takes time
+        current_time = 0.0
+
+        # Allow initial request to proceed at t=0.0, but expire timeout during refresh
+        async def fake_refresh(auth_request):
+            nonlocal current_time
+            current_time = 100.0  # Expire timeout during refresh before retry
             return None
-    
-        mock_creds.refresh = mock.AsyncMock(side_effect=mock_refresh)
-    
+
+        mock_creds.refresh = mock.AsyncMock(side_effect=fake_refresh)
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_request
         )
-    
-        # Simulate monotonic advancing so refresh completes but remaining time <= 0 for the retry
-        with mock.patch(
-            "time.monotonic",
-            side_effect=[0.0, 0.1, 0.2, 0.3, 0.4, 5.0, 5.0, 5.0],
-        ):
+        with mock.patch("time.monotonic", side_effect=lambda: current_time):
             with pytest.raises(exceptions.TimeoutError):
-                await session.request("GET", "https://example.com", max_allowed_time=1.0)
-    
-        # Assert refresh was called once, but the subsequent request aborted on timeout
+                await session.request(
+                    "GET", "https://example.com", max_allowed_time=1.0
+                )
+        # Refresh succeeded once, but subsequent retry was stopped by timeout
         assert mock_creds.refresh.call_count == 1
         assert mock_auth_request.call_count == 1
         await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -971,3 +971,119 @@ class TestSessionsMtls:
         assert mock_creds.refresh.call_count == 1
         assert mock_auth_request.call_count == 1
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_lock_contention_check_params_fails(self):
+        """Verifies lock contention when certificate parameter check raises a handled exception."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401_1 = mock.Mock()
+        mock_resp_401_1.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_1.close = mock.AsyncMock()
+
+        mock_resp_401_2 = mock.Mock()
+        mock_resp_401_2.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_2.close = mock.AsyncMock()
+
+        mock_resp_200_1 = mock.Mock()
+        mock_resp_200_1.status_code = http_client.OK
+        mock_resp_200_1.close = mock.AsyncMock()
+
+        mock_resp_200_2 = mock.Mock()
+        mock_resp_200_2.status_code = http_client.OK
+        mock_resp_200_2.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(
+            side_effect=[
+                mock_resp_401_1,
+                mock_resp_401_2,
+                mock_resp_200_1,
+                mock_resp_200_2,
+            ]
+        )
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"cached_cert"
+
+        async def slow_failing_check(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            raise exceptions.ClientCertError("check_params failed")
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                side_effect=slow_failing_check,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            results = await asyncio.gather(
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test1"),
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test2"),
+            )
+
+            assert results == [mock_resp_200_1, mock_resp_200_2]
+            assert mock_check.call_count == 1
+            assert session._mtls_check_counter == 1
+            assert mock_conf.call_count == 0
+            assert mock_creds.refresh.call_count == 1
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_no_cert_rotation_when_client_cert_does_not_exist(self, caplog):
+        """Verifies that if the client cert does not exist, reconfiguration is skipped and logged."""
+        import logging
+
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+            caplog.at_level(logging.INFO),
+        ):
+            mock_check.return_value = (None, None, None, None)
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            assert resp == mock_resp_200
+            mock_check.assert_called_once()
+            mock_conf.assert_not_called()
+            mock_creds.refresh.assert_called_once()
+            assert (
+                "Skipping reconfiguration of mTLS channel because the client certificate does not exist."
+                in caplog.text
+            )
+
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1085,3 +1085,44 @@ class TestSessionsMtls:
             )
 
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_request_cancellation_propagates_and_leaves_mtls_init_running(self):
+        """Verifies that cancelling an in-flight request propagates CancelledError
+        to the caller while asyncio.shield preserves self._mtls_init_task running
+        in the background.
+        """
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(mock_creds)
+        init_started = asyncio.Event()
+        init_can_finish = asyncio.Event()
+        async def slow_mtls_init():
+            init_started.set()
+            await init_can_finish.wait()
+            session._is_mtls = True
+        # Simulate an in-progress mTLS initialization task
+        mtls_task = asyncio.create_task(slow_mtls_init())
+        session._mtls_init_task = mtls_task
+        # Launch an in-flight request that awaits the shielded mTLS task
+        req_task = asyncio.create_task(
+            session.request("GET", "https://example.com")
+        )
+        # Ensure the mTLS task has started and the request is waiting on it
+        await init_started.wait()
+        # Yield to event loop to guarantee session.request has reached await asyncio.shield(...)
+        await asyncio.sleep(0)
+        # Cancel the in-flight request
+        req_task.cancel()
+        # 1. Verify asyncio.CancelledError is propagated to the request caller
+        with pytest.raises(asyncio.CancelledError):
+            await req_task
+        # 2. Verify self._mtls_init_task was NOT cancelled and is still running
+        assert not session._mtls_init_task.cancelled()
+        assert not session._mtls_init_task.done()
+        # 3. Allow self._mtls_init_task to complete and verify it finishes cleanly
+        init_can_finish.set()
+        await session._mtls_init_task
+        assert session._mtls_init_task.done()
+        assert not session._mtls_init_task.cancelled()
+        assert session._is_mtls is True
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -133,12 +133,16 @@ class TestSessionsMtls:
 
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_mock_callback(self):
-        """Tests that passing a direct callback bypasses the metadata config file."""
+        """Tests that passing a direct callback configures mTLS without metadata config file."""
 
         def custom_callback():
             return b"custom_cert", b"custom_key"
 
         with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"custom_cert", b"custom_key"),
+            ),
             mock.patch(
                 "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
             ) as mock_make_context,
@@ -148,12 +152,9 @@ class TestSessionsMtls:
             mock_session.return_value.close = mock.AsyncMock()
             mock_context = mock.Mock(spec=ssl.SSLContext)
             mock_make_context.return_value = mock_context
-
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
-
             await session.configure_mtls_channel(client_cert_callback=custom_callback)
-
             assert session._is_mtls is True
             assert session._cached_cert == b"custom_cert"
             mock_make_context.assert_called_once_with(b"custom_cert", b"custom_key")
@@ -164,10 +165,9 @@ class TestSessionsMtls:
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_custom_request(self):
         """Tests that a custom auth_request is properly initialized with mTLS."""
-        mock_custom_request = mock.AsyncMock(spec=transport.AsyncRequest)
+        mock_custom_request = mock.AsyncMock(spec=transport.Request)
         mock_custom_request.configure_mtls_channel = mock.AsyncMock()
         mock_custom_request.close = mock.AsyncMock()
-
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_custom_request
@@ -177,7 +177,6 @@ class TestSessionsMtls:
             return b"custom_cert", b"custom_key"
 
         await session.configure_mtls_channel(client_cert_callback=custom_callback)
-
         assert session._is_mtls is True
         mock_custom_request.configure_mtls_channel.assert_called_once_with(
             custom_callback
@@ -185,38 +184,13 @@ class TestSessionsMtls:
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_configure_mtls_channel_exception_resets_flag(self):
-        """Tests that if an unexpected error occurs, _is_mtls stays False."""
-        with (
-            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch("os.path.exists", return_value=True),
-            mock.patch(
-                "builtins.open",
-                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-            ),
-            mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key",
-                side_effect=Exception("Unexpected boom!"),
-            ),
-        ):
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-
-            assert session._is_mtls is False
-            await session.close()
-
-    @pytest.mark.asyncio
     async def test_configure_mtls_channel_transport_error_resets_flag(self):
         """Tests that if custom auth_request raises an error, _is_mtls stays False."""
-        mock_custom_request = mock.AsyncMock(spec=transport.AsyncRequest)
+        mock_custom_request = mock.AsyncMock(spec=transport.Request)
         mock_custom_request.configure_mtls_channel = mock.AsyncMock(
             side_effect=exceptions.TransportError("Boom!")
         )
         mock_custom_request.close = mock.AsyncMock()
-
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_custom_request
@@ -227,7 +201,6 @@ class TestSessionsMtls:
 
         with pytest.raises(exceptions.TransportError):
             await session.configure_mtls_channel(client_cert_callback=custom_callback)
-
         assert session._is_mtls is False
         await session.close()
 
@@ -235,13 +208,11 @@ class TestSessionsMtls:
     async def test_configure_mtls_channel_atomic_on_exception(self):
         """Tests that an exception during channel creation leaves the previous auth_request intact."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_original_auth_request = mock.AsyncMock(spec=transport.AsyncRequest)
+        mock_original_auth_request = mock.AsyncMock(spec=transport.Request)
         mock_original_auth_request.close = mock.AsyncMock()
-
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_original_auth_request
         )
-
         with (
             mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
             mock.patch("os.path.exists", return_value=True),
@@ -260,7 +231,6 @@ class TestSessionsMtls:
         ):
             with pytest.raises(exceptions.MutualTLSChannelError):
                 await session.configure_mtls_channel()
-
             assert session._is_mtls is False
             assert session._auth_request is mock_original_auth_request
             await session.close()
@@ -276,8 +246,9 @@ class TestSessionsMtls:
                 mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
             ),
             mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key"
-            ) as mock_helper,
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"fake_cert_data", b"fake_key_data"),
+            ),
             mock.patch(
                 "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
             ) as mock_make_context,
@@ -286,22 +257,17 @@ class TestSessionsMtls:
         ):
             mock_session.return_value.close = mock.AsyncMock()
             mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-
             mock_context = mock.Mock(spec=ssl.SSLContext)
             mock_make_context.return_value = mock_context
-
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            # Drive configure_mtls_channel 3 times with failing transports to exercise eviction loop (maxlen=2)
-            for i in range(3):
-                failing_req = mock.AsyncMock()
-                failing_req.close.side_effect = Exception(f"Failed to close session {i}")
-                session._auth_request = failing_req
-                session._mtls_init_task = None
-                await session.configure_mtls_channel()
-
+            # Pre-populate _old_auth_requests with failing transports to trigger and test eviction (maxlen >= 2)
+            failing_req_1 = mock.AsyncMock(spec=transport.Request)
+            failing_req_1.close.side_effect = Exception("Close error 1")
+            failing_req_2 = mock.AsyncMock(spec=transport.Request)
+            failing_req_2.close.side_effect = Exception("Close error 2")
+            session._old_auth_requests.extend([failing_req_1, failing_req_2])
+            await session.configure_mtls_channel()
             assert session._is_mtls is True
             assert session._cached_cert == b"fake_cert_data"
             await session.close()
@@ -355,31 +321,28 @@ class TestSessionsMtls:
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
-
         mock_auth_req = mock.AsyncMock()
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
         mock_resp.close = mock.AsyncMock()
         mock_auth_req.return_value = mock_resp
-
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
         )
         session._is_mtls = True
         session._cached_cert = b"cached_cert"
-
         with mock.patch(
             "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
             new_callable=mock.AsyncMock,
             side_effect=exceptions.ClientCertError("check_params failed"),
         ) as mock_check_params:
+            # Use mTLS URL so is_mtls_endpoint evaluates to True
             resp = await session.request(
                 "GET", "https://pubsub.mtls.googleapis.com/test"
             )
             assert resp == mock_resp
             mock_check_params.assert_called_once()
             mock_creds.refresh.assert_called_once()
-
         await session.close()
 
     @pytest.mark.asyncio

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -23,7 +23,6 @@ import pytest
 
 from google.auth import exceptions
 from google.auth.aio import credentials
-from google.auth.aio import transport
 from google.auth.aio.transport import sessions
 from google.auth.exceptions import TimeoutError
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -72,6 +72,7 @@ class TestSessionsMtls:
             await session.configure_mtls_channel()
 
             assert session._is_mtls is True
+            assert session._cached_cert == b"fake_cert_data"
             mock_make_context.assert_called_once_with(
                 b"fake_cert_data", b"fake_key_data"
             )
@@ -114,33 +115,30 @@ class TestSessionsMtls:
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_invalid_fields(self):
         """If cert is missing expected keys, it should fail gracefully."""
+        bad_config = {"version": 1, "cert_configs": {"workload": {}}}
         with (
             mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
             mock.patch("os.path.exists") as mock_exists,
             mock.patch(
-                "builtins.open", mock.mock_open(read_data='{"cert_configs": {}}')
+                "builtins.open", mock.mock_open(read_data=json.dumps(bad_config))
             ),
         ):
             mock_exists.return_value = True
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
-            await session.configure_mtls_channel()
-            assert session._is_mtls is False
+
+            with pytest.raises(exceptions.MutualTLSChannelError):
+                await session.configure_mtls_channel()
             await session.close()
 
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_mock_callback(self):
-        """Tests mTLS configuration using bytes-returning callback."""
+        """Tests that passing a direct callback bypasses the metadata config file."""
 
-        def mock_callback():
-            return (b"fake_cert_bytes", b"fake_key_bytes")
+        def custom_callback():
+            return b"custom_cert", b"custom_key"
 
         with (
-            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch(
-                "google.auth.transport.mtls.has_default_client_cert_source",
-                return_value=True,
-            ),
             mock.patch(
                 "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
             ) as mock_make_context,
@@ -154,73 +152,53 @@ class TestSessionsMtls:
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
 
-            await session.configure_mtls_channel(client_cert_callback=mock_callback)
+            await session.configure_mtls_channel(client_cert_callback=custom_callback)
 
             assert session._is_mtls is True
-            mock_make_context.assert_called_once_with(
-                b"fake_cert_bytes", b"fake_key_bytes"
-            )
+            assert session._cached_cert == b"custom_cert"
+            mock_make_context.assert_called_once_with(b"custom_cert", b"custom_key")
             mock_connector.assert_called_once_with(ssl=mock_context)
             mock_session.assert_called_once_with(connector=mock_connector.return_value)
             await session.close()
 
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_custom_request(self):
-        """Tests that if _auth_request is not an AiohttpRequest, _is_mtls is set to False."""
-        with (
-            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch("os.path.exists") as mock_exists,
-            mock.patch(
-                "builtins.open",
-                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-            ),
-            mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key"
-            ) as mock_helper,
-            mock.patch(
-                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-            ) as mock_make_context,
-        ):
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
+        """Tests that a custom auth_request is properly initialized with mTLS."""
+        mock_custom_request = mock.AsyncMock(spec=transport.AsyncRequest)
+        mock_custom_request.configure_mtls_channel = mock.AsyncMock()
+        mock_custom_request.close = mock.AsyncMock()
 
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_custom_request
+        )
 
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            mock_auth_request = mock.AsyncMock(spec=transport.Request)
-            session = sessions.AsyncAuthorizedSession(
-                mock_creds, auth_request=mock_auth_request
-            )
+        def custom_callback():
+            return b"custom_cert", b"custom_key"
 
-            with pytest.warns(UserWarning, match="Attempted to establish mTLS"):
-                await session.configure_mtls_channel()
+        await session.configure_mtls_channel(client_cert_callback=custom_callback)
 
-            assert session._is_mtls is False
-            mock_make_context.assert_not_called()
-            await session.close()
+        assert session._is_mtls is True
+        mock_custom_request.configure_mtls_channel.assert_called_once_with(
+            custom_callback
+        )
+        await session.close()
 
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_exception_resets_flag(self):
-        """Tests that self._is_mtls is reset to False if an exception is raised during configuration."""
+        """Tests that if an unexpected error occurs, _is_mtls stays False."""
         with (
             mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch("os.path.exists") as mock_exists,
+            mock.patch("os.path.exists", return_value=True),
             mock.patch(
                 "builtins.open",
                 mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
             ),
             mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key"
-            ) as mock_helper,
-            mock.patch(
-                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-            ) as mock_make_context,
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                side_effect=Exception("Unexpected boom!"),
+            ),
         ):
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-            mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
-
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
 
@@ -232,88 +210,64 @@ class TestSessionsMtls:
 
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_transport_error_resets_flag(self):
-        """Tests that self._is_mtls is reset to False if a TransportError is raised."""
+        """Tests that if custom auth_request raises an error, _is_mtls stays False."""
+        mock_custom_request = mock.AsyncMock(spec=transport.AsyncRequest)
+        mock_custom_request.configure_mtls_channel = mock.AsyncMock(
+            side_effect=exceptions.TransportError("Boom!")
+        )
+        mock_custom_request.close = mock.AsyncMock()
+
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_custom_request
+        )
+
+        def custom_callback():
+            return b"custom_cert", b"custom_key"
+
+        with pytest.raises(exceptions.TransportError):
+            await session.configure_mtls_channel(client_cert_callback=custom_callback)
+
+        assert session._is_mtls is False
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_atomic_on_exception(self):
+        """Tests that an exception during channel creation leaves the previous auth_request intact."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_original_auth_request = mock.AsyncMock(spec=transport.AsyncRequest)
+        mock_original_auth_request.close = mock.AsyncMock()
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_original_auth_request
+        )
+
         with (
             mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch("os.path.exists") as mock_exists,
+            mock.patch("os.path.exists", return_value=True),
             mock.patch(
                 "builtins.open",
                 mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
             ),
             mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key"
-            ) as mock_helper,
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"fake_cert_data", b"fake_key_data"),
+            ),
             mock.patch(
-                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-            ) as mock_make_context,
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                side_effect=Exception("Failed to make SSL context"),
+            ),
         ):
-            mock_exists.return_value = True
-            mock_helper.return_value = (True, b"fake_cert_data", b"fake_key_data")
-            mock_make_context.side_effect = exceptions.TransportError("Mock error")
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
             with pytest.raises(exceptions.MutualTLSChannelError):
                 await session.configure_mtls_channel()
 
             assert session._is_mtls is False
-            await session.close()
-
-    @pytest.mark.asyncio
-    async def test_configure_mtls_channel_atomic_on_exception(self):
-        """Tests that if configure_mtls_channel already succeeded, a subsequent failure preserves state."""
-        # Step 1: Successful configuration
-        with (
-            mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
-            mock.patch("os.path.exists") as mock_exists,
-            mock.patch(
-                "builtins.open",
-                mock.mock_open(read_data=json.dumps(VALID_WORKLOAD_CONFIG)),
-            ),
-            mock.patch(
-                "google.auth.aio.transport.mtls.get_client_cert_and_key"
-            ) as mock_helper,
-            mock.patch(
-                "google.auth.aio.transport.mtls.make_client_cert_ssl_context"
-            ) as mock_make_context,
-            mock.patch("aiohttp.TCPConnector"),
-            mock.patch("aiohttp.ClientSession") as mock_session,
-        ):
-            mock_session.return_value.close = mock.AsyncMock()
-            mock_exists.return_value = True
-            mock_helper.return_value = (
-                True,
-                b"fake_cert_data_1",
-                b"fake_key_data_1",
-            )
-
-            mock_context = mock.Mock(spec=ssl.SSLContext)
-            mock_make_context.return_value = mock_context
-
-            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-            session = sessions.AsyncAuthorizedSession(mock_creds)
-
-            await session.configure_mtls_channel()
-            assert session._is_mtls is True
-            assert session._cached_cert == b"fake_cert_data_1"
-            first_auth_request = session._auth_request
-
-            # Step 2: Failed subsequent configuration attempt
-            session._mtls_init_task = None
-            mock_make_context.side_effect = exceptions.ClientCertError("Mock error")
-
-            with pytest.raises(exceptions.MutualTLSChannelError):
-                await session.configure_mtls_channel()
-
-            assert session._is_mtls is True
-            assert session._cached_cert == b"fake_cert_data_1"
-            assert session._auth_request is first_auth_request
+            assert session._auth_request is mock_original_auth_request
             await session.close()
 
     @pytest.mark.asyncio
     async def test_configure_mtls_channel_close_exception_does_not_abort(self):
-        """Tests that an exception in old_auth_request.close() does not abort configuration."""
+        """Tests that an exception in old_auth_request.close() during eviction does not abort configuration."""
         with (
             mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}),
             mock.patch("os.path.exists") as mock_exists,
@@ -340,11 +294,13 @@ class TestSessionsMtls:
             mock_creds = mock.AsyncMock(spec=credentials.Credentials)
             session = sessions.AsyncAuthorizedSession(mock_creds)
 
-            session._auth_request.close = mock.AsyncMock(
-                side_effect=Exception("Mock close error")
-            )
-
-            await session.configure_mtls_channel()
+            # Drive configure_mtls_channel 3 times with failing transports to exercise eviction loop (maxlen=2)
+            for i in range(3):
+                failing_req = mock.AsyncMock()
+                failing_req.close.side_effect = Exception(f"Failed to close session {i}")
+                session._auth_request = failing_req
+                session._mtls_init_task = None
+                await session.configure_mtls_channel()
 
             assert session._is_mtls is True
             assert session._cached_cert == b"fake_cert_data"
@@ -352,12 +308,16 @@ class TestSessionsMtls:
 
     @pytest.mark.asyncio
     async def test_cert_rotation_failure_raises_error(self):
+        """Verifies that an error in configure_mtls_channel raises MutualTLSChannelError."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
 
+        mock_auth_req = mock.AsyncMock()
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+        mock_resp.close = mock.AsyncMock()
+        mock_auth_req.return_value = mock_resp
 
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
@@ -385,18 +345,55 @@ class TestSessionsMtls:
 
             mock_check.assert_called_once()
             mock_conf.assert_called_once()
+            mock_resp.close.assert_called_once()
 
         await session.close()
 
     @pytest.mark.asyncio
     async def test_cert_rotation_check_params_fails(self):
+        """Verifies that a failure during parameter checking falls back to the original response."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock()
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
 
+        mock_auth_req = mock.AsyncMock()
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp)
+        mock_resp.close = mock.AsyncMock()
+        mock_auth_req.return_value = mock_resp
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"cached_cert"
+
+        with mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+            side_effect=exceptions.ClientCertError("check_params failed"),
+        ) as mock_check_params:
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+            assert resp == mock_resp
+            mock_check_params.assert_called_once()
+            mock_creds.refresh.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
+        """Verifies that if the fingerprint has not changed, reconfiguration is skipped."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_auth_req = mock.AsyncMock()
+        mock_resp = mock.Mock()
+        mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_resp.close = mock.AsyncMock()
+        mock_auth_req.return_value = mock_resp
 
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
@@ -413,8 +410,11 @@ class TestSessionsMtls:
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
             ) as mock_conf,
         ):
-            mock_check.side_effect = exceptions.MutualTLSChannelError(
-                "Failed to check params"
+            mock_check.return_value = (
+                b"new_cert",
+                b"new_key",
+                b"same_fp",
+                b"same_fp",
             )
 
             resp = await session.request(
@@ -423,13 +423,14 @@ class TestSessionsMtls:
 
             assert resp == mock_resp
             mock_check.assert_called_once()
-            mock_creds.refresh.assert_not_called()
             mock_conf.assert_not_called()
+            mock_creds.refresh.assert_called_once()
 
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_no_cert_rotation_when_cert_matches_and_mtls_enabled(self):
+    async def test_cert_rotation_success_and_retry(self):
+        """Verifies successful cert rotation, channel reconfiguration, and request retry."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
@@ -440,54 +441,7 @@ class TestSessionsMtls:
 
         mock_resp_200 = mock.Mock()
         mock_resp_200.status_code = http_client.OK
-
-        # 401 on initial request, 200 on retry after refresh
-        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
-
-        session = sessions.AsyncAuthorizedSession(
-            mock_creds, auth_request=mock_auth_req
-        )
-        session._is_mtls = True
-        session._cached_cert = b"old_cert"
-
-        new_cert = b"new_cert"
-        new_key = b"new_key"
-
-        with (
-            mock.patch(
-                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-                new_callable=mock.AsyncMock,
-            ) as mock_check,
-            mock.patch.object(
-                session, "configure_mtls_channel", new_callable=mock.AsyncMock
-            ) as mock_conf,
-        ):
-            # Matching fingerprints mean no mTLS rotation is needed
-            mock_check.return_value = (new_cert, new_key, b"old_fp", b"old_fp")
-
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
-
-            assert resp == mock_resp_200
-            mock_check.assert_called_once()
-            mock_conf.assert_not_called()
-            mock_creds.refresh.assert_called_once()
-            assert mock_auth_req.call_count == 2
-            mock_resp_401.close.assert_awaited_once()
-
-        await session.close()
-
-    @pytest.mark.asyncio
-    async def test_cert_rotation_success_and_retry(self):
-        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock(return_value=None)
-
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
 
         mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
 
@@ -516,27 +470,49 @@ class TestSessionsMtls:
             )
 
             assert resp == mock_resp_200
-            mock_check.assert_called_once()
-            mock_conf.assert_called_once_with(mock.ANY)
+            mock_conf.assert_called_once()
+            cb = (
+                mock_conf.call_args.args[0]
+                if mock_conf.call_args.args
+                else mock_conf.call_args.kwargs["client_cert_callback"]
+            )
+            assert cb() == (new_cert, new_key)
             mock_creds.refresh.assert_called_once()
-            assert mock_creds.before_request.call_count == 2
+            assert mock_auth_req.call_count == 2
+            mock_resp_401.close.assert_called_once()
 
         await session.close()
 
     @pytest.mark.asyncio
     async def test_cert_rotation_lock_contention(self):
+        """Verifies that concurrent requests serialize mTLS check and skip redundant checks."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
 
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_1 = mock.Mock()
+        mock_resp_401_1.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_1.close = mock.AsyncMock()
 
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
+        mock_resp_401_2 = mock.Mock()
+        mock_resp_401_2.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_2.close = mock.AsyncMock()
+
+        mock_resp_200_1 = mock.Mock()
+        mock_resp_200_1.status_code = http_client.OK
+        mock_resp_200_1.close = mock.AsyncMock()
+
+        mock_resp_200_2 = mock.Mock()
+        mock_resp_200_2.status_code = http_client.OK
+        mock_resp_200_2.close = mock.AsyncMock()
 
         mock_auth_req = mock.AsyncMock(
-            side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
+            side_effect=[
+                mock_resp_401_1,
+                mock_resp_401_2,
+                mock_resp_200_1,
+                mock_resp_200_2,
+            ]
         )
 
         session = sessions.AsyncAuthorizedSession(
@@ -545,58 +521,61 @@ class TestSessionsMtls:
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        new_cert = b"new_cert"
-        new_key = b"new_key"
-
-        async def mock_configure_mtls_channel(*args, **kwargs):
-            await asyncio.sleep(0.01)
-            session._cached_cert = new_cert
-
-        async def mock_check_side_effect(cached_cert, callback=None):
-            if cached_cert == b"old_cert":
-                return (new_cert, new_key, b"old_fp", b"new_fp")
-            return (new_cert, new_key, b"new_fp", b"new_fp")
+        async def slow_check(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return (b"new", b"new", b"old_fp", b"new_fp")
 
         with (
             mock.patch(
                 "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-                new_callable=mock.AsyncMock,
+                side_effect=slow_check,
             ) as mock_check,
             mock.patch.object(
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
             ) as mock_conf,
         ):
-            mock_check.side_effect = mock_check_side_effect
-            mock_conf.side_effect = mock_configure_mtls_channel
+            results = await asyncio.gather(
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test1"),
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test2"),
+            )
 
-            tasks = [
-                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-                for _ in range(3)
-            ]
-            responses = await asyncio.gather(*tasks)
-
-        for resp in responses:
-            assert resp == mock_resp_200
-
-        mock_check.assert_called_once()
-        mock_conf.assert_called_once()
-        assert mock_creds.refresh.call_count == 1
+            assert results == [mock_resp_200_1, mock_resp_200_2]
+            assert mock_check.call_count == 1
+            assert mock_conf.call_count == 1
+            assert mock_creds.refresh.call_count == 1
 
         await session.close()
 
     @pytest.mark.asyncio
     async def test_cert_rotation_lock_contention_no_cert_change(self):
+        """Verifies lock contention when certificates have not changed."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
 
-        mock_resp_401 = mock.Mock()
-        mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_resp_200 = mock.Mock()
-        mock_resp_200.status_code = http_client.OK
+        mock_resp_401_1 = mock.Mock()
+        mock_resp_401_1.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_1.close = mock.AsyncMock()
+
+        mock_resp_401_2 = mock.Mock()
+        mock_resp_401_2.status_code = http_client.UNAUTHORIZED
+        mock_resp_401_2.close = mock.AsyncMock()
+
+        mock_resp_200_1 = mock.Mock()
+        mock_resp_200_1.status_code = http_client.OK
+        mock_resp_200_1.close = mock.AsyncMock()
+
+        mock_resp_200_2 = mock.Mock()
+        mock_resp_200_2.status_code = http_client.OK
+        mock_resp_200_2.close = mock.AsyncMock()
 
         mock_auth_req = mock.AsyncMock(
-            side_effect=[mock_resp_401] * 3 + [mock_resp_200] * 3
+            side_effect=[
+                mock_resp_401_1,
+                mock_resp_401_2,
+                mock_resp_200_1,
+                mock_resp_200_2,
+            ]
         )
 
         session = sessions.AsyncAuthorizedSession(
@@ -605,33 +584,27 @@ class TestSessionsMtls:
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        async def mock_check_side_effect(cached_cert, callback=None):
-            await asyncio.sleep(0.01)
-            return (b"old_cert", b"old_key", b"old_fp", b"old_fp")
+        async def slow_check(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return (b"new", b"new", b"same_fp", b"same_fp")
 
         with (
             mock.patch(
                 "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-                new_callable=mock.AsyncMock,
+                side_effect=slow_check,
             ) as mock_check,
             mock.patch.object(
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
             ) as mock_conf,
         ):
-            mock_check.side_effect = mock_check_side_effect
+            results = await asyncio.gather(
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test1"),
+                session.request("GET", "https://pubsub.mtls.googleapis.com/test2"),
+            )
 
-            tasks = [
-                session.request("GET", "https://pubsub.mtls.googleapis.com/test")
-                for _ in range(3)
-            ]
-            responses = await asyncio.gather(*tasks)
-
-            for resp in responses:
-                assert resp == mock_resp_200
-
-            mock_check.assert_called_once()
-            mock_conf.assert_not_called()
-            # Concurrent 401s properly deduplicate to 1 refresh
+            assert results == [mock_resp_200_1, mock_resp_200_2]
+            assert mock_check.call_count == 1
+            assert mock_conf.call_count == 0
             assert mock_creds.refresh.call_count == 1
 
         await session.close()
@@ -645,8 +618,11 @@ class TestSessionsMtls:
 
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
         mock_resp_200 = mock.Mock()
         mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
 
         mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
 
@@ -674,24 +650,36 @@ class TestSessionsMtls:
 
             assert resp == mock_resp_200
             mock_check.assert_called_once()
-            mock_conf.assert_called_once_with(mock.ANY)
+            mock_conf.assert_called_once()
+            cb = (
+                mock_conf.call_args.args[0]
+                if mock_conf.call_args.args
+                else mock_conf.call_args.kwargs["client_cert_callback"]
+            )
+            assert cb() == (new_cert, new_key)
 
         await session.close()
 
     @pytest.mark.asyncio
     async def test_non_mtls_url_bypasses_rotation(self):
+        """Verifies that standard non-mTLS URLs bypass certificate rotation."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
 
         mock_resp_401 = mock.Mock()
         mock_resp_401.status_code = http_client.UNAUTHORIZED
-        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
 
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_req
         )
-
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
@@ -704,24 +692,25 @@ class TestSessionsMtls:
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
             ) as mock_conf,
         ):
-            resp = await session.request("GET", "https://example.com/test")
+            resp = await session.request("GET", "https://pubsub.googleapis.com/test")
 
-            assert resp == mock_resp_401
+            assert resp == mock_resp_200
             mock_check.assert_not_called()
             mock_conf.assert_not_called()
-            assert mock_creds.refresh.call_count == 2
-            assert mock_auth_req.call_count == 3
+            mock_creds.refresh.assert_called_once()
 
         await session.close()
 
     @pytest.mark.asyncio
     async def test_cert_rotation_skips_retry_for_streaming(self):
+        """Verifies that streaming requests skip retry on 401 and return the response."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
-        mock_creds.refresh = mock.AsyncMock()
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
 
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_resp.close = mock.AsyncMock()
         mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
         session = sessions.AsyncAuthorizedSession(
@@ -730,9 +719,9 @@ class TestSessionsMtls:
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        class MockStream:
-            def read(self):
-                pass
+        def data_gen():
+            yield b"part1"
+            yield b"part2"
 
         with (
             mock.patch(
@@ -746,13 +735,16 @@ class TestSessionsMtls:
             mock_check.return_value = (b"new", b"new", b"old_fp", b"new_fp")
 
             resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test", data=MockStream()
+                "POST", "https://pubsub.mtls.googleapis.com/test", data=data_gen()
             )
 
             assert resp == mock_resp
+            mock_check.assert_called_once()
             mock_conf.assert_called_once()
+            mock_creds.refresh.assert_called_once()
+            assert mock_auth_req.call_count == 1
+            mock_resp.close.assert_not_called()
 
-        mock_creds.refresh.assert_called_once()
         await session.close()
 
     @pytest.mark.asyncio
@@ -766,6 +758,7 @@ class TestSessionsMtls:
 
         mock_resp = mock.Mock()
         mock_resp.status_code = http_client.UNAUTHORIZED
+        mock_resp.close = mock.AsyncMock()
         mock_auth_req = mock.AsyncMock(return_value=mock_resp)
 
         session = sessions.AsyncAuthorizedSession(
@@ -908,7 +901,7 @@ class TestSessionsMtls:
         )
 
         with pytest.raises(TimeoutError):
-            await session.request("GET", "https://example.com", max_allowed_time=0.01)
+            await session.request("GET", "https://example.com", max_allowed_time=0.1)
 
         mock_resp_401.close.assert_awaited_once()
         await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1037,10 +1037,8 @@ class TestSessionsMtls:
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_no_cert_rotation_when_client_cert_does_not_exist(self, caplog):
-        """Verifies that if the client cert does not exist, reconfiguration is skipped and logged."""
-        import logging
-
+    async def test_no_cert_rotation_when_client_cert_does_not_exist(self):
+        """Verifies that if client certificate does not exist, reconfiguration is skipped with proper logging."""
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_creds.before_request = mock.AsyncMock(return_value=None)
         mock_creds.refresh = mock.AsyncMock(return_value=None)
@@ -1069,7 +1067,7 @@ class TestSessionsMtls:
             mock.patch.object(
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
             ) as mock_conf,
-            caplog.at_level(logging.INFO),
+            mock.patch.object(sessions._LOGGER, "info") as mock_logger_info,
         ):
             mock_check.return_value = (None, None, None, None)
 
@@ -1081,9 +1079,9 @@ class TestSessionsMtls:
             mock_check.assert_called_once()
             mock_conf.assert_not_called()
             mock_creds.refresh.assert_called_once()
-            assert (
-                "Skipping reconfiguration of mTLS channel because the client certificate does not exist."
-                in caplog.text
+            mock_logger_info.assert_any_call(
+                "Skipping reconfiguration of mTLS channel because the client"
+                " certificate does not exist."
             )
 
         await session.close()


### PR DESCRIPTION
feat: [aiohttp] Add mTLS reconfiguration logic when certificate mismatch for existing credentials & Agent Identity workloads

**Changes included:**
* Adds mTLS reconfiguration logic when a certificate mismatch occurs.
* Aligns async session behavior with the synchronous session by triggering a credential refresh and request retry on all `401 Unauthorized` responses (not just mTLS).

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #18227 https://github.com/googleapis/google-cloud-python/issues/18227 🦕

related bug: b/551889462