### PR TITLE
fix(api-core): handle list-shaped REST error payloads

### DIFF
--- a/packages/google-api-core/google/api_core/exceptions.py
+++ b/packages/google-api-core/google/api_core/exceptions.py
@@ -510,6 +510,8 @@ def format_http_response_error(
             :class:`GoogleAPICallError`, with the message and errors populated
             from the response.
     """
+    if isinstance(payload, list):
+        payload = next((item for item in payload if isinstance(item, dict)), {})
     payload = {} if not payload else payload
     error_message = payload.get("error", {}).get("message", "unknown error")
     errors = payload.get("error", {}).get("errors", ())

--- a/packages/google-api-core/tests/unit/test_exceptions.py
+++ b/packages/google-api-core/tests/unit/test_exceptions.py
@@ -132,6 +132,31 @@ def test_from_http_response_json_content():
     assert exception.errors == ["1", "2"]
 
 
+def test_from_http_response_json_list_content():
+    response = make_response(
+        json.dumps(
+            [{"error": {"message": "json message", "errors": ["1", "2"]}}]
+        ).encode("utf-8")
+    )
+
+    exception = exceptions.from_http_response(response)
+
+    assert isinstance(exception, exceptions.NotFound)
+    assert exception.code == http.client.NOT_FOUND
+    assert exception.message == "POST https://example.com/: json message"
+    assert exception.errors == ["1", "2"]
+
+
+def test_from_http_response_json_list_content_without_error_dict():
+    response = make_response(json.dumps(["error message"]).encode("utf-8"))
+
+    exception = exceptions.from_http_response(response)
+
+    assert isinstance(exception, exceptions.NotFound)
+    assert exception.code == http.client.NOT_FOUND
+    assert exception.message == "POST https://example.com/: unknown error"
+
+
 def test_from_http_response_bad_json_content():
     response = make_response(json.dumps({"meep": "moop"}).encode("utf-8"))
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary; no docs change needed for this bug fix)

Fixes #18223 🦕

## Summary
- Normalize list-shaped REST error payloads to the first dict item before reading the standard `error` object.
- Preserve existing dict payload behavior and fall back to `unknown error` when no dict item is present.
- Add unit coverage for list-wrapped error payloads.

## Tests
- `pytest -q tests/unit/test_exceptions.py -k 'http_response or error_details_from_rest_response'`
- `pytest -q tests/unit/test_exceptions.py`
- `ruff format --check --target-version=py310 --line-length=88 google/api_core/exceptions.py tests/unit/test_exceptions.py`
- `flake8 google/api_core/exceptions.py tests/unit/test_exceptions.py`
- `git diff --check`

## CLA
Google CLA is required by the repository; awaiting the repository's CLA check on this PR.
