### PR TITLE
fix(django-spanner): backslash-escape string literals in quote_value

### DIFF
--- a/packages/django-google-spanner/django_spanner/schema.py
+++ b/packages/django-google-spanner/django_spanner/schema.py
@@ -450,7 +450,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def quote_value(self, value):
         # A more complete implementation isn't currently required.
         if isinstance(value, str):
-            return "'%s'" % value.replace("'", "''")
+            # GoogleSQL string literals use backslash escaping; '' quote
+            # doubling is not recognized, so escape the backslash first and
+            # then the quote (matching the db_default/generated inlining above).
+            return "'%s'" % value.replace("\\", "\\\\").replace("'", "\\'")
         if isinstance(value, bool):
             return "TRUE" if value else "FALSE"
         return str(value)

--- a/packages/django-google-spanner/tests/unit/django_spanner/test_schema.py
+++ b/packages/django-google-spanner/tests/unit/django_spanner/test_schema.py
@@ -40,6 +40,19 @@ class TestUtils(SpannerSimpleTestClass):
         schema_editor = DatabaseSchemaEditor(self.connection)
         self.assertEqual(schema_editor.quote_value(value=1.1), "1.1")
 
+    def test_quote_value_escapes_string(self):
+        """
+        String literals must be backslash-escaped for GoogleSQL. A quote or
+        backslash in the value must not be able to terminate the literal.
+        """
+        schema_editor = DatabaseSchemaEditor(self.connection)
+        self.assertEqual(schema_editor.quote_value(value="o'brien"), "'o\\'brien'")
+        self.assertEqual(schema_editor.quote_value(value="a\\b"), "'a\\\\b'")
+        self.assertEqual(
+            schema_editor.quote_value(value="\\'; DROP TABLE t; --"),
+            "'\\\\\\'; DROP TABLE t; --'",
+        )
+
     def test_skip_default(self):
         """
         Tries skipping default as Cloud spanner doesn't support it.


### PR DESCRIPTION
quote_value inlines a string value into DDL by wrapping it in single quotes and doubling embedded quotes, but Cloud Spanner GoogleSQL does not treat '' as an escaped quote and the routine never escapes backslashes, so a value beginning with a backslash and a quote closes the literal and the trailing text is parsed as DDL. The Spanner backend sets requires_literal_defaults, so column and table comments and altered defaults reach this method. The db_default and generated-column inlining a few lines above already escape by backslashing the backslash and then the quote, so route quote_value through the same escaping.

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)