### PR TITLE
feat(storage): Support AppendableWrites to RCU by setting storage_class to RAPID in async write object stream

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -124,7 +124,9 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
                 resource = _grpc_conversions.blob_to_proto(self.blob)
             else:
                 resource = _storage_v2.Object(
-                    name=self.object_name, bucket=self._full_bucket_name
+                    name=self.object_name,
+                    bucket=self._full_bucket_name,
+                    storage_class="RAPID",
                 )
             self.first_bidi_write_req = _storage_v2.BidiWriteObjectRequest(
                 write_object_spec=_storage_v2.WriteObjectSpec(

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_write_object_stream.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_write_object_stream.py
@@ -98,6 +98,7 @@ class TestAsyncWriteObjectStream:
         initial_request = call_args.kwargs["initial_request"]
         assert initial_request.write_object_spec is not None
         assert initial_request.write_object_spec.resource.name == OBJECT
+        assert initial_request.write_object_spec.resource.storage_class == "RAPID"
         assert initial_request.write_object_spec.appendable
 
         assert stream.is_stream_open


### PR DESCRIPTION
## Description
Set `storage_class="RAPID"` when creating an object resource for appendable write stream in `_AsyncWriteObjectStream.open()` if no blob was provided.

## Changes
- In `packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py`, set `storage_class="RAPID"` on `_storage_v2.Object` initialization.
- In `packages/google-cloud-storage/tests/unit/asyncio/test_async_write_object_stream.py`, add unit test assertion verifying `storage_class` is set to `"RAPID"`.