### PR TITLE
chore(spanner): bump google-cloud-spanner to 3.71.0 in samples

### DIFF
--- a/packages/google-cloud-spanner/samples/samples/requirements.txt
+++ b/packages/google-cloud-spanner/samples/samples/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-spanner==3.66.0
+google-cloud-spanner==3.71.0
 futures==3.4.0; python_version < "3"


### PR DESCRIPTION
Update samples/samples/requirements.txt to google-cloud-spanner==3.71.0 to include Cloud Spanner Queues mutation API (Batch.send and Batch.ack).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