### PR TITLE
chore(spanner): fix instance partition test configuration and snippets test flakes

### DIFF
--- a/packages/google-cloud-spanner/samples/samples/snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/snippets_test.py
@@ -213,20 +213,39 @@ def test_create_and_update_instance_default_backup_schedule_type(
     retry_429(instance.delete)()
 
 
-def test_create_instance_partition(capsys, instance_partition_instance_id):
-    # Unable to use create_instance since it has editions set where partitions are unsupported.
-    # The minimal requirement for editions is ENTERPRISE_PLUS for the paritions to get supported.
-    retry_429(snippets.create_instance_with_processing_units)(
-        instance_partition_instance_id, 1000
-    )
-    retry_429(snippets.create_instance_partition)(
-        instance_partition_instance_id, "my-instance-partition"
-    )
-    out, _ = capsys.readouterr()
-    assert "Created instance partition my-instance-partition" in out
+def test_create_instance_partition(
+    capsys, instance_partition_instance_id, multi_region_instance_config
+):
+    from google.cloud.spanner_admin_instance_v1.types import spanner_instance_admin
+
     spanner_client = spanner.Client()
     instance = spanner_client.instance(instance_partition_instance_id)
-    retry_429(instance.delete)()
+    try:
+        request = spanner_instance_admin.CreateInstanceRequest(
+            parent=spanner_client.project_name,
+            instance_id=instance_partition_instance_id,
+            instance=spanner_instance_admin.Instance(
+                config=multi_region_instance_config,
+                display_name="Instance for instance partition test",
+                node_count=1,
+                edition=spanner_instance_admin.Instance.Edition.ENTERPRISE_PLUS,
+            ),
+        )
+        operation = retry_429(spanner_client.instance_admin_api.create_instance)(
+            request=request
+        )
+        operation.result(900)
+
+        retry_429(snippets.create_instance_partition)(
+            instance_partition_instance_id, "my-instance-partition"
+        )
+        out, _ = capsys.readouterr()
+        assert "Created instance partition my-instance-partition" in out
+    finally:
+        try:
+            retry_429(instance.delete)()
+        except Exception:
+            pass
 
 
 def test_update_database(capsys, instance_id, sample_database):

--- a/packages/google-cloud-spanner/samples/samples/snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/snippets_test.py
@@ -18,6 +18,7 @@ import uuid
 from google.api_core import exceptions
 from google.cloud import spanner
 from google.cloud.spanner_admin_database_v1.types.common import DatabaseDialect
+from google.cloud.spanner_admin_instance_v1.types import spanner_instance_admin
 import pytest
 from test_utils.retry import RetryErrors
 
@@ -216,8 +217,6 @@ def test_create_and_update_instance_default_backup_schedule_type(
 def test_create_instance_partition(
     capsys, instance_partition_instance_id, multi_region_instance_config
 ):
-    from google.cloud.spanner_admin_instance_v1.types import spanner_instance_admin
-
     spanner_client = spanner.Client()
     instance = spanner_client.instance(instance_partition_instance_id)
     try:


### PR DESCRIPTION
## Description
- Fixes `test_create_instance_partition` in `packages/google-cloud-spanner/samples/samples/snippets_test.py`:
  Cloud Spanner enforces `CreateInstancePartitionInSingleRegionInstance` ("Cannot create an instance partition in a single region instance"). Previously, the test invoked `create_instance_with_processing_units`, which hardcodes `regional-us-central1` (single-region), and then attempted to create a partition in `nam3`. This fix updates the test to create a multi-region `ENTERPRISE_PLUS` instance using `multi_region_instance_config` (`nam3`), matching the partition configuration.
- Wraps instance creation in `retry_429` to mitigate transient 429 quota exhaustion.
- Updates `dorny/paths-filter` pin in `.github/workflows/django-spanner-django5.2_tests.yml` to `# v4.0.1` to align with the rest of the repository and satisfy the `zizmor` action version check.