### PR TITLE
fix: correct release config target version files

### DIFF
--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -645,7 +645,13 @@
       "component": "google-cloud-biglake-hive",
       "extra-files": [
         "google/cloud/biglake_hive/gapic_version.py",
+        "google/cloud/biglake_hive_v1/gapic_version.py",
         "google/cloud/biglake_hive_v1beta/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.biglake.hive.v1.json",
+          "type": "json"
+        },
         {
           "jsonpath": "$.clientLibrary.version",
           "path": "samples/generated_samples/snippet_metadata_google.cloud.biglake.hive.v1beta.json",
@@ -1046,6 +1052,7 @@
     "packages/google-cloud-compute-v1beta": {
       "component": "google-cloud-compute-v1beta",
       "extra-files": [
+        "google/cloud/compute/gapic_version.py",
         "google/cloud/compute_v1beta/gapic_version.py",
         {
           "jsonpath": "$.clientLibrary.version",

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -80,8 +80,8 @@
     "packages/google-shopping-merchant-loyaltycustomers": {
       "component": "google-shopping-merchant-loyaltycustomers",
       "extra-files": [
-        "google/shopping/merchant/loyaltycustomers/gapic_version.py",
-        "google/shopping/merchant/loyaltycustomers_v1/gapic_version.py",
+        "google/shopping/merchant_loyaltycustomers/gapic_version.py",
+        "google/shopping/merchant_loyaltycustomers_v1/gapic_version.py",
         {
           "jsonpath": "$.clientLibrary.version",
           "path": "samples/generated_samples/snippet_metadata_google.shopping.merchant.loyaltycustomers.v1.json",


### PR DESCRIPTION
Several libraries have incorrect or missing version files in the release-please config such that they aren't being bumped on release. This also produces a diff on main (https://github.com/googleapis/google-cloud-python/issues/18248#issuecomment-5531280740).

This fixes all such library release configs.

Fixes https://github.com/googleapis/google-cloud-python/issues/18248