### PR TITLE
test: isolate default credential project environment (#17759)

### DIFF
--- a/packages/google-auth/tests/test__default.py
+++ b/packages/google-auth/tests/test__default.py
@@ -41,6 +41,14 @@ import google.oauth2.credentials
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 AUTHORIZED_USER_FILE = os.path.join(DATA_DIR, "authorized_user.json")
 
+
+@pytest.fixture(autouse=True)
+def clear_project_environment_variables(monkeypatch):
+    """Keep default credential tests independent of local project settings."""
+    monkeypatch.delenv(environment_vars.PROJECT, raising=False)
+    monkeypatch.delenv(environment_vars.LEGACY_PROJECT, raising=False)
+
+
 with open(AUTHORIZED_USER_FILE) as fh:
     AUTHORIZED_USER_FILE_DATA = json.load(fh)
 


### PR DESCRIPTION
## Description

This PR fixes #17759 by isolating `tests/test__default.py` from project IDs configured in the local environment. It clears `GOOGLE_CLOUD_PROJECT` and the legacy `GCLOUD_PROJECT` before each test, while tests that need those variables continue to set them explicitly.

## Testing
I ran `python -m pytest tests/test__default.py` both with and without `GOOGLE_CLOUD_PROJECT` set. Both runs produced the same result: 93 passing tests and 3 unrelated Windows failures caused by unescaped Windows paths in regex assertions.

- [x] Issue #17759 was opened before this change
- [ ] Tests and linter pass completely; see the unrelated Windows failures above
- [x] Code coverage does not decrease because this is a test-only change
- [x] No documentation changes are needed

Fixes #17759 🦕