### PR TITLE
chore: re-enable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base",
     "group:all",
-    ":disableDependencyDashboard",
     "schedule:weekly"
   ],
   "ignorePaths": [


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/18287
b/557105840