### PR TITLE
chore(spanner): use nam6 instance config for test_create_instance_partition

### DIFF
--- a/packages/google-cloud-spanner/samples/samples/snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/snippets_test.py
@@ -214,9 +214,7 @@ def test_create_and_update_instance_default_backup_schedule_type(
     retry_429(instance.delete)()
 
 
-def test_create_instance_partition(
-    capsys, instance_partition_instance_id, multi_region_instance_config
-):
+def test_create_instance_partition(capsys, instance_partition_instance_id):
     spanner_client = spanner.Client()
     instance = spanner_client.instance(instance_partition_instance_id)
     try:
@@ -224,7 +222,7 @@ def test_create_instance_partition(
             parent=spanner_client.project_name,
             instance_id=instance_partition_instance_id,
             instance=spanner_instance_admin.Instance(
-                config=multi_region_instance_config,
+                config=f"{spanner_client.project_name}/instanceConfigs/nam6",
                 display_name="Partition test instance",
                 node_count=1,
                 edition=spanner_instance_admin.Instance.Edition.ENTERPRISE_PLUS,


### PR DESCRIPTION
Cloud Spanner enforces DuplicatedBaseInstancePartitionConfigs ('Cannot create an instance partition that shares a base config with another instance partition.').

Since snippets.create_instance_partition creates an instance partition in nam3, update test_create_instance_partition in snippets_test.py to create the parent instance in nam6 rather than nam3. This satisfies the multi-region parent instance requirement while avoiding base config collision.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