### PR TITLE
chore(sqlalchemy-bigquery): revert changes to autogenerated readme

### DIFF
--- a/packages/sqlalchemy-bigquery/README.rst
+++ b/packages/sqlalchemy-bigquery/README.rst
@@ -3,7 +3,7 @@ SQLAlchemy Dialect for BigQuery
 
 |GA| |pypi| |versions|
 
-`SQLAlchemy Dialects`_
+`SQLALchemy Dialects`_
 
 - `Dialect Documentation`_
 - `Product Documentation`_


### PR DESCRIPTION
The recent typo fix is breaking re-generation: https://github.com/googleapis/google-cloud-python/actions/runs/33430377687/job/99614008017

This PR reverts the change