### PR TITLE
fix(googleapis-common-protos): remove deprecated license classifier

### DIFF
--- a/packages/googleapis-common-protos/pyproject.toml
+++ b/packages/googleapis-common-protos/pyproject.toml
@@ -20,14 +20,13 @@ build-backend = "setuptools.build_meta"
 name = "googleapis-common-protos"
 version = "1.75.2"
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">= 3.10"
 readme = "README.rst"
 description = "Common protobufs used in Google APIs"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This PR drops the deprecated classifier from the project metadata of googleapis-common-protos. 

It also fixes the license to be SPDX-compliant which was also warned during the built of the project (https://spdx.org/licenses/):

```log
********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

By 2027-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```

Closes #18235 