### PR TITLE
feat(api-core): add ClientInterceptor and apply_interceptors helper (A)

### DIFF
--- a/packages/google-api-core/google/api_core/_observability.py
+++ b/packages/google-api-core/google/api_core/_observability.py
@@ -16,15 +16,16 @@
 
 """OpenTelemetry helpers for resolving and instantiating interceptors."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Callable
 
 from google.api_core import _feature_gating_helpers
 from google.api_core.client_options import ClientOptions
 
 if TYPE_CHECKING:
-    from google.api_core.grpc_helpers import ClientInterceptorCallable
-else:
-    ClientInterceptorCallable = Callable[[Any], Any]
+    # flake8: grpc is imported only for static analysis and type annotations
+    import grpc  # noqa: F401
 
 _TRACER_PROVIDER = "tracer_provider"
 
@@ -88,7 +89,7 @@ def _get_otel_interceptor(
 
 def get_otel_interceptor(
     client_options: ClientOptions | dict[str, Any] | None = None,
-) -> ClientInterceptorCallable | None:
+) -> Callable[[grpc.Channel], grpc.Channel] | None:
     """Returns an interceptor callable that wraps a sync gRPC channel with OpenTelemetry tracing.
 
     Args:
@@ -96,7 +97,7 @@ def get_otel_interceptor(
             and extracting the tracer provider.
 
     Returns:
-        Optional[ClientInterceptorCallable]: An interceptor callable if OpenTelemetry
+        Optional[Callable[[grpc.Channel], grpc.Channel]]: An interceptor callable if OpenTelemetry
             tracing is enabled and installed, None otherwise.
     """
     if not is_otel_capabilities_enabled(client_options):
@@ -106,7 +107,7 @@ def get_otel_interceptor(
 
     interceptor = _get_otel_interceptor(client_options, is_async=False)
 
-    def otel_interceptor(channel: Any) -> Any:
+    def otel_interceptor(channel: grpc.Channel) -> grpc.Channel:
         return otel_grpc.intercept_channel(channel, interceptor)
 
     return otel_interceptor

--- a/packages/google-api-core/google/api_core/_observability.py
+++ b/packages/google-api-core/google/api_core/_observability.py
@@ -22,9 +22,9 @@ from google.api_core import _feature_gating_helpers
 from google.api_core.client_options import ClientOptions
 
 if TYPE_CHECKING:
-    from google.api_core.grpc_helpers import ChannelWrapperCallable
+    from google.api_core.grpc_helpers import ClientInterceptorCallable
 else:
-    ChannelWrapperCallable = Callable[[Any], Any]
+    ClientInterceptorCallable = Callable[[Any], Any]
 
 _TRACER_PROVIDER = "tracer_provider"
 
@@ -67,7 +67,7 @@ def _get_otel_interceptor(
 
     Args:
         client_options: The client options object or dictionary.
-        is_async: If True, returns an async interceptor (`aio_client_interceptor`),
+        is_async: If True, returns an async interceptor (`aio_client_interceptors`),
             otherwise returns a sync interceptor (`client_interceptor`).
 
     Returns:
@@ -86,17 +86,17 @@ def _get_otel_interceptor(
     return otel_grpc.client_interceptor(tracer_provider=tracer_provider)
 
 
-def get_otel_channel_wrapper(
+def get_otel_interceptor(
     client_options: ClientOptions | dict[str, Any] | None = None,
-) -> ChannelWrapperCallable | None:
-    """Returns a channel wrapper callable that wraps a sync gRPC channel with OpenTelemetry tracing.
+) -> ClientInterceptorCallable | None:
+    """Returns an interceptor callable that wraps a sync gRPC channel with OpenTelemetry tracing.
 
     Args:
         client_options: The client options object or dictionary used for feature gating
             and extracting the tracer provider.
 
     Returns:
-        Optional[ChannelWrapperCallable]: A channel-wrapping callable if OpenTelemetry
+        Optional[ClientInterceptorCallable]: An interceptor callable if OpenTelemetry
             tracing is enabled and installed, None otherwise.
     """
     if not is_otel_capabilities_enabled(client_options):
