### PR TITLE
fix: correct client version strings

### DIFF
--- a/packages/google-cloud-biglake-hive/CHANGELOG.md
+++ b/packages/google-cloud-biglake-hive/CHANGELOG.md
@@ -40,3 +40,4 @@
 ### Features
 
 * onboard a new library ([a16755d8e2fcd941e94cc967a5acd72c95eb7644](https://github.com/googleapis/google-cloud-python/commit/a16755d8e2fcd941e94cc967a5acd72c95eb7644))
+

--- a/packages/google-cloud-compute-v1beta/CHANGELOG.md
+++ b/packages/google-cloud-compute-v1beta/CHANGELOG.md
@@ -181,3 +181,4 @@
 * add initial files for google.cloud.compute.v1beta ([4349ba1](https://github.com/googleapis/google-cloud-python/commit/4349ba11e3bc5795b6a5d51faed4d99a3a94d4e8))
 
 ## Changelog
+

--- a/packages/google-shopping-merchant-loyaltycustomers/CHANGELOG.md
+++ b/packages/google-shopping-merchant-loyaltycustomers/CHANGELOG.md
@@ -12,3 +12,4 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/google-shopping-merchant-loyaltycustomers/#history
+


### PR DESCRIPTION
Elicit `release-please` patch bumps in `google-cloud-compute-v1beta`, `google-cloud-biglake-hive`, and `google-cloud-shopping-merchant-loyaltycustomers` after fixing release config in https://github.com/googleapis/google-cloud-python/pull/18279.

We must change a file in a target package in order to elicit the bump, because we are in a monorepo. The traditional `Release-As` mechanism doesn't work without a file change to focus the bump. We use `fix` to get a `patch` version bump. 