### PR TITLE
fix(google-auth): raise cryptography lower bounds

### DIFF
--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_namespace_packages, setup
 
 cryptography_base_require = [
     "cryptography >= 38.0.3; python_version < '3.14'",
-    "cryptography >= 41.0.5; python_version >= '3.14'",
+    "cryptography >= 50.0.1; python_version >= '3.14'",
 ]
 
 DEPENDENCIES = (

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -18,7 +18,7 @@ import os
 from setuptools import find_namespace_packages, setup
 
 cryptography_base_require = [
-    "cryptography >= 38.0.3; python_version < '3.14'",
+    "cryptography >= 46.0.5; python_version < '3.14'",
     "cryptography >= 50.0.1; python_version >= '3.14'",
 ]
 

--- a/packages/google-auth/testing/constraints-3.10.txt
+++ b/packages/google-auth/testing/constraints-3.10.txt
@@ -7,7 +7,7 @@
 # Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
 setuptools==40.3.0
-cryptography==38.0.3
+cryptography==46.0.5
 aiohttp==3.8.0
 requests==2.30.0
 pyjwt==2.0

--- a/packages/google-auth/testing/constraints-3.14.txt
+++ b/packages/google-auth/testing/constraints-3.14.txt
@@ -6,5 +6,5 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
-cryptography==41.0.5
+cryptography==50.0.1
 aiohttp==3.9.0


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #18260 🦕

## Summary

Raise the `cryptography` lower bound in `google-auth` so unit tests can install on Python 3.14 and so older Pythons no longer allow releases with known high-severity CVEs.

| Python | Before | After |
| --- | --- | --- |
| 3.10–3.13 | `>= 38.0.3` | `>= 46.0.5` |
| 3.14+ | `>= 41.0.5` | `>= 50.0.1` |

Lower-bound constraints are updated to match: `testing/constraints-3.10.txt` pins `46.0.5`, `testing/constraints-3.14.txt` pins `50.0.1`.

## Rationale

- **Python 3.14:** `cryptography==41.0.5` has no 3.14 wheels, so `nox -s unit-3.14` fails with `ResolutionImpossible`. `50.0.1` is the first release with Python 3.14 support.
- **Python 3.10–3.13:** `46.0.5` is the first release that fixes [CVE-2026-26007](https://github.com/advisories). The previous floor (`38.0.3`, and the 3.14 pin of `41.0.5`) also included [CVE-2023-49083](https://nvd.nist.gov/vuln/detail/CVE-2023-49083).

This does not pin users to a specific `cryptography` version. Pip still installs a current compatible release unless something else constrains it. Anyone still depending on `cryptography < 46.0.5` (or `< 50.0.1` on 3.14) will need to upgrade that package.

## Test plan

- [x] `nox -s unit-3.12` (or another 3.10–3.13 interpreter) in `packages/google-auth`
- [x] `nox -s unit-3.14` in `packages/google-auth`
- [x] Confirm install resolves with the updated constraints files and no longer requests `cryptography==41.0.5` on 3.14