### PR TITLE
feat(storage): support storage_class in Blob

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/async_appendable_object_writer.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/async_appendable_object_writer.py
@@ -111,6 +111,7 @@ class AsyncAppendableObjectWriter:
         generation: Optional[int] = None,
         write_handle: Optional[_storage_v2.BidiWriteHandle] = None,
         writer_options: Optional[dict] = None,
+        storage_class: Optional[str] = None,
     ):
         """
         Class for appending data to a GCS Appendable Object.
@@ -179,6 +180,10 @@ class AsyncAppendableObjectWriter:
                 The number of bytes to append before "persisting" data in GCS
                 servers. Default is `_DEFAULT_FLUSH_INTERVAL_BYTES`.
                 Must be a multiple of `_MAX_CHUNK_SIZE_BYTES`.
+        :type storage_class: Optional[str]
+        :param storage_class: (Optional) Storage class of the object bytes.
+            If specified, it overrides the bucket's `storage_class`. If not, object storage class
+            will be the same as bucket's storage_class.
         """
         _utils.raise_if_no_fast_crc32c()
         self.client = client
@@ -186,6 +191,7 @@ class AsyncAppendableObjectWriter:
         self.object_name = object_name
         self.write_handle = write_handle
         self.generation = generation
+        self.storage_class = storage_class
 
         self.write_obj_stream: Optional[_AsyncWriteObjectStream] = None
         self._is_stream_open: bool = False
@@ -361,6 +367,7 @@ class AsyncAppendableObjectWriter:
                 generation_number=self.generation,
                 write_handle=self.write_handle,
                 routing_token=self._routing_token,
+                storage_class=self.storage_class,
             )
 
             if self._routing_token:

--- a/packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/packages/google-cloud-storage/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -58,6 +58,9 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
     :type write_handle: _storage_v2.BidiWriteHandle
     :param write_handle: (Optional) An existing handle for writing the object.
                         If provided, opening the bidi-gRPC connection will be faster.
+
+    :type storage_class: Optional[str]
+    :param storage_class: (Optional) The storage class of the object.
     """
 
     def __init__(
@@ -69,6 +72,7 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
         write_handle: Optional[_storage_v2.BidiWriteHandle] = None,
         routing_token: Optional[str] = None,
         blob: Optional[Blob] = None,
+        storage_class: Optional[str] = None,
     ) -> None:
         if client is None:
             raise ValueError("client must be provided")
@@ -86,6 +90,7 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
         self.write_handle: Optional[_storage_v2.BidiWriteHandle] = write_handle
         self.routing_token: Optional[str] = routing_token
         self.blob: Optional[Blob] = blob
+        self.storage_class: Optional[str] = storage_class
         self._full_bucket_name = f"projects/_/buckets/{self.bucket_name}"
 
         self.rpc = self.client._client._transport._wrapped_methods[
@@ -124,7 +129,9 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
                 resource = _grpc_conversions.blob_to_proto(self.blob)
             else:
                 resource = _storage_v2.Object(
-                    name=self.object_name, bucket=self._full_bucket_name
+                    name=self.object_name,
+                    bucket=self._full_bucket_name,
+                    storage_class=self.storage_class,
                 )
             self.first_bidi_write_req = _storage_v2.BidiWriteObjectRequest(
                 write_object_spec=_storage_v2.WriteObjectSpec(

--- a/packages/google-cloud-storage/google/cloud/storage/blob.py
+++ b/packages/google-cloud-storage/google/cloud/storage/blob.py
@@ -183,6 +183,11 @@ class Blob(_PropertyMixin):
     :type generation: long
     :param generation:
         (Optional) If present, selects a specific revision of this object.
+
+    :type storage_class: str
+    :param storage_class:
+        (Optional) The storage class for the blob. Default value is None. If
+        nothing specified, its value will be the same as bucket's storage_class.
     """
 
     _chunk_size = None  # Default value for each instance.
@@ -216,6 +221,7 @@ class Blob(_PropertyMixin):
         encryption_key=None,
         kms_key_name=None,
         generation=None,
+        storage_class=None,
     ):
         """
         property :attr:`name`
@@ -238,6 +244,9 @@ class Blob(_PropertyMixin):
 
         if generation is not None:
             self._properties["generation"] = generation
+
+        if storage_class is not None:
+            self._properties["storageClass"] = storage_class
 
     @property
     def bucket(self):
@@ -4943,28 +4952,42 @@ class Blob(_PropertyMixin):
         """
         self._patch_property("kmsKeyName", value)
 
-    storage_class = _scalar_property("storageClass")
-    """Retrieve the storage class for the object.
+    @property
+    def storage_class(self):
+        """Retrieve the storage class for the object.
 
-    This can only be set at blob / object **creation** time. If you'd
-    like to change the storage class **after** the blob / object already
-    exists in a bucket, call :meth:`update_storage_class` (which uses
-    :meth:`rewrite`).
+        Default value is None. If nothing specified, its value will be the
+        same as bucket's storage_class.
 
-    See https://cloud.google.com/storage/docs/storage-classes
+        This can only be set at blob / object **creation** time. If you'd
+        like to change the storage class **after** the blob / object already
+        exists in a bucket, call :meth:`update_storage_class` (which uses
+        :meth:`rewrite`).
 
