### PR TITLE
docs(bigquery): fix table rendering in markdown docs

### DIFF
--- a/packages/google-cloud-bigquery/docs/conf.py
+++ b/packages/google-cloud-bigquery/docs/conf.py
@@ -24,9 +24,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 import shlex
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -36,6 +36,26 @@ sys.path.insert(0, os.path.abspath(".."))
 # For plugins that can not read conf.py.
 # See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
 sys.path.insert(0, os.path.abspath("."))
+
+# sphinx-markdown-builder unconditionally inserts trailing newlines into
+# table cell paragraphs, breaking DevSite table formatting. Suppressing
+# newlines while inside table cells preserves valid GFM tables.
+try:
+    import sphinx_markdown_builder.markdown_writer as _smb_writer
+
+    _orig_depart_paragraph = _smb_writer.MarkdownTranslator.depart_paragraph
+
+    def _table_safe_depart_paragraph(self, node):
+        if getattr(self, "table_entries", None):
+            return
+        return _orig_depart_paragraph(self, node)
+
+    _smb_writer.MarkdownTranslator.depart_paragraph = _table_safe_depart_paragraph
+    _smb_writer.MarkdownTranslator.depart_compact_paragraph = (
+        _table_safe_depart_paragraph
+    )
+except ImportError:
+    pass
 
 __version__ = ""
 

--- a/packages/google-cloud-bigquery/docs/conf.py
+++ b/packages/google-cloud-bigquery/docs/conf.py
@@ -37,10 +37,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
 sys.path.insert(0, os.path.abspath("."))
 
-# TODO(b/559711363): Apply this table formatting fix across all google-cloud-* libraries.
-# sphinx-markdown-builder unconditionally inserts trailing newlines into
-# table cell paragraphs, breaking DevSite table formatting. Suppressing
-# newlines while inside table cells preserves valid GFM tables.
+# TODO(b/559711363): Propagate table formatting fix across all google-cloud-* libraries.
 try:
     import sphinx_markdown_builder.markdown_writer as _smb_writer
 

--- a/packages/google-cloud-bigquery/docs/conf.py
+++ b/packages/google-cloud-bigquery/docs/conf.py
@@ -37,6 +37,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
 sys.path.insert(0, os.path.abspath("."))
 
+# TODO(b/559711363): Apply this table formatting fix across all google-cloud-* libraries.
 # sphinx-markdown-builder unconditionally inserts trailing newlines into
 # table cell paragraphs, breaking DevSite table formatting. Suppressing
 # newlines while inside table cells preserves valid GFM tables.

--- a/packages/google-cloud-bigquery/tests/unit/test_docs.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_docs.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import runpy
+
+
+def test_docs_conf_executes_successfully():
+    docs_dir = pathlib.Path(__file__).parent.parent.parent / "docs"
+    conf_path = docs_dir / "conf.py"
+
+    res = runpy.run_path(str(conf_path))
+
+    assert "project" in res
+    assert res["project"] == "google-cloud-bigquery"

--- a/packages/google-cloud-bigquery/tests/unit/test_docs.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_docs.py
@@ -20,6 +20,10 @@ def test_docs_conf_executes_successfully():
     docs_dir = pathlib.Path(__file__).parent.parent.parent / "docs"
     conf_path = docs_dir / "conf.py"
 
+    if not conf_path.exists():
+        import pytest
+        pytest.skip("docs/conf.py not found")
+
     res = runpy.run_path(str(conf_path))
 
     assert "project" in res

--- a/packages/google-cloud-bigquery/tests/unit/test_docs.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_docs.py
@@ -22,6 +22,7 @@ def test_docs_conf_executes_successfully():
 
     if not conf_path.exists():
         import pytest
+
         pytest.skip("docs/conf.py not found")
 
     res = runpy.run_path(str(conf_path))

--- a/packages/google-cloud-bigquery/tests/unit/test_docs.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_docs.py
@@ -18,29 +18,25 @@ import sys
 import types
 from unittest import mock
 
+import pytest
+
 
 def test_docs_conf_executes_successfully():
     docs_dir = pathlib.Path(__file__).parent.parent.parent / "docs"
     conf_path = docs_dir / "conf.py"
-
     if not conf_path.exists():
-        import pytest
-
         pytest.skip("docs/conf.py not found")
 
     res = runpy.run_path(str(conf_path))
 
-    assert "project" in res
-    assert res["project"] == "google-cloud-bigquery"
+    assert res.get("project") == "google-cloud-bigquery"
 
 
-def test_docs_conf_patches_markdown_translator():
+@pytest.fixture
+def fake_translator_and_mock():
     docs_dir = pathlib.Path(__file__).parent.parent.parent / "docs"
     conf_path = docs_dir / "conf.py"
-
     if not conf_path.exists():
-        import pytest
-
         pytest.skip("docs/conf.py not found")
 
     mock_orig_depart = mock.MagicMock(return_value="original_output")
@@ -61,31 +57,41 @@ def test_docs_conf_patches_markdown_translator():
     ):
         runpy.run_path(str(conf_path))
 
-    assert FakeTranslator.depart_paragraph is not mock_orig_depart
-    assert FakeTranslator.depart_compact_paragraph is not mock_orig_depart
+    return FakeTranslator, mock_orig_depart
 
