### PR TITLE
chore: regenerate google-cloud-bigtable

### DIFF
--- a/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
@@ -669,6 +669,7 @@ replacements:
 
           hostport = "localhost:8789"
           session.env["BIGTABLE_EMULATOR_HOST"] = hostport
+          session.env["GOOGLE_CLOUD_PROJECT"] = "emulated-test-project"
 
           p = subprocess.Popen(
               ["gcloud", "beta", "emulators", "bigtable", "start", "--host-port", hostport]

--- a/packages/google-cloud-bigtable/tests/system/data/__init__.py
+++ b/packages/google-cloud-bigtable/tests/system/data/__init__.py
@@ -41,6 +41,7 @@ class SystemTestRunner:
         Automatically deletes any test instances older than 1 day.
         """
         from google.cloud.environment_vars import BIGTABLE_EMULATOR
+
         from tests.system.utils import clear_stale_instances
 
         if os.getenv(BIGTABLE_EMULATOR):

--- a/packages/google-cloud-bigtable/tests/system/utils.py
+++ b/packages/google-cloud-bigtable/tests/system/utils.py
@@ -14,8 +14,7 @@
 
 import os
 from datetime import datetime, timedelta, timezone
-
-from typing import Union, Tuple
+from typing import Tuple, Union
 
 from google.api_core.exceptions import NotFound
 from google.cloud.environment_vars import BIGTABLE_EMULATOR


### PR DESCRIPTION
The following commands were used to re-generate `google-cloud-bigtable`

```
pip install <path to gapic-generator @ commit faa0f81>
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
go run github.com/googleapis/librarian/cmd/librarian@${V} install
go run github.com/googleapis/librarian/cmd/librarian@${V} generate -v google-cloud-bigtable
```

Fixes https://github.com/googleapis/google-cloud-python/issues/18246