-    :rtype: str or ``NoneType``
-    :returns:
-        If set, one of
-        :attr:`~google.cloud.storage.constants.STANDARD_STORAGE_CLASS`,
-        :attr:`~google.cloud.storage.constants.NEARLINE_STORAGE_CLASS`,
-        :attr:`~google.cloud.storage.constants.COLDLINE_STORAGE_CLASS`,
-        :attr:`~google.cloud.storage.constants.ARCHIVE_STORAGE_CLASS`,
-        :attr:`~google.cloud.storage.constants.MULTI_REGIONAL_LEGACY_STORAGE_CLASS`,
-        :attr:`~google.cloud.storage.constants.REGIONAL_LEGACY_STORAGE_CLASS`,
-        :attr:`~google.cloud.storage.constants.DURABLE_REDUCED_AVAILABILITY_STORAGE_CLASS`,
-        else ``None``.
-    """
+        See https://cloud.google.com/storage/docs/storage-classes
+
+        :rtype: str or ``NoneType``
+        :returns:
+            If set, one of
+            :attr:`~google.cloud.storage.constants.STANDARD_STORAGE_CLASS`,
+            :attr:`~google.cloud.storage.constants.NEARLINE_STORAGE_CLASS`,
+            :attr:`~google.cloud.storage.constants.COLDLINE_STORAGE_CLASS`,
+            :attr:`~google.cloud.storage.constants.ARCHIVE_STORAGE_CLASS`,
+            :attr:`~google.cloud.storage.constants.MULTI_REGIONAL_LEGACY_STORAGE_CLASS`,
+            :attr:`~google.cloud.storage.constants.REGIONAL_LEGACY_STORAGE_CLASS`,
+            :attr:`~google.cloud.storage.constants.DURABLE_REDUCED_AVAILABILITY_STORAGE_CLASS`,
+            else ``None``.
+        """
+        return self._properties.get("storageClass")
+
+    @storage_class.setter
+    def storage_class(self, value):
+        """Set the storage class for the object.
+
+        :type value: str or ``NoneType``
+        :param value: new storage class name (None to clear any existing storage class).
+        """
+        self._patch_property("storageClass", value)
 
     temporary_hold = _scalar_property("temporaryHold")
     """Is a temporary hold active on the object?

--- a/packages/google-cloud-storage/tests/system/conftest.py
+++ b/packages/google-cloud-storage/tests/system/conftest.py
@@ -30,13 +30,12 @@ except ImportError:
 
 import pytest  # noqa: E402
 from google.api_core import exceptions  # noqa: E402
-
+from google.api_core.client_options import ClientOptions  # noqa: E402
 from google.cloud import kms  # noqa: E402
 from google.cloud.storage._helpers import _base64_md5hash  # noqa: E402
 from google.cloud.storage.retry import DEFAULT_RETRY  # noqa: E402
 
 from . import _helpers  # noqa: E402
-from google.api_core.client_options import ClientOptions
 
 PREPROD_JSON_HOST = "https://storage-preprod-test-unified.googleusercontent.com"
 RUN_SYSTEM_TESTS_ON_PREPROD = os.getenv("RUN_SYSTEM_TESTS_ON_PREPROD") == "True"

--- a/packages/google-cloud-storage/tests/system/conftest.py
+++ b/packages/google-cloud-storage/tests/system/conftest.py
@@ -36,6 +36,10 @@ from google.cloud.storage._helpers import _base64_md5hash  # noqa: E402
 from google.cloud.storage.retry import DEFAULT_RETRY  # noqa: E402
 
 from . import _helpers  # noqa: E402
+from google.api_core.client_options import ClientOptions
+
+PREPROD_JSON_HOST = "https://storage-preprod-test-unified.googleusercontent.com"
+RUN_SYSTEM_TESTS_ON_PREPROD = os.getenv("RUN_SYSTEM_TESTS_ON_PREPROD") == "True"
 
 if trace_api is not None:
     _global_exporter = InMemorySpanExporter()
@@ -110,12 +114,19 @@ def _kms_key_name(client, bucket, key_name):
         key_name,
     )
 
+@pytest.fixture(scope="session")
+def run_system_tests_on_preprod():
+    return os.getenv("RUN_SYSTEM_TESTS_ON_PREPROD") == "True"
 
 @pytest.fixture(scope="session")
-def storage_client():
+def storage_client(run_system_tests_on_preprod):
     from google.cloud.storage import Client
 
-    client = Client()
+    client = Client(
+        client_options=ClientOptions(api_endpoint=PREPROD_JSON_HOST)
+        if run_system_tests_on_preprod
+        else None
+    )
     with contextlib.closing(client):
         yield client
 

--- a/packages/google-cloud-storage/tests/system/test_zonal.py
+++ b/packages/google-cloud-storage/tests/system/test_zonal.py
@@ -11,6 +11,7 @@ from io import BytesIO
 import google_crc32c
 import pytest
 from google.api_core import exceptions
+from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import FailedPrecondition, NotFound, OutOfRange
 
 # current library imports
@@ -27,7 +28,6 @@ from google.cloud.storage.blob import (
     ObjectContexts,
     ObjectCustomContextPayload,
 )
-from google.api_core.client_options import ClientOptions
 
 PREPROD_GRPC_ENDPOINT = "storage-preprod-test-grpc.googleusercontent.com:443"
 

--- a/packages/google-cloud-storage/tests/system/test_zonal.py
+++ b/packages/google-cloud-storage/tests/system/test_zonal.py
@@ -66,7 +66,7 @@ async def create_async_grpc_client(attempt_direct_path=True, preprod=False):
 def zonal_kms_key(storage_client, kms_client):
     """Provisions a KMS key in the same location as of the zonal bucket."""
     # Get the zonal bucket and extract its location
-    bucket = storage_client.get_bucket(_ZONAL_BUCKET)
+    bucket = storage_client.get_bucket(bucket_for_testing)
     location = bucket.location.lower()
 
     project = storage_client.project
@@ -160,7 +160,7 @@ def _get_equal_dist(a: int, b: int) -> tuple[int, int]:
     step = (b - a) // 3
     return a + step, a + 2 * step
 
-
+@pytest.mark.skipif(RCU_SYSTEM_TESTS, reason='X regions reads/writes for RCU not supported in SDK yet')
 @pytest.mark.parametrize(
     "object_size",
     [
@@ -237,7 +237,6 @@ def test_basic_wrd(
         object_data = os.urandom(object_size)
         object_checksum = google_crc32c.value(object_data)
         grpc_client = grpc_clients[attempt_direct_path]
-        print("bucket for testing", bucket_for_testing)
         writer = AsyncAppendableObjectWriter(
             grpc_client,
             bucket_for_testing,
@@ -287,7 +286,12 @@ def test_basic_wrd_in_slices(
         object_data = os.urandom(object_size)
         object_checksum = google_crc32c.value(object_data)
 
-        writer = AsyncAppendableObjectWriter(grpc_client, _ZONAL_BUCKET, object_name)
+        writer = AsyncAppendableObjectWriter(
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
+        )
         await writer.open()
         mark1, mark2 = _get_equal_dist(0, object_size)
         await writer.append(object_data[0:mark1])
@@ -297,7 +301,7 @@ def test_basic_wrd_in_slices(
         assert object_metadata.size == object_size
         assert int(object_metadata.checksums.crc32c) == object_checksum
 
-        mrd = AsyncMultiRangeDownloader(grpc_client, _ZONAL_BUCKET, object_name)
+        mrd = AsyncMultiRangeDownloader(grpc_client, bucket_for_testing, object_name)
         buffer = BytesIO()
         await mrd.open()
         # (0, 0) means read the whole object
@@ -307,7 +311,7 @@ def test_basic_wrd_in_slices(
         assert mrd.persisted_size == object_size
 
         # Clean up; use json client (i.e. `storage_client` fixture) to delete.
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         del mrd
         gc.collect()
@@ -340,8 +344,9 @@ def test_wrd_with_non_default_flush_interval(
 
         writer = AsyncAppendableObjectWriter(
             grpc_client,
-            _ZONAL_BUCKET,
+            bucket_for_testing,
             object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
             writer_options={"FLUSH_INTERVAL_BYTES": flush_interval},
         )
         await writer.open()
@@ -353,7 +358,7 @@ def test_wrd_with_non_default_flush_interval(
         assert object_metadata.size == object_size
         assert int(object_metadata.checksums.crc32c) == object_checksum
 
-        mrd = AsyncMultiRangeDownloader(grpc_client, _ZONAL_BUCKET, object_name)
+        mrd = AsyncMultiRangeDownloader(grpc_client, bucket_for_testing, object_name)
         buffer = BytesIO()
         await mrd.open()
         # (0, 0) means read the whole object
@@ -363,14 +368,14 @@ def test_wrd_with_non_default_flush_interval(
         assert mrd.persisted_size == object_size
 
         # Clean up; use json client (i.e. `storage_client` fixture) to delete.
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         del mrd
         gc.collect()
 
     event_loop.run_until_complete(_run())
 
-
+@pytest.mark.skipif(RCU_SYSTEM_TESTS, reason='Write from blob for RCU not supported in SDK yet')
 def test_write_from_blob(
     storage_client,
     blobs_to_delete,
@@ -389,7 +394,7 @@ def test_write_from_blob(
 
     async def _run():
         # 1. Create a Blob instance
-        blob = storage_client.bucket(_ZONAL_BUCKET).blob(object_name)
+        blob = storage_client.bucket(bucket_for_testing).blob(object_name)
         blob.content_type = content_type
         blob.metadata = metadata
         blob.cache_control = cache_control
@@ -406,7 +411,7 @@ def test_write_from_blob(
 
         # 3. Verify the object metadata
         obj = await grpc_client.get_object(
-            bucket_name=_ZONAL_BUCKET,
+            bucket_name=bucket_for_testing,
             object_name=object_name,
         )
 
@@ -423,6 +428,7 @@ def test_write_from_blob(
     event_loop.run_until_complete(_run())
 
 
+@pytest.mark.skipif(RCU_SYSTEM_TESTS, reason='Write from blob with KMS key for RCU not supported in SDK yet')
 def test_write_from_blob_with_kms_key(
     storage_client,
     blobs_to_delete,
@@ -437,7 +443,7 @@ def test_write_from_blob_with_kms_key(
 
     async def _run():
         # Create a local Blob instance with the KMS key
-        blob = storage_client.bucket(_ZONAL_BUCKET).blob(
+        blob = storage_client.bucket(bucket_for_testing).blob(
             object_name, kms_key_name=zonal_kms_key
         )
 
@@ -450,7 +456,7 @@ def test_write_from_blob_with_kms_key(
 
         # Verify the encryption metadata
         obj = await grpc_client.get_object(
-            bucket_name=_ZONAL_BUCKET,
+            bucket_name=bucket_for_testing,
             object_name=object_name,
         )
 
@@ -463,12 +469,13 @@ def test_write_from_blob_with_kms_key(
     event_loop.run_until_complete(_run())
 
 
+@pytest.mark.skipif(RCU_SYSTEM_TESTS, reason='Write blob with contexts for RCU not supported in SDK yet')
 @pytest.mark.asyncio
 async def test_write_blob_with_contexts(storage_client, blobs_to_delete):
     async_client = await create_async_grpc_client()
     blob_name = f"ObjectContextsGrpc-{uuid.uuid4().hex}"
 
-    bucket = storage_client.bucket(_ZONAL_BUCKET)
+    bucket = storage_client.bucket(bucket_for_testing)
     blob = bucket.blob(blob_name)
     blob.contexts = ObjectContexts(
         blob, custom={"foo": ObjectCustomContextPayload(value="bar")}
@@ -480,17 +487,17 @@ async def test_write_blob_with_contexts(storage_client, blobs_to_delete):
 
     try:
         blobs = list(
-            storage_client.list_blobs(_ZONAL_BUCKET, filter_='contexts."foo"="bar"')
+            storage_client.list_blobs(bucket_for_testing, filter_='contexts."foo"="bar"')
         )
         names = [b.name for b in blobs]
         assert blob_name in names
 
         # Assert contexts via gRPC GetObject
-        obj_proto = await async_client.get_object(_ZONAL_BUCKET, blob_name)
+        obj_proto = await async_client.get_object(bucket_for_testing, blob_name)
         assert "foo" in obj_proto.contexts.custom
         assert obj_proto.contexts.custom["foo"].value == "bar"
     finally:
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(blob_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(blob_name))
 
 
 def test_read_unfinalized_appendable_object(
@@ -500,12 +507,17 @@ def test_read_unfinalized_appendable_object(
 
     async def _run():
         grpc_client = grpc_client_direct
-        writer = AsyncAppendableObjectWriter(grpc_client, _ZONAL_BUCKET, object_name)
+        writer = AsyncAppendableObjectWriter(
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
+        )
         await writer.open()
         await writer.append(_BYTES_TO_UPLOAD)
         await writer.flush()
 
-        mrd = AsyncMultiRangeDownloader(grpc_client, _ZONAL_BUCKET, object_name)
+        mrd = AsyncMultiRangeDownloader(grpc_client, bucket_for_testing, object_name)
         buffer = BytesIO()
         await mrd.open()
         assert mrd.persisted_size == len(_BYTES_TO_UPLOAD)
@@ -515,7 +527,7 @@ def test_read_unfinalized_appendable_object(
         assert buffer.getvalue() == _BYTES_TO_UPLOAD
 
         # Clean up; use json client (i.e. `storage_client` fixture) to delete.
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         del mrd
         gc.collect()
@@ -529,20 +541,23 @@ def test_mrd_open_with_read_handle(event_loop, grpc_client_direct):
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(_BYTES_TO_UPLOAD)
         await writer.close()
 
-        mrd = AsyncMultiRangeDownloader(grpc_client_direct, _ZONAL_BUCKET, object_name)
+        mrd = AsyncMultiRangeDownloader(grpc_client_direct, bucket_for_testing, object_name)
         await mrd.open()
         read_handle = mrd.read_handle
         await mrd.close()
 
         # Open a new MRD using the `read_handle` obtained above
         new_mrd = AsyncMultiRangeDownloader(
-            grpc_client_direct, _ZONAL_BUCKET, object_name, read_handle=read_handle
+            grpc_client_direct, bucket_for_testing, object_name, read_handle=read_handle
         )
         await new_mrd.open()
         # persisted_size not set when opened with read_handle
@@ -562,19 +577,24 @@ def test_mrd_open_with_read_handle_over_cloud_path(event_loop, grpc_client):
     object_name = f"test_read_handl-{str(uuid.uuid4())[:4]}"
 
     async def _run():
-        writer = AsyncAppendableObjectWriter(grpc_client, _ZONAL_BUCKET, object_name)
+        writer = AsyncAppendableObjectWriter(
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
+        )
         await writer.open()
         await writer.append(_BYTES_TO_UPLOAD)
         await writer.close()
 
-        mrd = AsyncMultiRangeDownloader(grpc_client, _ZONAL_BUCKET, object_name)
+        mrd = AsyncMultiRangeDownloader(grpc_client, bucket_for_testing, object_name)
         await mrd.open()
         read_handle = mrd.read_handle
         await mrd.close()
 
         # Open a new MRD using the `read_handle` obtained above
         new_mrd = AsyncMultiRangeDownloader(
-            grpc_client, _ZONAL_BUCKET, object_name, read_handle=read_handle
+            grpc_client, bucket_for_testing, object_name, read_handle=read_handle
         )
         await new_mrd.open()
         # persisted_size is set regardless of whether we use read_handle or not
@@ -599,7 +619,10 @@ def test_wrd_open_with_write_handle(
     async def _run():
         # 1. Create an object and get its write_handle
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         write_handle = writer.write_handle
@@ -608,10 +631,11 @@ def test_wrd_open_with_write_handle(
         # 2. Open a new writer using the obtained `write_handle` and generation
         new_writer = AsyncAppendableObjectWriter(
             grpc_client_direct,
-            _ZONAL_BUCKET,
+            bucket_for_testing,
             object_name,
             write_handle=write_handle,
             generation=writer.generation,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await new_writer.open()
         # Verify that the new writer is open and has the same write_handle
@@ -624,7 +648,7 @@ def test_wrd_open_with_write_handle(
         await new_writer.close()
 
         # 4. Verify the data was written correctly by reading it back
-        mrd = AsyncMultiRangeDownloader(grpc_client_direct, _ZONAL_BUCKET, object_name)
+        mrd = AsyncMultiRangeDownloader(grpc_client_direct, bucket_for_testing, object_name)
         buffer = BytesIO()
         await mrd.open()
         await mrd.download_ranges([(0, 0, buffer)])
@@ -632,7 +656,7 @@ def test_wrd_open_with_write_handle(
         assert buffer.getvalue() == test_data
 
         # Clean up
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         del new_writer
         del mrd
@@ -651,7 +675,7 @@ def test_read_unfinalized_appendable_object_with_generation(
         async def _read_and_verify(expected_content, generation=None):
             """Helper to read object content and verify against expected."""
             mrd = AsyncMultiRangeDownloader(
-                grpc_client, _ZONAL_BUCKET, object_name, generation
+                grpc_client, bucket_for_testing, object_name, generation
             )
             buffer = BytesIO()
             await mrd.open()
@@ -664,7 +688,12 @@ def test_read_unfinalized_appendable_object_with_generation(
             return mrd
 
         # First write
-        writer = AsyncAppendableObjectWriter(grpc_client, _ZONAL_BUCKET, object_name)
+        writer = AsyncAppendableObjectWriter(
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
+        )
         await writer.open()
         await writer.append(_BYTES_TO_UPLOAD)
         await writer.flush()
@@ -675,7 +704,11 @@ def test_read_unfinalized_appendable_object_with_generation(
 
         # Second write, using generation from the first write.
         writer_2 = AsyncAppendableObjectWriter(
-            grpc_client, _ZONAL_BUCKET, object_name, generation=generation
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            generation=generation,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer_2.open()
         await writer_2.append(_BYTES_TO_UPLOAD)
@@ -685,7 +718,7 @@ def test_read_unfinalized_appendable_object_with_generation(
         mrd_2 = await _read_and_verify(_BYTES_TO_UPLOAD + _BYTES_TO_UPLOAD, generation)
 
         # Clean up
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         del writer_2
         del mrd
@@ -710,7 +743,11 @@ def test_open_with_generation_zero(
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client, _ZONAL_BUCKET, object_name, generation=0
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            generation=0,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
 
         # Empty object is created.
@@ -722,7 +759,11 @@ def test_open_with_generation_zero(
 
         with pytest.raises(FailedPrecondition) as exc_info:
             writer_fail = AsyncAppendableObjectWriter(
-                grpc_client, _ZONAL_BUCKET, object_name, generation=0
+                grpc_client,
+                bucket_for_testing,
+                object_name,
+                generation=0,
+                storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
             )
             await writer_fail.open()
         assert exc_info.value.code == 400
@@ -731,7 +772,7 @@ def test_open_with_generation_zero(
         del writer
         gc.collect()
 
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -746,7 +787,11 @@ def test_open_existing_object_with_gen_None_overrides_existing(
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client, _ZONAL_BUCKET, object_name, generation=0
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            generation=0,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
 
         # Empty object is created.
@@ -758,7 +803,11 @@ def test_open_existing_object_with_gen_None_overrides_existing(
         assert not writer.is_stream_open
 
         new_writer = AsyncAppendableObjectWriter(
-            grpc_client, _ZONAL_BUCKET, object_name, generation=None
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            generation=None,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await new_writer.open()
         assert new_writer.generation != old_gen
@@ -768,7 +817,7 @@ def test_open_existing_object_with_gen_None_overrides_existing(
         del new_writer
         gc.collect()
 
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -781,7 +830,11 @@ def test_delete_object_using_grpc_client(event_loop, grpc_client_direct):
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name, generation=0
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            generation=0,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
 
         # Empty object is created.
@@ -789,13 +842,13 @@ def test_delete_object_using_grpc_client(event_loop, grpc_client_direct):
         await writer.append(b"some_bytes")
         await writer.close()
 
-        await grpc_client_direct.delete_object(_ZONAL_BUCKET, object_name)
+        await grpc_client_direct.delete_object(bucket_for_testing, object_name)
 
         # trying to get raises raises 404.
         with pytest.raises(NotFound):
             # TODO: Remove this once GET_OBJECT is exposed in `AsyncGrpcClient`
             await grpc_client_direct._grpc_client.get_object(
-                bucket=f"projects/_/buckets/{_ZONAL_BUCKET}", object_=object_name
+                bucket=f"projects/_/buckets/{bucket_for_testing}", object_=object_name
             )
         # cleanup
         del writer
@@ -833,14 +886,17 @@ def test_mrd_concurrent_download(
         object_data = os.urandom(object_size)
 
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(object_data)
         await writer.close(finalize_on_close=True)
 
         async with AsyncMultiRangeDownloader(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct, bucket_for_testing, object_name
         ) as mrd:
             tasks = []
             ranges_to_fetch = []
@@ -876,7 +932,7 @@ def test_mrd_concurrent_download(
 
         del writer
         gc.collect()
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -896,14 +952,17 @@ def test_mrd_concurrent_download_cancellation(
         object_data = os.urandom(object_size)
 
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(object_data)
         await writer.close(finalize_on_close=True)
 
         async with AsyncMultiRangeDownloader(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct, bucket_for_testing, object_name
         ) as mrd:
             tasks = []
             num_chunks = 40
@@ -937,7 +996,7 @@ def test_mrd_concurrent_download_cancellation(
 
         del writer
         gc.collect()
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -957,14 +1016,17 @@ def test_mrd_concurrent_download_out_of_bounds(
         object_data = os.urandom(object_size)
 
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(object_data)
         await writer.close(finalize_on_close=True)
 
         async with AsyncMultiRangeDownloader(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct, bucket_for_testing, object_name
         ) as mrd:
             valid_buffer = BytesIO()
             valid_task = asyncio.create_task(
@@ -986,7 +1048,7 @@ def test_mrd_concurrent_download_out_of_bounds(
 
         del writer
         gc.collect()
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -1018,14 +1080,17 @@ def test_mrd_checksum_validation(
         object_data = os.urandom(object_size)
 
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(object_data)
         await writer.close(finalize_on_close=True)
 
         async with AsyncMultiRangeDownloader(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct, bucket_for_testing, object_name
         ) as mrd:
             buffer = BytesIO()
             await mrd.download_ranges(
@@ -1036,7 +1101,7 @@ def test_mrd_checksum_validation(
         # cleanup
         del writer
         gc.collect()
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -1052,7 +1117,10 @@ def test_mrd_checksum_unfinalized_appendable_skipped(
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(_BYTES_TO_UPLOAD)
@@ -1060,7 +1128,7 @@ def test_mrd_checksum_unfinalized_appendable_skipped(
 
         # Download the unfinalized appendable object with enable_checksum=True
         async with AsyncMultiRangeDownloader(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct, bucket_for_testing, object_name
         ) as mrd:
             buffer = BytesIO()
             # Since it's unfinalized, it should skip the checksum check without raising
@@ -1071,7 +1139,7 @@ def test_mrd_checksum_unfinalized_appendable_skipped(
         await writer.close()
         del writer
         gc.collect()
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
 
     event_loop.run_until_complete(_run())
 
@@ -1088,7 +1156,10 @@ def test_finalize_with_correct_checksum(
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(object_data)
@@ -1098,7 +1169,7 @@ def test_finalize_with_correct_checksum(
         assert int(object_metadata.checksums.crc32c) == object_checksum
 
         # clean up
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         gc.collect()
 
@@ -1118,7 +1189,10 @@ def test_finalize_with_incorrect_checksum_fails(
 
     async def _run():
         writer = AsyncAppendableObjectWriter(
-            grpc_client_direct, _ZONAL_BUCKET, object_name
+            grpc_client_direct,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
         )
         await writer.open()
         await writer.append(object_data)
@@ -1134,7 +1208,7 @@ def test_finalize_with_incorrect_checksum_fails(
         )
 
         # clean up
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(storage_client.bucket(bucket_for_testing).blob(object_name))
         del writer
         gc.collect()
 

--- a/packages/google-cloud-storage/tests/system/test_zonal.py
+++ b/packages/google-cloud-storage/tests/system/test_zonal.py
@@ -27,10 +27,16 @@ from google.cloud.storage.blob import (
     ObjectContexts,
     ObjectCustomContextPayload,
 )
+from google.api_core.client_options import ClientOptions
+
+PREPROD_GRPC_ENDPOINT = "storage-preprod-test-grpc.googleusercontent.com:443"
 
 pytestmark = pytest.mark.skipif(
-    os.getenv("RUN_ZONAL_SYSTEM_TESTS") != "True",
-    reason="Zonal system tests need to be explicitly enabled. This helps scheduling tests in Kokoro and Cloud Build.",
+    not (
+        (os.getenv("RUN_ZONAL_SYSTEM_TESTS") == "True")
+        ^ (os.getenv("RUN_RCU_SYSTEM_TESTS") == "True")
+    ),
+    reason="Any one of Zonal or RCU system tests need to be explicitly enabled. This helps scheduling tests in Kokoro and Cloud Build.",
 )
 
 
@@ -40,10 +46,20 @@ _ZONAL_BUCKET = os.getenv("ZONAL_BUCKET")
 _CROSS_REGION_BUCKET = os.getenv("CROSS_REGION_BUCKET")
 _BYTES_TO_UPLOAD = b"dummy_bytes_to_write_read_and_delete_appendable_object"
 
+RCU_SYSTEM_TESTS = os.getenv("RUN_RCU_SYSTEM_TESTS") == "True"
+_RCU_BUCKET = os.getenv("RCU_BUCKET")
+bucket_for_testing = (
+    _ZONAL_BUCKET if os.getenv("RUN_ZONAL_SYSTEM_TESTS") else _RCU_BUCKET
+)
 
-async def create_async_grpc_client(attempt_direct_path=True):
+async def create_async_grpc_client(attempt_direct_path=True, preprod=False):
     """Initializes async client and gets the current event loop."""
-    return AsyncGrpcClient(attempt_direct_path=attempt_direct_path)
+    return AsyncGrpcClient(
+        attempt_direct_path=attempt_direct_path,
+        client_options=ClientOptions(api_endpoint=PREPROD_GRPC_ENDPOINT)
+        if preprod
+        else None,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -107,7 +123,7 @@ def event_loop():
 
 
 @pytest.fixture(scope="session")
-def grpc_clients(event_loop):
+def grpc_clients(event_loop, run_system_tests_on_preprod):
     # grpc clients has to be instantiated in the event loop,
     # otherwise grpc creates it's own event loop and attaches to the client.
     # Which will lead to deadlock because client running in one event loop and
@@ -116,10 +132,14 @@ def grpc_clients(event_loop):
     # https://github.com/grpc/grpc/blob/61fe9b40a986792ab7d4eb8924027b671faf26ba/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi#L249
     clients = {
         True: event_loop.run_until_complete(
-            create_async_grpc_client(attempt_direct_path=True)
+            create_async_grpc_client(
+                attempt_direct_path=True, preprod=run_system_tests_on_preprod
+            )
         ),
         False: event_loop.run_until_complete(
-            create_async_grpc_client(attempt_direct_path=False)
+            create_async_grpc_client(
+                attempt_direct_path=False, preprod=run_system_tests_on_preprod
+            )
         ),
     }
     return clients
@@ -217,8 +237,13 @@ def test_basic_wrd(
         object_data = os.urandom(object_size)
         object_checksum = google_crc32c.value(object_data)
         grpc_client = grpc_clients[attempt_direct_path]
-
-        writer = AsyncAppendableObjectWriter(grpc_client, _ZONAL_BUCKET, object_name)
+        print("bucket for testing", bucket_for_testing)
+        writer = AsyncAppendableObjectWriter(
+            grpc_client,
+            bucket_for_testing,
+            object_name,
+            storage_class="RAPID" if RCU_SYSTEM_TESTS else None,
+        )
         await writer.open()
         await writer.append(object_data)
         object_metadata = await writer.close(finalize_on_close=True)
@@ -227,7 +252,7 @@ def test_basic_wrd(
 
         buffer = BytesIO()
         async with AsyncMultiRangeDownloader(
-            grpc_client, _ZONAL_BUCKET, object_name
+            grpc_client, bucket_for_testing, object_name
         ) as mrd:
             # (0, 0) means read the whole object
             await mrd.download_ranges([(0, 0, buffer)])
@@ -236,7 +261,9 @@ def test_basic_wrd(
         assert buffer.getvalue() == object_data
 
         # Clean up; use json client (i.e. `storage_client` fixture) to delete.
-        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        blobs_to_delete.append(
+            storage_client.bucket(bucket_for_testing).blob(object_name)
+        )
         del writer
         gc.collect()
 

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_appendable_object_writer.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_appendable_object_writer.py
@@ -117,6 +117,7 @@ def mock_appendable_writer():
     yield {
         "mock_client": mock_client,
         "mock_stream": mock_stream,
+        "mock_stream_cls": mock_stream_cls,
     }
 
     stream_patcher.stop()
@@ -137,6 +138,15 @@ class TestAsyncAppendableObjectWriter:
         assert writer.persisted_size is None
         assert writer.bytes_appended_since_last_flush == 0
         assert writer.flush_interval == _DEFAULT_FLUSH_INTERVAL_BYTES
+        assert writer.storage_class is None
+
+    @pytest.mark.parametrize("storage_class", ["STANDARD", "RAPID"])
+    def test_init_with_storage_class(self, mock_appendable_writer, storage_class):
+        writer = self._make_one(
+            mock_appendable_writer["mock_client"],
+            storage_class=storage_class,
+        )
+        assert writer.storage_class == storage_class
 
     def test_init_with_writer_options(self, mock_appendable_writer):
         writer = self._make_one(
@@ -218,6 +228,36 @@ class TestAsyncAppendableObjectWriter:
         assert writer.generation == 456
         assert writer.write_handle == b"new-h"
         mock_appendable_writer["mock_stream"].open.assert_awaited_once()
+        mock_stream_cls = mock_appendable_writer["mock_stream_cls"]
+        assert mock_stream_cls.call_args.kwargs["storage_class"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("storage_class", ["STANDARD", "RAPID"])
+    async def test_open_passes_storage_class(
+        self, mock_appendable_writer, storage_class
+    ):
+        writer = self._make_one(
+            mock_appendable_writer["mock_client"],
+            storage_class=storage_class,
+        )
+        mock_appendable_writer["mock_stream"].generation_number = 456
+        mock_appendable_writer["mock_stream"].write_handle = b"new-h"
+        mock_appendable_writer["mock_stream"].persisted_size = 0
+
+        await writer.open()
+
+        assert writer._is_stream_open
+        mock_stream_cls = mock_appendable_writer["mock_stream_cls"]
+        mock_stream_cls.assert_called_once_with(
+            client=mock_appendable_writer["mock_client"].grpc_client,
+            bucket_name=BUCKET,
+            object_name=OBJECT,
+            blob=None,
+            generation_number=None,
+            write_handle=None,
+            routing_token=None,
+            storage_class=storage_class,
+        )
 
     def test_on_open_error_redirection(self, mock_appendable_writer):
         """Verify redirect info is extracted from helper."""

--- a/packages/google-cloud-storage/tests/unit/asyncio/test_async_write_object_stream.py
+++ b/packages/google-cloud-storage/tests/unit/asyncio/test_async_write_object_stream.py
@@ -63,6 +63,14 @@ class TestAsyncWriteObjectStream:
             ("x-goog-request-params", f"bucket={FULL_BUCKET_PATH}"),
         )
         assert not stream.is_stream_open
+        assert stream.storage_class is None
+
+    @pytest.mark.parametrize("storage_class", ["STANDARD", "RAPID"])
+    def test_init_with_storage_class(self, mock_client, storage_class):
+        stream = _AsyncWriteObjectStream(
+            mock_client, BUCKET, OBJECT, storage_class=storage_class
+        )
+        assert stream.storage_class == storage_class
 
     def test_init_raises_value_error(self, mock_client):
         with pytest.raises(ValueError, match="client must be provided"):
@@ -96,8 +104,44 @@ class TestAsyncWriteObjectStream:
         # Check if BidiRpc was initialized with WriteObjectSpec
         call_args = mock_rpc_cls.call_args
         initial_request = call_args.kwargs["initial_request"]
+        # In proto3, string fields default to "" rather than None
+        resource = initial_request.write_object_spec.resource
+        assert "storage_class" not in resource
+        assert resource.storage_class == ""
+        assert initial_request.write_object_spec.appendable
+
+        assert stream.is_stream_open
+        assert stream.write_handle == WRITE_HANDLE
+        assert stream.generation_number == GENERATION
+
+    @mock.patch("google.cloud.storage.asyncio.async_write_object_stream.AsyncBidiRpc")
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("storage_class", ["STANDARD", "RAPID"])
+    async def test_open_new_object_with_storage_class(
+        self, mock_rpc_cls, mock_client, storage_class
+    ):
+        mock_rpc = mock_rpc_cls.return_value
+        mock_rpc.open = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.persisted_size = 0
+        mock_response.resource.generation = GENERATION
+        mock_response.resource.size = 0
+        mock_response.write_handle = WRITE_HANDLE
+        mock_rpc.recv = AsyncMock(return_value=mock_response)
+
+        stream = _AsyncWriteObjectStream(
+            mock_client, BUCKET, OBJECT, storage_class=storage_class
+        )
+        await stream.open()
+
+        call_args = mock_rpc_cls.call_args
+        initial_request = call_args.kwargs["initial_request"]
         assert initial_request.write_object_spec is not None
         assert initial_request.write_object_spec.resource.name == OBJECT
+        assert (
+            initial_request.write_object_spec.resource.storage_class == storage_class
+        )
         assert initial_request.write_object_spec.appendable
 
         assert stream.is_stream_open

--- a/packages/google-cloud-storage/tests/unit/test_blob.py
+++ b/packages/google-cloud-storage/tests/unit/test_blob.py
@@ -86,6 +86,7 @@ class Test_Blob(unittest.TestCase):
         self.assertIs(blob._acl.blob, blob)
         self.assertEqual(blob._encryption_key, None)
         self.assertEqual(blob.kms_key_name, None)
+        self.assertIsNone(blob.storage_class)
 
     def test_ctor_with_encoded_unicode(self):
         blob_name = b"wet \xe2\x9b\xb5"
@@ -138,6 +139,43 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket()
         blob = self._make_one(BLOB_NAME, bucket=bucket, generation=GENERATION)
         self.assertEqual(blob.generation, GENERATION)
+
+    def test_ctor_with_storage_class(self):
+        BLOB_NAME = "blob-name"
+        STORAGE_CLASS = "STANDARD"
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket, storage_class=STORAGE_CLASS)
+        self.assertEqual(blob.storage_class, STORAGE_CLASS)
+        self.assertEqual(blob._properties.get("storageClass"), STORAGE_CLASS)
+
+    def test_ctor_with_storage_class_rapid(self):
+        BLOB_NAME = "blob-name"
+        STORAGE_CLASS = "RAPID"
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket, storage_class=STORAGE_CLASS)
+        self.assertEqual(blob.storage_class, STORAGE_CLASS)
+        self.assertEqual(blob._properties.get("storageClass"), STORAGE_CLASS)
+
+    def test_ctor_with_storage_class_default(self):
+        BLOB_NAME = "blob-name"
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        self.assertIsNone(blob.storage_class)
+        self.assertNotIn("storageClass", blob._properties)
+
+    def test_storage_class_property(self):
+        BLOB_NAME = "blob-name"
+        bucket = _Bucket()
+        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        self.assertIsNone(blob.storage_class)
+        blob.storage_class = "STANDARD"
+        self.assertEqual(blob.storage_class, "STANDARD")
+        self.assertEqual(blob._properties.get("storageClass"), "STANDARD")
+        self.assertIn("storageClass", blob._changes)
+
+        blob.storage_class = None
+        self.assertIsNone(blob.storage_class)
+        self.assertIsNone(blob._properties.get("storageClass"))
 
     def _set_properties_helper(self, kms_key_name=None):
         from google.cloud._helpers import _RFC3339_MICROS


### PR DESCRIPTION
## Description
Adds support for specifying and accessing `storage_class` in `Blob`.

> **Note**: Stacked on #18289 (`feat/storage-class-rapid`).

### Changes
- Added `storage_class=None` parameter and documentation to `Blob.__init__`.
- Stored `storage_class` in `self._properties["storageClass"]`.
- Added explicit `storage_class` property getter and setter with docstrings noting that it defaults to `None` and inherits the bucket's storage class if unspecified.
- Added unit tests in `tests/unit/test_blob.py` verifying constructor behavior with default and specified storage classes (`STANDARD`, `RAPID`), as well as getter/setter behavior.