### PR TITLE
chore: update generator version to 1.39.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -24,7 +24,7 @@ tools:
       version: 23.7.0
       package: black[jupyter]==23.7.0
     - name: gapic-generator
-      version: 1.37.1
+      version: 1.39.0
     - name: isort
       version: 5.11.0
     - name: nox


### PR DESCRIPTION
Update generator to 1.39.0