### PR TITLE
fix(google-devicesandservices-health): pin pypandoc-binary 1.16.2 and regenerate docstrings

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -30,6 +30,8 @@ tools:
       version: 5.11.0
     - name: nox
       version: 2025.11.12
+    - name: pypandoc-binary
+      version: 1.16.2
     - name: ruff
       version: 0.14.14
     - name: synthtool

--- a/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/async_client.py
+++ b/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/async_client.py
@@ -452,9 +452,10 @@ class DataSubscriptionServiceAsyncClient:
             google.api_core.operation_async.AsyncOperation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
-                   A subscriber receives notifications from Google
-                   Health API.
+                The result type for the operation will be
+                :class:`google.devicesandservices.health_v4.types.Subscriber`
+                -- Resource Messages -- A subscriber receives
+                notifications from Google Health API.
 
         """
         # Create or coerce a protobuf request object.
@@ -752,9 +753,10 @@ class DataSubscriptionServiceAsyncClient:
             google.api_core.operation_async.AsyncOperation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
-                   A subscriber receives notifications from Google
-                   Health API.
+                The result type for the operation will be
+                :class:`google.devicesandservices.health_v4.types.Subscriber`
+                -- Resource Messages -- A subscriber receives
+                notifications from Google Health API.
 
         """
         # Create or coerce a protobuf request object.

--- a/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/client.py
+++ b/packages/google-devicesandservices-health/google/devicesandservices/health_v4/services/data_subscription_service/client.py
@@ -781,9 +781,10 @@ class DataSubscriptionServiceClient(metaclass=DataSubscriptionServiceClientMeta)
             google.api_core.operation.Operation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
-                   A subscriber receives notifications from Google
-                   Health API.
+                The result type for the operation will be
+                :class:`google.devicesandservices.health_v4.types.Subscriber`
+                -- Resource Messages -- A subscriber receives
+                notifications from Google Health API.
 
         """
         # Create or coerce a protobuf request object.
@@ -1075,9 +1076,10 @@ class DataSubscriptionServiceClient(metaclass=DataSubscriptionServiceClientMeta)
             google.api_core.operation.Operation:
                 An object representing a long-running operation.
 
-                The result type for the operation will be :class:`google.devicesandservices.health_v4.types.Subscriber` -- Resource Messages --
-                   A subscriber receives notifications from Google
-                   Health API.
+                The result type for the operation will be
+                :class:`google.devicesandservices.health_v4.types.Subscriber`
+                -- Resource Messages -- A subscriber receives
+                notifications from Google Health API.
 
         """
         # Create or coerce a protobuf request object.


### PR DESCRIPTION
Fixes #18306.

- Adds `pypandoc-binary==1.16.2` (which bundles Pandoc 3.8.2.1, matching `.github/workflows/regenerate-all.yml`) to `tools.pip` in `librarian.yaml` so `librarian install` provisions the expected Pandoc binary in local and rotation environments.
- Regenerates docstrings in `packages/google-devicesandservices-health` using Pandoc 3.8.2.


BEGIN_COMMIT_OVERRIDE
chore(google-devicesandservices-health): pin pypandoc-binary 1.16.2 and regenerate docstrings
END_COMMIT_OVERRIDE