-    translator_in_table = FakeTranslator()
-    translator_in_table.table_entries = ["entry"]
-    assert (
-        FakeTranslator.depart_paragraph(translator_in_table, mock.MagicMock()) is None
-    )
-    assert (
-        FakeTranslator.depart_compact_paragraph(translator_in_table, mock.MagicMock())
-        is None
-    )
+
+def test_depart_paragraph_suppresses_newlines_inside_table_cells(
+    fake_translator_and_mock,
+):
+    FakeTranslator, mock_orig_depart = fake_translator_and_mock
+    translator = FakeTranslator()
+    translator.table_entries = ["cell"]
+    node = mock.MagicMock()
+
+    res_paragraph = FakeTranslator.depart_paragraph(translator, node)
+    res_compact = FakeTranslator.depart_compact_paragraph(translator, node)
+
+    assert res_paragraph is None
+    assert res_compact is None
     mock_orig_depart.assert_not_called()
 
-    translator_outside_table = FakeTranslator()
-    mock_node = mock.MagicMock()
-    assert (
-        FakeTranslator.depart_paragraph(translator_outside_table, mock_node)
-        == "original_output"
-    )
-    mock_orig_depart.assert_called_once_with(translator_outside_table, mock_node)
 
-    mock_orig_depart.reset_mock()
-    assert (
-        FakeTranslator.depart_compact_paragraph(translator_outside_table, mock_node)
-        == "original_output"
+def test_depart_paragraph_delegates_outside_table_cells(
+    fake_translator_and_mock,
+):
+    FakeTranslator, mock_orig_depart = fake_translator_and_mock
+    translator = FakeTranslator()
+    node = mock.MagicMock()
+
+    res_paragraph = FakeTranslator.depart_paragraph(translator, node)
+    res_compact = FakeTranslator.depart_compact_paragraph(translator, node)
+
+    assert res_paragraph == "original_output"
+    assert res_compact == "original_output"
+    assert mock_orig_depart.call_count == 2
+    mock_orig_depart.assert_has_calls(
+        [
+            mock.call(translator, node),
+            mock.call(translator, node),
+        ]
     )
-    mock_orig_depart.assert_called_once_with(translator_outside_table, mock_node)

--- a/packages/google-cloud-bigquery/tests/unit/test_docs.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_docs.py
@@ -14,6 +14,9 @@
 
 import pathlib
 import runpy
+import sys
+import types
+from unittest import mock
 
 
 def test_docs_conf_executes_successfully():
@@ -29,3 +32,60 @@ def test_docs_conf_executes_successfully():
 
     assert "project" in res
     assert res["project"] == "google-cloud-bigquery"
+
+
+def test_docs_conf_patches_markdown_translator():
+    docs_dir = pathlib.Path(__file__).parent.parent.parent / "docs"
+    conf_path = docs_dir / "conf.py"
+
+    if not conf_path.exists():
+        import pytest
+
+        pytest.skip("docs/conf.py not found")
+
+    mock_orig_depart = mock.MagicMock(return_value="original_output")
+
+    class FakeTranslator:
+        depart_paragraph = mock_orig_depart
+        depart_compact_paragraph = mock_orig_depart
+
+    fake_module = types.ModuleType("sphinx_markdown_builder.markdown_writer")
+    fake_module.MarkdownTranslator = FakeTranslator
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sphinx_markdown_builder": types.ModuleType("sphinx_markdown_builder"),
+            "sphinx_markdown_builder.markdown_writer": fake_module,
+        },
+    ):
+        runpy.run_path(str(conf_path))
+
+    assert FakeTranslator.depart_paragraph is not mock_orig_depart
+    assert FakeTranslator.depart_compact_paragraph is not mock_orig_depart
+
+    translator_in_table = FakeTranslator()
+    translator_in_table.table_entries = ["entry"]
+    assert (
+        FakeTranslator.depart_paragraph(translator_in_table, mock.MagicMock()) is None
+    )
+    assert (
+        FakeTranslator.depart_compact_paragraph(translator_in_table, mock.MagicMock())
+        is None
+    )
+    mock_orig_depart.assert_not_called()
+
+    translator_outside_table = FakeTranslator()
+    mock_node = mock.MagicMock()
+    assert (
+        FakeTranslator.depart_paragraph(translator_outside_table, mock_node)
+        == "original_output"
+    )
+    mock_orig_depart.assert_called_once_with(translator_outside_table, mock_node)
+
+    mock_orig_depart.reset_mock()
+    assert (
+        FakeTranslator.depart_compact_paragraph(translator_outside_table, mock_node)
+        == "original_output"
+    )
+    mock_orig_depart.assert_called_once_with(translator_outside_table, mock_node)


### PR DESCRIPTION
This monkeypatch is an isolated workaround in docs/conf.py while a permanent upstream fix is not scheduled in gcp-sphinx-docfx-yaml.

Fixes table formatting in the generated Markdown reference documentation for `google-cloud-bigquery`.
When building Markdown documentation via `sphinx-markdown-builder`, table cell paragraphs unconditionally emit trailing newlines. This breaks single-line GitHub Flavored Markdown (GFM) table rows, causing cell padding to be interpreted as 4-space indented code blocks on reference doc pages. 

This change adds a targeted patch in `docs/conf.py` that suppresses newlines when exiting paragraphs inside table cells, restoring valid GFM table syntax.

before: screen/3oup25c57irb8
after: screen/4GqUXF7gs4p6GZV (render locally with `nox -s doxfx`)
stage: https://clouddocs.devsite.corp.google.com/python/docs/reference/bigquery/latest

Fixes #<522853190> 🦕