### PR TITLE
chore: update librarian version to v0.42.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.40.0
+version: v0.42.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:

--- a/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/async_client.py
+++ b/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/async_client.py
@@ -452,10 +452,9 @@ class DataSubscriptionServiceAsyncClient:
             google.api_core.operation_async.AsyncOperation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be
-                :class:`google.devicesandservices.health_v4.types.Subscriber`
-                -- Resource Messages -- A subscriber receives
-                notifications from Google Health API.
+                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
+                   A subscriber receives notifications from Google
+                   Health API.
 
         """
         # Create or coerce a protobuf request object.
@@ -753,10 +752,9 @@ class DataSubscriptionServiceAsyncClient:
             google.api_core.operation_async.AsyncOperation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be
-                :class:`google.devicesandservices.health_v4.types.Subscriber`
-                -- Resource Messages -- A subscriber receives
-                notifications from Google Health API.
+                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
+                   A subscriber receives notifications from Google
+                   Health API.
 
         """
         # Create or coerce a protobuf request object.

--- a/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/client.py
+++ b/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/client.py
@@ -781,10 +781,9 @@ class DataSubscriptionServiceClient(metaclass=DataSubscriptionServiceClientMeta)
             google.api_core.operation.Operation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be
-                :class:`google.devicesandservices.health_v4.types.Subscriber`
-                -- Resource Messages -- A subscriber receives
-                notifications from Google Health API.
+                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
+                   A subscriber receives notifications from Google
+                   Health API.
 
         """
         # Create or coerce a protobuf request object.
@@ -1076,10 +1075,9 @@ class DataSubscriptionServiceClient(metaclass=DataSubscriptionServiceClientMeta)
             google.api_core.operation.Operation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be
-                :class:`google.devicesandservices.health_v4.types.Subscriber`
-                -- Resource Messages -- A subscriber receives
-                notifications from Google Health API.
+                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
+                   A subscriber receives notifications from Google
+                   Health API.
 
         """
         # Create or coerce a protobuf request object.


### PR DESCRIPTION
Update librarian version to v0.42.0.
### Included Librarian Updates
- googleapis/librarian#7524: chore(main): release 0.42.0
- googleapis/librarian#7473: chore(main): release 0.41.0
- googleapis/librarian#7508: fix(internal/librarian): update bulk release-please config for existing python libraries
- googleapis/librarian#7489: build(.github/workflows): separate java integration test into standalone job
- googleapis/librarian#7491: ci(.github): increase timeout of php integration test
- googleapis/librarian#7487: refactor(internal/config): remove nodejs_apis from NodejsPackage
- googleapis/librarian#7469: build(.github): add test matrix for PHP
- googleapis/librarian#7482: build(deps): bump google.golang.org/grpc from 1.82.1 to 1.83.1