@@ -106,23 +106,23 @@ def get_otel_channel_wrapper(
 
     interceptor = _get_otel_interceptor(client_options, is_async=False)
 
-    def channel_wrapper(channel: Any) -> Any:
+    def otel_interceptor(channel: Any) -> Any:
         return otel_grpc.intercept_channel(channel, interceptor)
 
-    return channel_wrapper
+    return otel_interceptor
 
 
 def get_otel_async_interceptor(
     client_options: ClientOptions | dict[str, Any] | None = None,
 ) -> Any | None:
-    """Returns an async gRPC client interceptor for OpenTelemetry tracing.
+    """Returns async gRPC client interceptors for OpenTelemetry tracing.
 
     Args:
         client_options: The client options object or dictionary used for feature gating
             and extracting the tracer provider.
 
     Returns:
-        Optional[Any]: An instantiated OpenTelemetry async client interceptor
+        Optional[Any]: Instantiated OpenTelemetry async client interceptors
             if tracing is enabled and installed, None otherwise.
     """
     if not is_otel_capabilities_enabled(client_options):

--- a/packages/google-api-core/google/api_core/_observability.py
+++ b/packages/google-api-core/google/api_core/_observability.py
@@ -26,7 +26,7 @@ _TRACER_PROVIDER = "tracer_provider"
 
 def is_otel_capabilities_enabled(
     client_options: Optional[ClientOptions | dict[str, Any]] = None,
-    env_var: str = "GOOGLE_CLOUD_PYTHON_TRACING_ENABLED",
+    env_var: str = "GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED",
 ) -> bool:
     """Checks if OTel capabilities are enabled and installed.
 

--- a/packages/google-api-core/google/api_core/_observability.py
+++ b/packages/google-api-core/google/api_core/_observability.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from google.api_core import _feature_gating_helpers
 from google.api_core.client_options import ClientOptions
@@ -115,7 +115,7 @@ def get_otel_interceptor(
 
 def get_otel_async_interceptor(
     client_options: ClientOptions | dict[str, Any] | None = None,
-) -> Any | None:
+) -> Sequence[grpc.aio.ClientInterceptor] | None:
     """Returns async gRPC client interceptors for OpenTelemetry tracing.
 
     Args:
@@ -123,8 +123,8 @@ def get_otel_async_interceptor(
             and extracting the tracer provider.
 
     Returns:
-        Optional[Any]: Instantiated OpenTelemetry async client interceptors
-            if tracing is enabled and installed, None otherwise.
+        Optional[Sequence[grpc.aio.ClientInterceptor]]: Instantiated OpenTelemetry async
+            client interceptors if tracing is enabled and installed, None otherwise.
     """
     if not is_otel_capabilities_enabled(client_options):
         return None

--- a/packages/google-api-core/google/api_core/_observability.py
+++ b/packages/google-api-core/google/api_core/_observability.py
@@ -16,16 +16,21 @@
 
 """OpenTelemetry helpers for resolving and instantiating interceptors."""
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 from google.api_core import _feature_gating_helpers
 from google.api_core.client_options import ClientOptions
+
+if TYPE_CHECKING:
+    from google.api_core.grpc_helpers import ChannelWrapperCallable
+else:
+    ChannelWrapperCallable = Callable[[Any], Any]
 
 _TRACER_PROVIDER = "tracer_provider"
 
 
 def is_otel_capabilities_enabled(
-    client_options: Optional[ClientOptions | dict[str, Any]] = None,
+    client_options: ClientOptions | dict[str, Any] | None = None,
     env_var: str = "GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED",
 ) -> bool:
     """Checks if OTel capabilities are enabled and installed.
@@ -54,26 +59,19 @@ def is_otel_capabilities_enabled(
     return False
 
 
-def apply_otel_capabilities_to_channel(
-    channel: Any,
-    client_options: Optional[ClientOptions | dict[str, Any]] = None,
+def _get_otel_interceptor(
+    client_options: ClientOptions | dict[str, Any] | None = None,
+    is_async: bool = False,
 ) -> Any:
-    """Applies OTel capabilities (like tracing) to the channel.
-
-    Precondition: This function assumes `is_otel_capabilities_enabled` has already
-    been called and returned `True`, i.e. in the Client. At this time
-    this function is not intended to be standalone.
+    """Instantiates a sync or async OpenTelemetry gRPC client interceptor.
 
     Args:
-        channel: The raw gRPC channel to wrap.
         client_options: The client options object or dictionary.
+        is_async: If True, returns an async interceptor (`aio_client_interceptor`),
+            otherwise returns a sync interceptor (`client_interceptor`).
 
     Returns:
-        Any: The intercepted channel.
-
-    Raises:
-        ImportError: If OpenTelemetry packages are not installed and this function
-            is called directly (bypassing the precondition).
+        Any: The instantiated OpenTelemetry client interceptor.
     """
     import opentelemetry.instrumentation.grpc as otel_grpc  # type: ignore[import-not-found]
 
@@ -83,7 +81,51 @@ def apply_otel_capabilities_to_channel(
     elif client_options is not None:
         tracer_provider = getattr(client_options, _TRACER_PROVIDER, None)
 
-    interceptor = otel_grpc.client_interceptor(tracer_provider=tracer_provider)
+    if is_async:
+        return otel_grpc.aio_client_interceptors(tracer_provider=tracer_provider)
+    return otel_grpc.client_interceptor(tracer_provider=tracer_provider)
 
-    # We use OTel's own compatible applier to avoid standard gRPC TypeError.
-    return otel_grpc.intercept_channel(channel, interceptor)
+
+def get_otel_channel_wrapper(
+    client_options: ClientOptions | dict[str, Any] | None = None,
+) -> ChannelWrapperCallable | None:
+    """Returns a channel wrapper callable that wraps a sync gRPC channel with OpenTelemetry tracing.
+
+    Args:
+        client_options: The client options object or dictionary used for feature gating
+            and extracting the tracer provider.
+
+    Returns:
+        Optional[ChannelWrapperCallable]: A channel-wrapping callable if OpenTelemetry
+            tracing is enabled and installed, None otherwise.
+    """
+    if not is_otel_capabilities_enabled(client_options):
+        return None
+
+    import opentelemetry.instrumentation.grpc as otel_grpc  # type: ignore[import-not-found]
+
+    interceptor = _get_otel_interceptor(client_options, is_async=False)
+
+    def channel_wrapper(channel: Any) -> Any:
+        return otel_grpc.intercept_channel(channel, interceptor)
+
+    return channel_wrapper
+
+
+def get_otel_async_interceptor(
+    client_options: ClientOptions | dict[str, Any] | None = None,
+) -> Any | None:
+    """Returns an async gRPC client interceptor for OpenTelemetry tracing.
+
+    Args:
+        client_options: The client options object or dictionary used for feature gating
+            and extracting the tracer provider.
+
+    Returns:
+        Optional[Any]: An instantiated OpenTelemetry async client interceptor
+            if tracing is enabled and installed, None otherwise.
+    """
+    if not is_otel_capabilities_enabled(client_options):
+        return None
+
+    return _get_otel_interceptor(client_options, is_async=True)

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -432,8 +432,8 @@ def apply_interceptors(
 ) -> grpc.Channel:
     """Applies a sequence of interceptors to a gRPC channel.
 
-    The interceptors are applied in the order provided, wrapping the channel
-    sequentially.
+    The interceptors are applied in the order provided, such that the first
+    interceptor in the sequence is the outermost layer (executes first).
 
     Args:
         channel (grpc.Channel): The channel to intercept.
@@ -445,8 +445,7 @@ def apply_interceptors(
             interceptors were provided.
     """
     if interceptors:
-        for interceptor in interceptors:
-            channel = grpc.intercept_channel(channel, interceptor)
+        return grpc.intercept_channel(channel, *interceptors)
     return channel
 
 

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -35,7 +35,6 @@ import google.auth.transport.grpc
 import google.auth.transport.requests
 import google.protobuf
 import grpc
-
 from google.api_core import exceptions, general_helpers
 
 # The list of gRPC Callable interfaces that return iterators.
@@ -54,12 +53,6 @@ ClientInterceptor: TypeAlias = (
 
 # Runtime tuple of gRPC client interceptor base classes for isinstance checks
 _CLIENT_INTERCEPTOR_CLASSES = get_args(ClientInterceptor)
-
-# Type alias representing a channel-intercepting callable
-ClientInterceptorCallable: TypeAlias = Callable[[grpc.Channel], grpc.Channel]
-
-# Generic type alias representing any client interceptor (standard interceptor or callable)
-ClientInterceptorType: TypeAlias = ClientInterceptor | ClientInterceptorCallable
 
 
 def _patch_callable_name(callable_):
@@ -448,7 +441,9 @@ def _modify_target_for_direct_path(target: str) -> str:
 
 def apply_channel_interceptors(
     channel: grpc.Channel,
-    interceptors: Sequence[ClientInterceptorType] | None = None,
+    interceptors: (
+        Sequence[ClientInterceptor | Callable[[grpc.Channel], grpc.Channel]] | None
+    ) = None,
 ) -> grpc.Channel:
     """Applies client interceptors or channel-intercepting callables to a gRPC channel.
 
@@ -478,7 +473,9 @@ def apply_channel_interceptors(
         if isinstance(interceptor, _CLIENT_INTERCEPTOR_CLASSES):
             modified_channel = grpc.intercept_channel(modified_channel, interceptor)
         elif callable(interceptor):
-            interceptor_callable = cast(ClientInterceptorCallable, interceptor)
+            interceptor_callable = cast(
+                Callable[[grpc.Channel], grpc.Channel], interceptor
+            )
             modified_channel = interceptor_callable(modified_channel)
         else:
             raise TypeError(

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -17,7 +17,7 @@
 import collections
 import functools
 import warnings
-from typing import Generic, Iterator, Optional, TypeVar
+from typing import Generic, Iterator, Optional, Sequence, TypeVar, Union
 
 import google.auth
 import google.auth.credentials
@@ -25,7 +25,6 @@ import google.auth.transport.grpc
 import google.auth.transport.requests
 import google.protobuf
 import grpc
-
 from google.api_core import exceptions, general_helpers
 
 # The list of gRPC Callable interfaces that return iterators.
@@ -33,6 +32,14 @@ _STREAM_WRAP_CLASSES = (grpc.UnaryStreamMultiCallable, grpc.StreamStreamMultiCal
 
 # denotes the proto response type for grpc calls
 P = TypeVar("P")
+
+# Type alias representing any client-side gRPC interceptor
+ClientInterceptor = Union[
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+]
 
 
 def _patch_callable_name(callable_):
@@ -417,6 +424,30 @@ def _modify_target_for_direct_path(target: str) -> str:
         # Modify the target to use Direct Path by adding the `google-c2p:///` prefix
         target = f"google-c2p{direct_path_separator}{target_without_port}"
     return target
+
+
+def apply_interceptors(
+    channel: grpc.Channel,
+    interceptors: Optional[Sequence[ClientInterceptor]] = None,
+) -> grpc.Channel:
+    """Applies a sequence of interceptors to a gRPC channel.
+
+    The interceptors are applied in the order provided, wrapping the channel
+    sequentially.
+
+    Args:
+        channel (grpc.Channel): The channel to intercept.
+        interceptors (Optional[Sequence[ClientInterceptor]]): An optional sequence
+            of client interceptors to apply.
+
+    Returns:
+        grpc.Channel: The intercepted channel, or the original channel if no
+            interceptors were provided.
+    """
+    if interceptors:
+        for interceptor in interceptors:
+            channel = grpc.intercept_channel(channel, interceptor)
+    return channel
 
 
 _MethodCall = collections.namedtuple(

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -34,6 +34,7 @@ import google.auth.transport.grpc
 import google.auth.transport.requests
 import google.protobuf
 import grpc
+
 from google.api_core import exceptions, general_helpers
 
 # The list of gRPC Callable interfaces that return iterators.

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -35,7 +35,6 @@ import google.auth.transport.grpc
 import google.auth.transport.requests
 import google.protobuf
 import grpc
-
 from google.api_core import exceptions, general_helpers
 
 # The list of gRPC Callable interfaces that return iterators.
@@ -55,11 +54,11 @@ ClientInterceptor: TypeAlias = (
 # Runtime tuple of gRPC client interceptor base classes for isinstance checks
 _CLIENT_INTERCEPTOR_CLASSES = get_args(ClientInterceptor)
 
-# Type alias representing a channel-wrapping callable
-ChannelWrapperCallable: TypeAlias = Callable[[grpc.Channel], grpc.Channel]
+# Type alias representing a channel-intercepting callable
+ClientInterceptorCallable: TypeAlias = Callable[[grpc.Channel], grpc.Channel]
 
-# Generic type alias representing any channel wrapper (interceptor or callable)
-ChannelWrapper: TypeAlias = ClientInterceptor | ChannelWrapperCallable
+# Generic type alias representing any client interceptor (standard interceptor or callable)
+ClientInterceptorType: TypeAlias = ClientInterceptor | ClientInterceptorCallable
 
 
 def _patch_callable_name(callable_):
@@ -446,43 +445,43 @@ def _modify_target_for_direct_path(target: str) -> str:
     return target
 
 
-def apply_channel_wrappers(
+def apply_channel_interceptors(
     channel: grpc.Channel,
-    wrappers: Sequence[ChannelWrapper] | None = None,
+    interceptors: Sequence[ClientInterceptorType] | None = None,
 ) -> grpc.Channel:
-    """Applies channel wrappers (client interceptors or channel-wrapping callables) to a gRPC channel.
+    """Applies client interceptors or channel-intercepting callables to a gRPC channel.
 
-    Executes in reverse order so the first wrapper in the sequence becomes the
-    outermost layer on outbound requests and the innermost layer on inbound responses.
+    Executes in reverse order so the first interceptor in the sequence becomes the
+    outermost layer on outbound requests and the innermost layer on inbound responses,
+    aligning with the behavior of ``grpc.intercept_channel``.
 
     Args:
-        channel (grpc.Channel): The channel to wrap.
-        wrappers (Optional[Sequence[ChannelWrapper]]):
-            An optional sequence of client interceptors or channel-wrapping
-            callables to apply.
+        channel (grpc.Channel): The channel to intercept.
+        interceptors (Optional[Sequence[Union[ClientInterceptor, Callable[[grpc.Channel], grpc.Channel]]]]):
+            Additional interceptors (or callables that apply interceptors) to apply to the gRPC channel.
 
     Returns:
-        grpc.Channel: The wrapped channel, or the original channel if no
-            wrappers were provided.
+        grpc.Channel: The intercepted channel, or the original channel if no
+            interceptors were provided.
 
     Raises:
-        TypeError: If an item in ``wrappers`` is neither a gRPC ClientInterceptor
+        TypeError: If an item in ``interceptors`` is neither a gRPC ClientInterceptor
             nor a Callable[[Channel], Channel].
     """
-    if not wrappers:
+    if not interceptors:
         return channel
 
     modified_channel = channel
     # Reverse the inputs to align with the behavior of grpc.create_channel(*interceptors)
-    for wrapper in reversed(list(wrappers)):
-        if isinstance(wrapper, _CLIENT_INTERCEPTOR_CLASSES):
-            modified_channel = grpc.intercept_channel(modified_channel, wrapper)
-        elif callable(wrapper):
-            wrapper_callable = cast(ChannelWrapperCallable, wrapper)
-            modified_channel = wrapper_callable(modified_channel)
+    for interceptor in reversed(list(interceptors)):
+        if isinstance(interceptor, _CLIENT_INTERCEPTOR_CLASSES):
+            modified_channel = grpc.intercept_channel(modified_channel, interceptor)
+        elif callable(interceptor):
+            interceptor_callable = cast(ClientInterceptorCallable, interceptor)
+            modified_channel = interceptor_callable(modified_channel)
         else:
             raise TypeError(
-                f"Expected ChannelWrapper (ClientInterceptor or Callable[[Channel], Channel]), got {type(wrapper).__name__}"
+                f"Expected ClientInterceptor or Callable[[Channel], Channel], got {type(interceptor).__name__}"
             )
 
     return modified_channel

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -23,7 +23,9 @@ from typing import (
     Iterator,
     Optional,
     Sequence,
+    TypeAlias,
     TypeVar,
+    cast,
     get_args,
 )
 
@@ -43,7 +45,7 @@ _STREAM_WRAP_CLASSES = (grpc.UnaryStreamMultiCallable, grpc.StreamStreamMultiCal
 P = TypeVar("P")
 
 # Type alias representing any client-side gRPC interceptor
-ClientInterceptor = (
+ClientInterceptor: TypeAlias = (
     grpc.UnaryUnaryClientInterceptor
     | grpc.UnaryStreamClientInterceptor
     | grpc.StreamUnaryClientInterceptor
@@ -54,10 +56,10 @@ ClientInterceptor = (
 _CLIENT_INTERCEPTOR_CLASSES = get_args(ClientInterceptor)
 
 # Type alias representing a channel-wrapping callable
-ChannelWrapperCallable = Callable[[grpc.Channel], grpc.Channel]
+ChannelWrapperCallable: TypeAlias = Callable[[grpc.Channel], grpc.Channel]
 
 # Generic type alias representing any channel wrapper (interceptor or callable)
-ChannelWrapper = ClientInterceptor | ChannelWrapperCallable
+ChannelWrapper: TypeAlias = ClientInterceptor | ChannelWrapperCallable
 
 
 def _patch_callable_name(callable_):
@@ -476,7 +478,8 @@ def apply_channel_wrappers(
         if isinstance(wrapper, _CLIENT_INTERCEPTOR_CLASSES):
             modified_channel = grpc.intercept_channel(modified_channel, wrapper)
         elif callable(wrapper):
-            modified_channel = wrapper(modified_channel)
+            wrapper_callable = cast(ChannelWrapperCallable, wrapper)
+            modified_channel = wrapper_callable(modified_channel)
         else:
             raise TypeError(
                 f"Expected ChannelWrapper (ClientInterceptor or Callable[[Channel], Channel]), got {type(wrapper).__name__}"

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -17,7 +17,16 @@
 import collections
 import functools
 import warnings
-from typing import Generic, Iterator, Optional, Sequence, TypeVar, Union
+from typing import (
+    Callable,
+    Generic,
+    Iterator,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    get_args,
+)
 
 import google.auth
 import google.auth.credentials
@@ -40,6 +49,15 @@ ClientInterceptor = Union[
     grpc.StreamUnaryClientInterceptor,
     grpc.StreamStreamClientInterceptor,
 ]
+
+# Runtime tuple of gRPC client interceptor base classes for isinstance checks
+_CLIENT_INTERCEPTOR_CLASSES = get_args(ClientInterceptor)
+
+# Type alias representing a channel-wrapping callable
+ChannelWrapperCallable = Callable[[grpc.Channel], grpc.Channel]
+
+# Generic type alias representing any channel wrapper (interceptor or callable)
+ChannelWrapper = Union[ClientInterceptor, ChannelWrapperCallable]
 
 
 def _patch_callable_name(callable_):
@@ -426,27 +444,44 @@ def _modify_target_for_direct_path(target: str) -> str:
     return target
 
 
-def apply_interceptors(
+def apply_channel_wrappers(
     channel: grpc.Channel,
-    interceptors: Optional[Sequence[ClientInterceptor]] = None,
+    wrappers: Optional[Sequence[ChannelWrapper]] = None,
 ) -> grpc.Channel:
-    """Applies client interceptors to a gRPC channel.
+    """Applies channel wrappers (client interceptors or channel-wrapping callables) to a gRPC channel.
 
-    The first interceptor in the sequence is the outermost layer: it
-    executes first on outbound requests and last on inbound responses.
+    Executes in reverse order so the first wrapper in the sequence becomes the
+    outermost layer on outbound requests and the innermost layer on inbound responses.
 
     Args:
-        channel (grpc.Channel): The channel to intercept.
-        interceptors (Optional[Sequence[ClientInterceptor]]): An optional sequence
-            of client interceptors to apply.
+        channel (grpc.Channel): The channel to wrap.
+        wrappers (Optional[Sequence[ChannelWrapper]]):
+            An optional sequence of client interceptors or channel-wrapping
+            callables to apply.
 
     Returns:
-        grpc.Channel: The intercepted channel, or the original channel if no
-            interceptors were provided.
+        grpc.Channel: The wrapped channel, or the original channel if no
+            wrappers were provided.
+
+    Raises:
+        TypeError: If an item in ``wrappers`` is neither a gRPC ClientInterceptor
+            nor a Callable[[Channel], Channel].
     """
-    if interceptors:
-        return grpc.intercept_channel(channel, *interceptors)
-    return channel
+    if not wrappers:
+        return channel
+
+    modified_channel = channel
+    for wrapper in reversed(list(wrappers)):
+        if isinstance(wrapper, _CLIENT_INTERCEPTOR_CLASSES):
+            modified_channel = grpc.intercept_channel(modified_channel, wrapper)
+        elif callable(wrapper):
+            modified_channel = wrapper(modified_channel)
+        else:
+            raise TypeError(
+                f"Expected ChannelWrapper (ClientInterceptor or Callable[[Channel], Channel]), got {type(wrapper).__name__}"
+            )
+
+    return modified_channel
 
 
 _MethodCall = collections.namedtuple(

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -430,10 +430,10 @@ def apply_interceptors(
     channel: grpc.Channel,
     interceptors: Optional[Sequence[ClientInterceptor]] = None,
 ) -> grpc.Channel:
-    """Applies a sequence of interceptors to a gRPC channel.
+    """Applies client interceptors to a gRPC channel.
 
-    The interceptors are applied in the order provided, such that the first
-    interceptor in the sequence is the outermost layer (executes first).
+    The first interceptor in the sequence is the outermost layer: it
+    executes first on outbound requests and last on inbound responses.
 
     Args:
         channel (grpc.Channel): The channel to intercept.

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -24,7 +24,6 @@ from typing import (
     Optional,
     Sequence,
     TypeVar,
-    Union,
     get_args,
 )
 
@@ -44,12 +43,12 @@ _STREAM_WRAP_CLASSES = (grpc.UnaryStreamMultiCallable, grpc.StreamStreamMultiCal
 P = TypeVar("P")
 
 # Type alias representing any client-side gRPC interceptor
-ClientInterceptor = Union[
-    grpc.UnaryUnaryClientInterceptor,
-    grpc.UnaryStreamClientInterceptor,
-    grpc.StreamUnaryClientInterceptor,
-    grpc.StreamStreamClientInterceptor,
-]
+ClientInterceptor = (
+    grpc.UnaryUnaryClientInterceptor
+    | grpc.UnaryStreamClientInterceptor
+    | grpc.StreamUnaryClientInterceptor
+    | grpc.StreamStreamClientInterceptor
+)
 
 # Runtime tuple of gRPC client interceptor base classes for isinstance checks
 _CLIENT_INTERCEPTOR_CLASSES = get_args(ClientInterceptor)
@@ -58,7 +57,7 @@ _CLIENT_INTERCEPTOR_CLASSES = get_args(ClientInterceptor)
 ChannelWrapperCallable = Callable[[grpc.Channel], grpc.Channel]
 
 # Generic type alias representing any channel wrapper (interceptor or callable)
-ChannelWrapper = Union[ClientInterceptor, ChannelWrapperCallable]
+ChannelWrapper = ClientInterceptor | ChannelWrapperCallable
 
 
 def _patch_callable_name(callable_):
@@ -447,7 +446,7 @@ def _modify_target_for_direct_path(target: str) -> str:
 
 def apply_channel_wrappers(
     channel: grpc.Channel,
-    wrappers: Optional[Sequence[ChannelWrapper]] = None,
+    wrappers: Sequence[ChannelWrapper] | None = None,
 ) -> grpc.Channel:
     """Applies channel wrappers (client interceptors or channel-wrapping callables) to a gRPC channel.
 
@@ -472,6 +471,7 @@ def apply_channel_wrappers(
         return channel
 
     modified_channel = channel
+    # Reverse the inputs to align with the behavior of grpc.create_channel(*interceptors)
     for wrapper in reversed(list(wrappers)):
         if isinstance(wrapper, _CLIENT_INTERCEPTOR_CLASSES):
             modified_channel = grpc.intercept_channel(modified_channel, wrapper)

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -35,6 +35,7 @@ import google.auth.transport.grpc
 import google.auth.transport.requests
 import google.protobuf
 import grpc
+
 from google.api_core import exceptions, general_helpers
 
 # The list of gRPC Callable interfaces that return iterators.

--- a/packages/google-api-core/tests/unit/test_client_options.py
+++ b/packages/google-api-core/tests/unit/test_client_options.py
@@ -15,6 +15,7 @@
 from re import match
 
 import pytest
+
 from google.api_core import client_options
 
 from ..helpers import warn_deprecated_credentials_file

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -933,32 +933,100 @@ class TestChannelStub(object):
         assert channel.close() is None
 
 
-@pytest.mark.parametrize("falsy_interceptors", [None, [], ()])
-def test_apply_interceptors_passthrough(falsy_interceptors):
-    """Verify that falsy or empty interceptor sequences return the channel unmodified."""
+@pytest.mark.parametrize("falsy_wrappers", [None, [], ()])
+def test_apply_channel_wrappers_passthrough(falsy_wrappers):
+    """Verify that falsy or empty wrapper sequences return the channel unmodified."""
     mock_base_channel = mock.Mock(name="base_channel")
-    result = grpc_helpers.apply_interceptors(mock_base_channel, falsy_interceptors)
+    result = grpc_helpers.apply_channel_wrappers(mock_base_channel, falsy_wrappers)
     assert result is mock_base_channel
 
 
-@pytest.mark.parametrize("count", [1, 2, 3])
-def test_apply_interceptors_wrapping(count):
-    """Verify that interceptors are passed to grpc.intercept_channel unpacked in a single call.
+def test_apply_channel_wrappers_grpc_client_interceptors():
+    """Verify that standard gRPC ClientInterceptor instances are applied via grpc.intercept_channel."""
 
-    When given a sequence of N interceptors [i_0, i_1, ..., i_{N-1}], apply_interceptors
-    must pass the base channel and all interceptors unpacked (*interceptors) to
-    grpc.intercept_channel.
-    """
+    class DummyUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
+        def intercept_unary_unary(self, continuation, client_call_details, request):
+            return continuation(client_call_details, request)
+
+    class DummyStreamInterceptor(grpc.StreamStreamClientInterceptor):
+        def intercept_stream_stream(
+            self, continuation, client_call_details, request_iterator
+        ):
+            return continuation(client_call_details, request_iterator)
+
+    interceptor1 = DummyUnaryInterceptor()
+    interceptor2 = DummyStreamInterceptor()
+
     mock_base_channel = mock.Mock(name="base_channel")
-    mock_wrapped_channel = mock.Mock(name="wrapped_channel")
-    mock_interceptors = [mock.Mock(name=f"interceptor_{i}") for i in range(count)]
+    mock_chan_after_i2 = mock.Mock(name="chan_after_i2")
+    mock_chan_after_i1 = mock.Mock(name="chan_after_i1")
 
     with mock.patch(
-        "grpc.intercept_channel", return_value=mock_wrapped_channel
-    ) as mock_intercept_channel:
-        result = grpc_helpers.apply_interceptors(mock_base_channel, mock_interceptors)
+        "grpc.intercept_channel",
+        side_effect=[mock_chan_after_i2, mock_chan_after_i1],
+    ) as mock_intercept:
+        result = grpc_helpers.apply_channel_wrappers(
+            mock_base_channel, [interceptor1, interceptor2]
+        )
 
-    assert result is mock_wrapped_channel
-    mock_intercept_channel.assert_called_once_with(
-        mock_base_channel, *mock_interceptors
+    assert result is mock_chan_after_i1
+    assert mock_intercept.call_count == 2
+    # Executed in reverse order so interceptor1 is outermost
+    mock_intercept.assert_has_calls(
+        [
+            mock.call(mock_base_channel, interceptor2),
+            mock.call(mock_chan_after_i2, interceptor1),
+        ]
     )
+
+
+def test_apply_channel_wrappers_callables():
+    """Verify that channel-wrapping callables Callable[[Channel], Channel] are invoked in sequence."""
+    mock_base_channel = mock.Mock(name="base_channel")
+    mock_chan_1 = mock.Mock(name="chan_1")
+    mock_chan_2 = mock.Mock(name="chan_2")
+
+    wrapper1 = mock.Mock(side_effect=lambda ch: mock_chan_2)
+    wrapper2 = mock.Mock(side_effect=lambda ch: mock_chan_1)
+
+    result = grpc_helpers.apply_channel_wrappers(
+        mock_base_channel, [wrapper1, wrapper2]
+    )
+
+    assert result is mock_chan_2
+    # Executed in reverse order: wrapper2 runs first on base channel, then wrapper1
+    wrapper2.assert_called_once_with(mock_base_channel)
+    wrapper1.assert_called_once_with(mock_chan_1)
+
+
+def test_apply_channel_wrappers_interspersed():
+    """Verify that a mixed sequence of gRPC interceptors and channel wrapper callables are applied."""
+
+    class DummyUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
+        def intercept_unary_unary(self, continuation, client_call_details, request):
+            return continuation(client_call_details, request)
+
+    interceptor = DummyUnaryInterceptor()
+    mock_base_channel = mock.Mock(name="base_channel")
+    mock_chan_after_wrapper = mock.Mock(name="chan_after_wrapper")
+    mock_chan_after_interceptor = mock.Mock(name="chan_after_interceptor")
+
+    wrapper = mock.Mock(return_value=mock_chan_after_wrapper)
+
+    with mock.patch(
+        "grpc.intercept_channel", return_value=mock_chan_after_interceptor
+    ) as mock_intercept:
+        result = grpc_helpers.apply_channel_wrappers(
+            mock_base_channel, [interceptor, wrapper]
+        )
+
+    assert result is mock_chan_after_interceptor
+    wrapper.assert_called_once_with(mock_base_channel)
+    mock_intercept.assert_called_once_with(mock_chan_after_wrapper, interceptor)
+
+
+def test_apply_channel_wrappers_invalid_type_raises():
+    """Verify that passing an invalid object that is neither an interceptor nor callable raises TypeError."""
+    mock_base_channel = mock.Mock(name="base_channel")
+    with pytest.raises(TypeError, match="Expected ChannelWrapper"):
+        grpc_helpers.apply_channel_wrappers(mock_base_channel, [12345])

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -24,9 +24,8 @@ except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 import google.auth.credentials
-from google.longrunning import operations_pb2
-
 from google.api_core import exceptions, grpc_helpers
+from google.longrunning import operations_pb2
 
 
 def test__patch_callable_name():
@@ -934,15 +933,17 @@ class TestChannelStub(object):
         assert channel.close() is None
 
 
-@pytest.mark.parametrize("falsy_wrappers", [None, [], ()])
-def test_apply_channel_wrappers_passthrough(falsy_wrappers):
-    """Verify that falsy or empty wrapper sequences return the channel unmodified."""
+@pytest.mark.parametrize("falsy_interceptors", [None, [], ()])
+def test_apply_channel_interceptors_passthrough(falsy_interceptors):
+    """Verify that falsy or empty interceptor sequences return the channel unmodified."""
     mock_base_channel = mock.Mock(name="base_channel")
-    result = grpc_helpers.apply_channel_wrappers(mock_base_channel, falsy_wrappers)
+    result = grpc_helpers.apply_channel_interceptors(
+        mock_base_channel, falsy_interceptors
+    )
     assert result is mock_base_channel
 
 
-def test_apply_channel_wrappers_grpc_client_interceptors():
+def test_apply_channel_interceptors_grpc_client_interceptors():
     """Verify that standard gRPC ClientInterceptor instances are applied via grpc.intercept_channel."""
 
     class DummyUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
@@ -966,7 +967,7 @@ def test_apply_channel_wrappers_grpc_client_interceptors():
         "grpc.intercept_channel",
         side_effect=[mock_chan_after_i2, mock_chan_after_i1],
     ) as mock_intercept:
-        result = grpc_helpers.apply_channel_wrappers(
+        result = grpc_helpers.apply_channel_interceptors(
             mock_base_channel, [interceptor1, interceptor2]
         )
 
@@ -981,27 +982,27 @@ def test_apply_channel_wrappers_grpc_client_interceptors():
     )
 
 
-def test_apply_channel_wrappers_callables():
-    """Verify that channel-wrapping callables Callable[[Channel], Channel] are invoked in sequence."""
+def test_apply_channel_interceptors_callables():
+    """Verify that channel-intercepting callables Callable[[Channel], Channel] are invoked in sequence."""
     mock_base_channel = mock.Mock(name="base_channel")
     mock_chan_1 = mock.Mock(name="chan_1")
     mock_chan_2 = mock.Mock(name="chan_2")
 
-    wrapper1 = mock.Mock(side_effect=lambda ch: mock_chan_2)
-    wrapper2 = mock.Mock(side_effect=lambda ch: mock_chan_1)
+    interceptor1 = mock.Mock(side_effect=lambda ch: mock_chan_2)
+    interceptor2 = mock.Mock(side_effect=lambda ch: mock_chan_1)
 
-    result = grpc_helpers.apply_channel_wrappers(
-        mock_base_channel, [wrapper1, wrapper2]
+    result = grpc_helpers.apply_channel_interceptors(
+        mock_base_channel, [interceptor1, interceptor2]
     )
 
     assert result is mock_chan_2
-    # Executed in reverse order: wrapper2 runs first on base channel, then wrapper1
-    wrapper2.assert_called_once_with(mock_base_channel)
-    wrapper1.assert_called_once_with(mock_chan_1)
+    # Executed in reverse order: interceptor2 runs first on base channel, then interceptor1
+    interceptor2.assert_called_once_with(mock_base_channel)
+    interceptor1.assert_called_once_with(mock_chan_1)
 
 
-def test_apply_channel_wrappers_interspersed():
-    """Verify that a mixed sequence of gRPC interceptors and channel wrapper callables are applied."""
+def test_apply_channel_interceptors_interspersed():
+    """Verify that a mixed sequence of gRPC interceptors and interceptor callables are applied."""
 
     class DummyUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
         def intercept_unary_unary(self, continuation, client_call_details, request):
@@ -1009,25 +1010,25 @@ def test_apply_channel_wrappers_interspersed():
 
     interceptor = DummyUnaryInterceptor()
     mock_base_channel = mock.Mock(name="base_channel")
-    mock_chan_after_wrapper = mock.Mock(name="chan_after_wrapper")
+    mock_chan_after_callable = mock.Mock(name="chan_after_callable")
     mock_chan_after_interceptor = mock.Mock(name="chan_after_interceptor")
 
-    wrapper = mock.Mock(return_value=mock_chan_after_wrapper)
+    interceptor_callable = mock.Mock(return_value=mock_chan_after_callable)
 
     with mock.patch(
         "grpc.intercept_channel", return_value=mock_chan_after_interceptor
     ) as mock_intercept:
-        result = grpc_helpers.apply_channel_wrappers(
-            mock_base_channel, [interceptor, wrapper]
+        result = grpc_helpers.apply_channel_interceptors(
+            mock_base_channel, [interceptor, interceptor_callable]
         )
 
     assert result is mock_chan_after_interceptor
-    wrapper.assert_called_once_with(mock_base_channel)
-    mock_intercept.assert_called_once_with(mock_chan_after_wrapper, interceptor)
+    interceptor_callable.assert_called_once_with(mock_base_channel)
+    mock_intercept.assert_called_once_with(mock_chan_after_callable, interceptor)
 
 
-def test_apply_channel_wrappers_invalid_type_raises():
+def test_apply_channel_interceptors_invalid_type_raises():
     """Verify that passing an invalid object that is neither an interceptor nor callable raises TypeError."""
     mock_base_channel = mock.Mock(name="base_channel")
-    with pytest.raises(TypeError, match="Expected ChannelWrapper"):
-        grpc_helpers.apply_channel_wrappers(mock_base_channel, [12345])
+    with pytest.raises(TypeError, match="Expected ClientInterceptor or Callable"):
+        grpc_helpers.apply_channel_interceptors(mock_base_channel, [12345])

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -24,8 +24,9 @@ except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 import google.auth.credentials
-from google.api_core import exceptions, grpc_helpers
 from google.longrunning import operations_pb2
+
+from google.api_core import exceptions, grpc_helpers
 
 
 def test__patch_callable_name():

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -936,9 +936,9 @@ class TestChannelStub(object):
 @pytest.mark.parametrize("falsy_interceptors", [None, [], ()])
 def test_apply_interceptors_passthrough(falsy_interceptors):
     """Verify that falsy or empty interceptor sequences return the channel unmodified."""
-    mock_channel = mock.Mock()
-    result = grpc_helpers.apply_interceptors(mock_channel, falsy_interceptors)
-    assert result is mock_channel
+    mock_base_channel = mock.Mock(name="base_channel")
+    result = grpc_helpers.apply_interceptors(mock_base_channel, falsy_interceptors)
+    assert result is mock_base_channel
 
 
 @pytest.mark.parametrize("count", [1, 2, 3])
@@ -949,14 +949,16 @@ def test_apply_interceptors_wrapping(count):
     must pass the base channel and all interceptors unpacked (*interceptors) to
     grpc.intercept_channel.
     """
-    mock_channel = mock.Mock(name="base_channel")
-    mock_intercepted = mock.Mock(name="intercepted_channel")
-    interceptors = [mock.Mock(name=f"interceptor_{i}") for i in range(count)]
+    mock_base_channel = mock.Mock(name="base_channel")
+    mock_wrapped_channel = mock.Mock(name="wrapped_channel")
+    mock_interceptors = [mock.Mock(name=f"interceptor_{i}") for i in range(count)]
 
     with mock.patch(
-        "grpc.intercept_channel", return_value=mock_intercepted
-    ) as mock_intercept:
-        result = grpc_helpers.apply_interceptors(mock_channel, interceptors)
+        "grpc.intercept_channel", return_value=mock_wrapped_channel
+    ) as mock_intercept_channel:
+        result = grpc_helpers.apply_interceptors(mock_base_channel, mock_interceptors)
 
-    assert result is mock_intercepted
-    mock_intercept.assert_called_once_with(mock_channel, *interceptors)
+    assert result is mock_wrapped_channel
+    mock_intercept_channel.assert_called_once_with(
+        mock_base_channel, *mock_interceptors
+    )

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -943,52 +943,41 @@ def test_apply_interceptors_passthrough(falsy_interceptors):
 
 @pytest.mark.parametrize("count", [1, 2, 3])
 def test_apply_interceptors_wrapping(count):
-    """Verify that interceptors are wrapped sequentially in the order provided.
+    """Verify that interceptors are passed to grpc.intercept_channel in a single call.
 
     When given a sequence of N interceptors [i_0, i_1, ..., i_{N-1}], apply_interceptors
-    must pass the base channel and i_0 to grpc.intercept_channel, then pass the
-    resulting wrapped channel and i_1 to grpc.intercept_channel, and so on.
-    This ensures each subsequent interceptor wraps the preceding channel state.
+    must pass the base channel and all interceptors unpacked (*interceptors) to
+    grpc.intercept_channel. This creates a single intercepted channel wrapper rather than
+    multiple nested wrappers.
     """
     mock_channel = mock.Mock(name="base_channel")
-    # Generate distinct mock interceptors and the expected wrapped channel returns for each step
+    mock_intercepted = mock.Mock(name="intercepted_channel")
     interceptors = [mock.Mock(name=f"interceptor_{i}") for i in range(count)]
-    wrapped_channels = [mock.Mock(name=f"wrapped_channel_{i}") for i in range(count)]
 
     with mock.patch(
-        "grpc.intercept_channel", side_effect=wrapped_channels
+        "grpc.intercept_channel", return_value=mock_intercepted
     ) as mock_intercept:
         result = grpc_helpers.apply_interceptors(mock_channel, interceptors)
 
-    # The final return value must be the outermost wrapped channel from the final loop iteration
-    assert result is wrapped_channels[-1]
-    assert mock_intercept.call_count == count
-
-    # Construct the expected sequential chaining: (base, i_0) -> (wrapped_0, i_1) -> ...
-    expected_calls = []
-    current_channel = mock_channel
-    for i, interceptor in enumerate(interceptors):
-        expected_calls.append(mock.call(current_channel, interceptor))
-        current_channel = wrapped_channels[i]
-
-    mock_intercept.assert_has_calls(expected_calls)
+    assert result is mock_intercepted
+    mock_intercept.assert_called_once_with(mock_channel, *interceptors)
 
 
 def test_apply_interceptors_execution_order():
     """Verify runtime execution order (onion model) when invoking an RPC on an intercepted channel.
 
-    In gRPC Python, sequential wrapping via grpc.intercept_channel(channel, i) creates an
-    'onion' layer where the LAST applied interceptor becomes the OUTSIDE layer.
+    In standard gRPC Python, grpc.intercept_channel(channel, *interceptors) processes
+    the interceptor list such that the first interceptor in the sequence is the outermost layer.
     Therefore, given [i1, i2]:
-      - i1 wraps the raw channel (innermost layer)
-      - i2 wraps the result of (channel + i1) (outermost layer)
+      - i1 is the outermost layer (executes first on outbound request)
+      - i2 is the inner layer (executes second on outbound request)
 
     During an RPC invocation:
-      1. i2 intercepts the call first (request inbound / pre-call)
-      2. i2 calls continuation(), which triggers i1
-      3. i1 calls continuation(), which reaches the channel stub / network
-      4. i1 post-call logic finishes
-      5. i2 post-call logic finishes
+      1. i1 intercepts the call first (request inbound / pre-call)
+      2. i1 calls continuation(), which triggers i2
+      3. i2 calls continuation(), which reaches the channel stub / network
+      4. i2 post-call logic finishes
+      5. i1 post-call logic finishes
     """
     execution_order = []
 
@@ -1020,5 +1009,5 @@ def test_apply_interceptors_execution_order():
     response = stub.GetOperation(operations_pb2.GetOperationRequest(name="test_op"))
 
     assert response.name == "test_op"
-    # Verify i2 executed as the outer layer surrounding i1
-    assert execution_order == ["i2_start", "i1_start", "i1_end", "i2_end"]
+    # Verify i1 executed as the outer layer surrounding i2
+    assert execution_order == ["i1_start", "i2_start", "i2_end", "i1_end"]

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -24,9 +24,8 @@ except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 import google.auth.credentials
-from google.longrunning import operations_pb2
-
 from google.api_core import exceptions, grpc_helpers
+from google.longrunning import operations_pb2
 
 
 def test__patch_callable_name():
@@ -932,3 +931,94 @@ class TestChannelStub(object):
     def test_close(self):
         channel = grpc_helpers.ChannelStub()
         assert channel.close() is None
+
+
+@pytest.mark.parametrize("falsy_interceptors", [None, [], ()])
+def test_apply_interceptors_passthrough(falsy_interceptors):
+    """Verify that falsy or empty interceptor sequences return the channel unmodified."""
+    mock_channel = mock.Mock()
+    result = grpc_helpers.apply_interceptors(mock_channel, falsy_interceptors)
+    assert result is mock_channel
+
+
+@pytest.mark.parametrize("count", [1, 2, 3])
+def test_apply_interceptors_wrapping(count):
+    """Verify that interceptors are wrapped sequentially in the order provided.
+
+    When given a sequence of N interceptors [i_0, i_1, ..., i_{N-1}], apply_interceptors
+    must pass the base channel and i_0 to grpc.intercept_channel, then pass the
+    resulting wrapped channel and i_1 to grpc.intercept_channel, and so on.
+    This ensures each subsequent interceptor wraps the preceding channel state.
+    """
+    mock_channel = mock.Mock(name="base_channel")
+    # Generate distinct mock interceptors and the expected wrapped channel returns for each step
+    interceptors = [mock.Mock(name=f"interceptor_{i}") for i in range(count)]
+    wrapped_channels = [mock.Mock(name=f"wrapped_channel_{i}") for i in range(count)]
+
+    with mock.patch(
+        "grpc.intercept_channel", side_effect=wrapped_channels
+    ) as mock_intercept:
+        result = grpc_helpers.apply_interceptors(mock_channel, interceptors)
+
+    # The final return value must be the outermost wrapped channel from the final loop iteration
+    assert result is wrapped_channels[-1]
+    assert mock_intercept.call_count == count
+
+    # Construct the expected sequential chaining: (base, i_0) -> (wrapped_0, i_1) -> ...
+    expected_calls = []
+    current_channel = mock_channel
+    for i, interceptor in enumerate(interceptors):
+        expected_calls.append(mock.call(current_channel, interceptor))
+        current_channel = wrapped_channels[i]
+
+    mock_intercept.assert_has_calls(expected_calls)
+
+
+def test_apply_interceptors_execution_order():
+    """Verify runtime execution order (onion model) when invoking an RPC on an intercepted channel.
+
+    In gRPC Python, sequential wrapping via grpc.intercept_channel(channel, i) creates an
+    'onion' layer where the LAST applied interceptor becomes the OUTSIDE layer.
+    Therefore, given [i1, i2]:
+      - i1 wraps the raw channel (innermost layer)
+      - i2 wraps the result of (channel + i1) (outermost layer)
+
+    During an RPC invocation:
+      1. i2 intercepts the call first (request inbound / pre-call)
+      2. i2 calls continuation(), which triggers i1
+      3. i1 calls continuation(), which reaches the channel stub / network
+      4. i1 post-call logic finishes
+      5. i2 post-call logic finishes
+    """
+    execution_order = []
+
+    class OrderInterceptor(grpc.UnaryUnaryClientInterceptor):
+        def __init__(self, name):
+            self.name = name
+
+        def intercept_unary_unary(self, continuation, client_call_details, request):
+            execution_order.append(f"{self.name}_start")
+            response = continuation(client_call_details, request)
+            execution_order.append(f"{self.name}_end")
+            return response
+
+    i1 = OrderInterceptor("i1")
+    i2 = OrderInterceptor("i2")
+
+    mock_channel = mock.Mock(spec=grpc.Channel)
+    mock_callable = mock.Mock(spec=grpc.UnaryUnaryMultiCallable)
+    mock_call = mock.Mock(spec=grpc.Call)
+    expected_response = operations_pb2.Operation(name="test_op")
+    mock_callable.with_call.return_value = (expected_response, mock_call)
+    mock_channel.unary_unary.return_value = mock_callable
+
+    # Apply interceptors in sequence [i1, i2]
+    intercepted_channel = grpc_helpers.apply_interceptors(mock_channel, [i1, i2])
+
+    # Trigger a unary RPC through the intercepted channel
+    stub = operations_pb2.OperationsStub(intercepted_channel)
+    response = stub.GetOperation(operations_pb2.GetOperationRequest(name="test_op"))
+
+    assert response.name == "test_op"
+    # Verify i2 executed as the outer layer surrounding i1
+    assert execution_order == ["i2_start", "i1_start", "i1_end", "i2_end"]

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -943,12 +943,11 @@ def test_apply_interceptors_passthrough(falsy_interceptors):
 
 @pytest.mark.parametrize("count", [1, 2, 3])
 def test_apply_interceptors_wrapping(count):
-    """Verify that interceptors are passed to grpc.intercept_channel in a single call.
+    """Verify that interceptors are passed to grpc.intercept_channel unpacked in a single call.
 
     When given a sequence of N interceptors [i_0, i_1, ..., i_{N-1}], apply_interceptors
     must pass the base channel and all interceptors unpacked (*interceptors) to
-    grpc.intercept_channel. This creates a single intercepted channel wrapper rather than
-    multiple nested wrappers.
+    grpc.intercept_channel.
     """
     mock_channel = mock.Mock(name="base_channel")
     mock_intercepted = mock.Mock(name="intercepted_channel")
@@ -961,53 +960,3 @@ def test_apply_interceptors_wrapping(count):
 
     assert result is mock_intercepted
     mock_intercept.assert_called_once_with(mock_channel, *interceptors)
-
-
-def test_apply_interceptors_execution_order():
-    """Verify runtime execution order (onion model) when invoking an RPC on an intercepted channel.
-
-    In standard gRPC Python, grpc.intercept_channel(channel, *interceptors) processes
-    the interceptor list such that the first interceptor in the sequence is the outermost layer.
-    Therefore, given [i1, i2]:
-      - i1 is the outermost layer (executes first on outbound request)
-      - i2 is the inner layer (executes second on outbound request)
-
-    During an RPC invocation:
-      1. i1 intercepts the call first (request inbound / pre-call)
-      2. i1 calls continuation(), which triggers i2
-      3. i2 calls continuation(), which reaches the channel stub / network
-      4. i2 post-call logic finishes
-      5. i1 post-call logic finishes
-    """
-    execution_order = []
-
-    class OrderInterceptor(grpc.UnaryUnaryClientInterceptor):
-        def __init__(self, name):
-            self.name = name
-
-        def intercept_unary_unary(self, continuation, client_call_details, request):
-            execution_order.append(f"{self.name}_start")
-            response = continuation(client_call_details, request)
-            execution_order.append(f"{self.name}_end")
-            return response
-
-    i1 = OrderInterceptor("i1")
-    i2 = OrderInterceptor("i2")
-
-    mock_channel = mock.Mock(spec=grpc.Channel)
-    mock_callable = mock.Mock(spec=grpc.UnaryUnaryMultiCallable)
-    mock_call = mock.Mock(spec=grpc.Call)
-    expected_response = operations_pb2.Operation(name="test_op")
-    mock_callable.with_call.return_value = (expected_response, mock_call)
-    mock_channel.unary_unary.return_value = mock_callable
-
-    # Apply interceptors in sequence [i1, i2]
-    intercepted_channel = grpc_helpers.apply_interceptors(mock_channel, [i1, i2])
-
-    # Trigger a unary RPC through the intercepted channel
-    stub = operations_pb2.OperationsStub(intercepted_channel)
-    response = stub.GetOperation(operations_pb2.GetOperationRequest(name="test_op"))
-
-    assert response.name == "test_op"
-    # Verify i1 executed as the outer layer surrounding i2
-    assert execution_order == ["i1_start", "i2_start", "i2_end", "i1_end"]

--- a/packages/google-api-core/tests/unit/test_observability.py
+++ b/packages/google-api-core/tests/unit/test_observability.py
@@ -15,17 +15,19 @@
 import sys
 from unittest import mock
 
+import pytest
 from google.api_core import _observability
+from google.api_core._feature_gating_helpers import FeatureGatingError
 from google.api_core.client_options import ClientOptions
 
 
 def test_is_otel_capabilities_enabled_disabled(monkeypatch):
-    monkeypatch.setenv("GOOGLE_CLOUD_PYTHON_TRACING_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "false")
     assert not _observability.is_otel_capabilities_enabled()
 
 
 def test_is_otel_capabilities_enabled_otel_missing(monkeypatch):
-    monkeypatch.setenv("GOOGLE_CLOUD_PYTHON_TRACING_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
     # Simulate OTel not being installed by blocking imports
     monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.grpc", None)
 
@@ -33,7 +35,7 @@ def test_is_otel_capabilities_enabled_otel_missing(monkeypatch):
 
 
 def test_is_otel_capabilities_enabled_otel_installed(monkeypatch):
-    monkeypatch.setenv("GOOGLE_CLOUD_PYTHON_TRACING_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
 
     mock_otel = mock.Mock()
     mock_otel_grpc = mock_otel.instrumentation.grpc
@@ -47,6 +49,41 @@ def test_is_otel_capabilities_enabled_otel_installed(monkeypatch):
     )
 
     assert _observability.is_otel_capabilities_enabled()
+
+
+def test_is_otel_capabilities_enabled_experimental_requires_env_var(monkeypatch):
+    """Proves that passing client_options with tracer_provider without the experimental
+    env var set to 'true' raises FeatureGatingError (Fail Fast).
+    """
+    monkeypatch.delenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", raising=False)
+    options = ClientOptions(tracer_provider=object())
+
+    with pytest.raises(
+        FeatureGatingError,
+        match="requires GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED",
+    ):
+        _observability.is_otel_capabilities_enabled(options)
+
+
+def test_is_otel_capabilities_enabled_experimental_enabled_with_config(monkeypatch):
+    """Proves that when GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED=true and tracer_provider
+    is supplied via client_options, is_otel_capabilities_enabled returns True.
+    """
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
+
+    mock_otel = mock.Mock()
+    mock_otel_grpc = mock_otel.instrumentation.grpc
+
+    monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation", mock_otel.instrumentation
+    )
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
+    )
+
+    options = ClientOptions(tracer_provider=object())
+    assert _observability.is_otel_capabilities_enabled(options)
 
 
 def test_apply_otel_capabilities_to_channel_enabled_otel_installed(monkeypatch):

--- a/packages/google-api-core/tests/unit/test_observability.py
+++ b/packages/google-api-core/tests/unit/test_observability.py
@@ -16,6 +16,7 @@ import sys
 from unittest import mock
 
 import pytest
+
 from google.api_core import _observability
 from google.api_core._feature_gating_helpers import FeatureGatingError
 from google.api_core.client_options import ClientOptions

--- a/packages/google-api-core/tests/unit/test_observability.py
+++ b/packages/google-api-core/tests/unit/test_observability.py
@@ -87,16 +87,11 @@ def test_is_otel_capabilities_enabled_experimental_enabled_with_config(monkeypat
     assert _observability.is_otel_capabilities_enabled(options)
 
 
-def test_apply_otel_capabilities_to_channel_enabled_otel_installed(monkeypatch):
-    mock_channel = mock.Mock()
-    mock_intercepted_channel = mock.Mock()
-
+def test_get_otel_interceptor_sync_default(monkeypatch):
     mock_otel = mock.Mock()
     mock_otel_grpc = mock_otel.instrumentation.grpc
     mock_interceptor = mock.Mock()
-
     mock_otel_grpc.client_interceptor.return_value = mock_interceptor
-    mock_otel_grpc.intercept_channel.return_value = mock_intercepted_channel
 
     monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
     monkeypatch.setitem(
@@ -106,29 +101,19 @@ def test_apply_otel_capabilities_to_channel_enabled_otel_installed(monkeypatch):
         sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
     )
 
-    result = _observability.apply_otel_capabilities_to_channel(mock_channel)
-
-    assert result is mock_intercepted_channel
+    result = _observability._get_otel_interceptor()
+    assert result is mock_interceptor
     mock_otel_grpc.client_interceptor.assert_called_once_with(tracer_provider=None)
-    mock_otel_grpc.intercept_channel.assert_called_once_with(
-        mock_channel, mock_interceptor
-    )
 
 
-def test_apply_otel_capabilities_to_channel_enabled_via_config(monkeypatch):
-    # Tracing enabled via config (tracer_provider is set)
+def test_get_otel_interceptor_sync_config(monkeypatch):
     mock_tracer_provider = object()
     options = ClientOptions(tracer_provider=mock_tracer_provider)
 
-    mock_channel = mock.Mock()
-    mock_intercepted_channel = mock.Mock()
-
     mock_otel = mock.Mock()
     mock_otel_grpc = mock_otel.instrumentation.grpc
     mock_interceptor = mock.Mock()
-
     mock_otel_grpc.client_interceptor.return_value = mock_interceptor
-    mock_otel_grpc.intercept_channel.return_value = mock_intercepted_channel
 
     monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
     monkeypatch.setitem(
@@ -138,33 +123,21 @@ def test_apply_otel_capabilities_to_channel_enabled_via_config(monkeypatch):
         sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
     )
 
-    result = _observability.apply_otel_capabilities_to_channel(
-        mock_channel, client_options=options
-    )
-
-    assert result is mock_intercepted_channel
+    result = _observability._get_otel_interceptor(client_options=options)
+    assert result is mock_interceptor
     mock_otel_grpc.client_interceptor.assert_called_once_with(
         tracer_provider=mock_tracer_provider
     )
-    mock_otel_grpc.intercept_channel.assert_called_once_with(
-        mock_channel, mock_interceptor
-    )
 
 
-def test_apply_otel_capabilities_to_channel_enabled_via_dict_config(monkeypatch):
-    # Tracing enabled via dict config
+def test_get_otel_interceptor_sync_dict_config(monkeypatch):
     mock_tracer_provider = object()
     options = {"tracer_provider": mock_tracer_provider}
 
-    mock_channel = mock.Mock()
-    mock_intercepted_channel = mock.Mock()
-
     mock_otel = mock.Mock()
     mock_otel_grpc = mock_otel.instrumentation.grpc
     mock_interceptor = mock.Mock()
-
     mock_otel_grpc.client_interceptor.return_value = mock_interceptor
-    mock_otel_grpc.intercept_channel.return_value = mock_intercepted_channel
 
     monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
     monkeypatch.setitem(
@@ -174,14 +147,156 @@ def test_apply_otel_capabilities_to_channel_enabled_via_dict_config(monkeypatch)
         sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
     )
 
-    result = _observability.apply_otel_capabilities_to_channel(
-        mock_channel, client_options=options
-    )
-
-    assert result is mock_intercepted_channel
+    result = _observability._get_otel_interceptor(client_options=options)
+    assert result is mock_interceptor
     mock_otel_grpc.client_interceptor.assert_called_once_with(
         tracer_provider=mock_tracer_provider
     )
+
+
+def test_get_otel_interceptor_async(monkeypatch):
+    mock_tracer_provider = object()
+    options = ClientOptions(tracer_provider=mock_tracer_provider)
+
+    mock_otel = mock.Mock()
+    mock_otel_grpc = mock_otel.instrumentation.grpc
+    mock_async_interceptors = [mock.Mock()]
+    mock_otel_grpc.aio_client_interceptors.return_value = mock_async_interceptors
+
+    monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation", mock_otel.instrumentation
+    )
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
+    )
+
+    result = _observability._get_otel_interceptor(client_options=options, is_async=True)
+    assert result is mock_async_interceptors
+    mock_otel_grpc.aio_client_interceptors.assert_called_once_with(
+        tracer_provider=mock_tracer_provider
+    )
+
+
+def test_get_otel_channel_wrapper_disabled(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "false")
+    assert _observability.get_otel_channel_wrapper() is None
+
+
+def test_get_otel_channel_wrapper_otel_missing(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.grpc", None)
+    assert _observability.get_otel_channel_wrapper() is None
+
+
+def test_get_otel_channel_wrapper_enabled(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
+    mock_tracer_provider = object()
+    options = ClientOptions(tracer_provider=mock_tracer_provider)
+
+    mock_raw_channel = mock.Mock(name="raw_channel")
+    mock_wrapped_channel = mock.Mock(name="wrapped_channel")
+
+    mock_otel = mock.Mock()
+    mock_otel_grpc = mock_otel.instrumentation.grpc
+    mock_interceptor = mock.Mock(name="otel_interceptor")
+
+    mock_otel_grpc.client_interceptor.return_value = mock_interceptor
+    mock_otel_grpc.intercept_channel.return_value = mock_wrapped_channel
+
+    monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation", mock_otel.instrumentation
+    )
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
+    )
+
+    wrapper = _observability.get_otel_channel_wrapper(client_options=options)
+    assert callable(wrapper)
+
+    mock_otel_grpc.client_interceptor.assert_called_once_with(
+        tracer_provider=mock_tracer_provider
+    )
+
+    result = wrapper(mock_raw_channel)
+    assert result is mock_wrapped_channel
     mock_otel_grpc.intercept_channel.assert_called_once_with(
-        mock_channel, mock_interceptor
+        mock_raw_channel, mock_interceptor
+    )
+
+
+def test_get_otel_channel_wrapper_with_apply_channel_wrappers(monkeypatch):
+    """Proves that get_otel_channel_wrapper integrates seamlessly into apply_channel_wrappers."""
+    pytest.importorskip("grpc")
+    from google.api_core import grpc_helpers
+
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
+    mock_tracer_provider = object()
+    options = ClientOptions(tracer_provider=mock_tracer_provider)
+
+    mock_raw_channel = mock.Mock(name="raw_channel")
+    mock_wrapped_channel = mock.Mock(name="wrapped_channel")
+
+    mock_otel = mock.Mock()
+    mock_otel_grpc = mock_otel.instrumentation.grpc
+    mock_interceptor = mock.Mock(name="otel_interceptor")
+
+    mock_otel_grpc.client_interceptor.return_value = mock_interceptor
+    mock_otel_grpc.intercept_channel.return_value = mock_wrapped_channel
+
+    monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation", mock_otel.instrumentation
+    )
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
+    )
+
+    otel_wrapper = _observability.get_otel_channel_wrapper(client_options=options)
+    assert callable(otel_wrapper)
+
+    result = grpc_helpers.apply_channel_wrappers(
+        mock_raw_channel, wrappers=[otel_wrapper]
+    )
+    assert result is mock_wrapped_channel
+    mock_otel_grpc.intercept_channel.assert_called_once_with(
+        mock_raw_channel, mock_interceptor
+    )
+
+
+def test_get_otel_async_interceptor_disabled(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "false")
+    assert _observability.get_otel_async_interceptor() is None
+
+
+def test_get_otel_async_interceptor_otel_missing(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.grpc", None)
+    assert _observability.get_otel_async_interceptor() is None
+
+
+def test_get_otel_async_interceptor_enabled(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
+    mock_tracer_provider = object()
+    options = ClientOptions(tracer_provider=mock_tracer_provider)
+
+    mock_async_interceptors = [mock.Mock(name="otel_async_interceptor")]
+
+    mock_otel = mock.Mock()
+    mock_otel_grpc = mock_otel.instrumentation.grpc
+    mock_otel_grpc.aio_client_interceptors.return_value = mock_async_interceptors
+
+    monkeypatch.setitem(sys.modules, "opentelemetry", mock_otel)
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation", mock_otel.instrumentation
+    )
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
+    )
+
+    result = _observability.get_otel_async_interceptor(client_options=options)
+    assert result is mock_async_interceptors
+    mock_otel_grpc.aio_client_interceptors.assert_called_once_with(
+        tracer_provider=mock_tracer_provider
     )

--- a/packages/google-api-core/tests/unit/test_observability.py
+++ b/packages/google-api-core/tests/unit/test_observability.py
@@ -16,7 +16,6 @@ import sys
 from unittest import mock
 
 import pytest
-
 from google.api_core import _observability
 from google.api_core._feature_gating_helpers import FeatureGatingError
 from google.api_core.client_options import ClientOptions
@@ -178,18 +177,18 @@ def test_get_otel_interceptor_async(monkeypatch):
     )
 
 
-def test_get_otel_channel_wrapper_disabled(monkeypatch):
+def test_get_otel_interceptor_disabled(monkeypatch):
     monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "false")
-    assert _observability.get_otel_channel_wrapper() is None
+    assert _observability.get_otel_interceptor() is None
 
 
-def test_get_otel_channel_wrapper_otel_missing(monkeypatch):
+def test_get_otel_interceptor_otel_missing(monkeypatch):
     monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
     monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.grpc", None)
-    assert _observability.get_otel_channel_wrapper() is None
+    assert _observability.get_otel_interceptor() is None
 
 
-def test_get_otel_channel_wrapper_enabled(monkeypatch):
+def test_get_otel_interceptor_enabled(monkeypatch):
     monkeypatch.setenv("GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED", "true")
     mock_tracer_provider = object()
     options = ClientOptions(tracer_provider=mock_tracer_provider)
@@ -212,22 +211,22 @@ def test_get_otel_channel_wrapper_enabled(monkeypatch):
         sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
     )
 
-    wrapper = _observability.get_otel_channel_wrapper(client_options=options)
-    assert callable(wrapper)
+    interceptor = _observability.get_otel_interceptor(client_options=options)
+    assert callable(interceptor)
 
     mock_otel_grpc.client_interceptor.assert_called_once_with(
         tracer_provider=mock_tracer_provider
     )
 
-    result = wrapper(mock_raw_channel)
+    result = interceptor(mock_raw_channel)
     assert result is mock_wrapped_channel
     mock_otel_grpc.intercept_channel.assert_called_once_with(
         mock_raw_channel, mock_interceptor
     )
 
 
-def test_get_otel_channel_wrapper_with_apply_channel_wrappers(monkeypatch):
-    """Proves that get_otel_channel_wrapper integrates seamlessly into apply_channel_wrappers."""
+def test_get_otel_interceptor_with_apply_channel_interceptors(monkeypatch):
+    """Proves that get_otel_interceptor integrates seamlessly into apply_channel_interceptors."""
     pytest.importorskip("grpc")
     from google.api_core import grpc_helpers
 
@@ -253,11 +252,11 @@ def test_get_otel_channel_wrapper_with_apply_channel_wrappers(monkeypatch):
         sys.modules, "opentelemetry.instrumentation.grpc", mock_otel_grpc
     )
 
-    otel_wrapper = _observability.get_otel_channel_wrapper(client_options=options)
-    assert callable(otel_wrapper)
+    otel_interceptor = _observability.get_otel_interceptor(client_options=options)
+    assert callable(otel_interceptor)
 
-    result = grpc_helpers.apply_channel_wrappers(
-        mock_raw_channel, wrappers=[otel_wrapper]
+    result = grpc_helpers.apply_channel_interceptors(
+        mock_raw_channel, interceptors=[otel_interceptor]
     )
     assert result is mock_wrapped_channel
     mock_otel_grpc.intercept_channel.assert_called_once_with(

--- a/packages/google-api-core/tests/unit/test_path_template.py
+++ b/packages/google-api-core/tests/unit/test_path_template.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 import pytest
 from google.api import auth_pb2
+
 from google.api_core import path_template
 
 


### PR DESCRIPTION
### Problem
Generated client libraries and transports need a centralized, maintainable way in `google-api-core` to apply gRPC channel wrappers (standard client interceptors as well as custom channel-wrapping callables) in a clean, order-preserving pipeline. Without a shared helper, downstream packages must duplicate wrapping loops or risk wrapper ordering issues.

Because synchronous gRPC channels can be wrapped post-creation while asynchronous gRPC channels require interceptors at channel creation time, client transports need helpers that return the appropriate channel wrapper or async interceptors without duplicating OpenTelemetry resolution logic across client libraries.

Additionally, OpenTelemetry tracing support in client initialization defaults to the EXPERIMENTAL token for experimental feature gating to prevent premature invocation of in-development capabilities.

### Solution
This PR introduces the following foundational utilities to `google-api-core`:

1. **gRPC Channel Wrapper Utilities (`google.api_core.grpc_helpers`)**:
   * `ClientInterceptor`: Type alias representing any client-side gRPC interceptor (`UnaryUnaryClientInterceptor`, `UnaryStreamClientInterceptor`, `StreamUnaryClientInterceptor`, `StreamStreamClientInterceptor`).
   * `ChannelWrapperCallable`: Type alias representing a channel-wrapping callable (`Callable[[grpc.Channel], grpc.Channel]`).
   * `ChannelWrapper`: Generic union type alias representing any channel wrapper (`Union[ClientInterceptor, ChannelWrapperCallable]`).
   * `apply_channel_wrappers`: Applies an optional sequence of channel wrappers to a `grpc.Channel` in reverse order so the first item in the sequence becomes the outermost layer on outbound requests. Returns the original channel unmodified if `wrappers` is `None` or empty.
   * `get_otel_channel_wrapper(client_options)`: Returns a channel-wrapping function (`Callable[[Channel], Channel]`) for synchronous gRPC channels when OpenTelemetry tracing is enabled and installed.
   * `get_otel_async_interceptor(client_options)`: Returns a list of OpenTelemetry asynchronous client interceptors (`aio_client_interceptors`) for use when constructing `grpc.aio` channels.
   * Integrates with `grpc_helpers.apply_channel_wrappers` to wrap raw channels using OpenTelemetry's `intercept_channel`.
   * `_get_otel_interceptor(client_options, is_async)`: Internal helper that extracts `tracer_provider` from `ClientOptions` and creates the appropriate OpenTelemetry sync or async interceptors.

2. **Experimental Feature Gating for Tracing (`google.api_core._observability`)**:
   * Sets the default environment variable in `is_otel_capabilities_enabled` to `GOOGLE_SDK_EXPERIMENTAL_PYTHON_TRACING_ENABLED`.
   * Enforces fail-fast behavior: attempting to configure tracing via `ClientOptions.tracer_provider` without setting the experimental environment variable raises `FeatureGatingError`.

### Testing
* Added comprehensive unit tests in `test_grpc_helpers.py` covering passthrough behavior, pure `ClientInterceptor` sequences, pure callable sequences, interspersed `[interceptor, callable]` sequences, and `TypeError` validation on invalid types.
* Added unit tests in `test_observability.py` validating experimental feature gating (`FeatureGatingError` fail-fast validation and successful enablement).
* Added unit tests in `tests/unit/test_observability.py` covering:
  * Sync and async interceptor extraction and `tracer_provider` configuration.
  * `get_otel_channel_wrapper` behavior when tracing is disabled, when OpenTelemetry is not installed, and when tracing is enabled.
  * Integration between `get_otel_channel_wrapper` and `grpc_helpers.apply_channel_wrappers`.
  * `get_otel_async_interceptor` behavior across disabled, missing, and enabled states.

### Notes for Reviewers
* `get_otel_channel_wrapper` returns a callable rather than modifying the channel immediately, allowing transport layers to combine OpenTelemetry wrapping with user-supplied custom channel wrappers.