### PR TITLE
chore: add ruff format hook to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,6 @@ repos:
     # Run the linter.
     - id: ruff-check
       args: [ --select, I, --fix, --target-version=py310, --line-length=88 ]
+    # Run the formatter.
+    - id: ruff-format
+      args: [ --target-version=py310, --line-length=88 ]


### PR DESCRIPTION
## The Problem
The repository pre-commit configuration only ran `ruff-check` for sorting and fixing imports (`--select I --fix`). It did not run `ruff format` on staged files. As a result, commits could pass local pre-commit checks but subsequently fail repository lint sessions during presubmit testing due to formatting discrepancies.

## The Solution
- Added the `ruff-format` hook to `.pre-commit-config.yaml`
- Configured arguments `--target-version=py310` and `--line-length=88` to align with the formatting standards enforced across the repository's lint Nox sessions.

## Notes to Reviewers
- This change ensures that code formatting is automatically applied locally prior to commit, matching what our CI/CD lint sessions expect.