### PR TITLE
feat(sql): prepare first release

### DIFF
--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -1,6 +1,7 @@
 {
   "packages/google-cloud-apptopology": "0.0.0",
   "packages/google-cloud-ftp": "0.1.0",
+  "packages/google-cloud-sql": "0.0.0",
   "packages/google-cloud-workloadidentity": "0.1.0",
   "packages/google-crc32c": "1.8.0",
   "packages/google-maps-mapmanagement": "0.1.1",

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -26,6 +26,24 @@
         }
       ]
     },
+    "packages/google-cloud-sql": {
+      "component": "google-cloud-sql",
+      "extra-files": [
+        "google/cloud/sql/gapic_version.py",
+        "google/cloud/sql_v1/gapic_version.py",
+        "google/cloud/sql_v1beta4/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.sql.v1.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.sql.v1beta4.json",
+          "type": "json"
+        }
+      ]
+    },
     "packages/google-cloud-workloadidentity": {
       "component": "google-cloud-workloadidentity",
       "extra-files": [


### PR DESCRIPTION
Populate missing release-please configuration for new library `google-cloud-sql` with versions for v1 and v1beta4.

This is a `feat` in order to elicit a bump and release PR.

For http://b/537730936 http://b/555923115