### PR TITLE
chore(bigquery): ignore case in assertion

### DIFF
--- a/packages/google-cloud-bigquery/tests/unit/test_client.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_client.py
@@ -1798,13 +1798,19 @@ class TestClient(unittest.TestCase):
         http.request.assert_called_once_with(
             url=mock.ANY,
             method="GET",
-            headers={
-                "x-goog-api-client": expected_user_agent,
-                "Accept-Encoding": "gzip",
-                "User-Agent": expected_user_agent,
-            },
+            headers=mock.ANY,
             data=mock.ANY,
             timeout=DEFAULT_TIMEOUT,
+        )
+        _, kwargs = http.request.call_args
+        actual_headers = {k.lower(): v for k, v in kwargs["headers"].items()}
+        self.assertEqual(
+            actual_headers,
+            {
+                "x-goog-api-client": expected_user_agent,
+                "accept-encoding": "gzip",
+                "user-agent": expected_user_agent,
+            },
         )
         self.assertIn("my-application/1.2.3", expected_user_agent)
 

--- a/packages/google-cloud-bigquery/tests/unit/test_client.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_client.py
@@ -1798,13 +1798,11 @@ class TestClient(unittest.TestCase):
         http.request.assert_called_once_with(
             url=mock.ANY,
             method="GET",
-            headers=requests.structures.CaseInsensitiveDict(
-                {
-                    "X-Goog-API-Client": expected_user_agent,
-                    "Accept-Encoding": "gzip",
-                    "User-Agent": expected_user_agent,
-                }
-            ),
+            headers={
+                "x-goog-api-client": expected_user_agent,
+                "Accept-Encoding": "gzip",
+                "User-Agent": expected_user_agent,
+            },
             data=mock.ANY,
             timeout=DEFAULT_TIMEOUT,
         )

--- a/packages/google-cloud-bigquery/tests/unit/test_client.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_client.py
@@ -1798,11 +1798,13 @@ class TestClient(unittest.TestCase):
         http.request.assert_called_once_with(
             url=mock.ANY,
             method="GET",
-            headers={
-                "X-Goog-API-Client": expected_user_agent,
-                "Accept-Encoding": "gzip",
-                "User-Agent": expected_user_agent,
-            },
+            headers=requests.structures.CaseInsensitiveDict(
+                {
+                    "X-Goog-API-Client": expected_user_agent,
+                    "Accept-Encoding": "gzip",
+                    "User-Agent": expected_user_agent,
+                }
+            ),
             data=mock.ANY,
             timeout=DEFAULT_TIMEOUT,
         )


### PR DESCRIPTION
In https://github.com/googleapis/google-cloud-python/pull/18064, `X-Goog-API-Client` was changed to lowercase. This broke an assertion in the bigquery tests

This PR updates the test to support either case, like https://github.com/googleapis/google-cloud-python/pull/18064