### PR TITLE
test(auth): clean up test coverage and outdated docstrings for mTLS and identity pool

### DIFF
--- a/packages/google-auth/tests/compute_engine/test__mtls.py
+++ b/packages/google-auth/tests/compute_engine/test__mtls.py
@@ -326,3 +326,15 @@ def test_mds_mtls_adapter_send_no_fallback_strict_mode(
         request = requests.Request(method="GET", url="https://fake-mds.com").prepare()
         with pytest.raises(requests.exceptions.SSLError):
             adapter.send(request)
+
+@mock.patch("requests.adapters.HTTPAdapter.close")
+@mock.patch("ssl.create_default_context")
+def test_mds_mtls_adapter_close(
+    mock_ssl_context, mock_super_close, mock_mds_mtls_config
+):
+    adapter = _mtls.MdsMtlsAdapter(mock_mds_mtls_config)
+    with mock.patch.object(adapter._fallback_adapter, "close") as mock_fallback_close:
+        adapter.close()
+        mock_fallback_close.assert_called_once()
+        mock_super_close.assert_called_once()
+

--- a/packages/google-auth/tests/compute_engine/test__mtls.py
+++ b/packages/google-auth/tests/compute_engine/test__mtls.py
@@ -327,6 +327,7 @@ def test_mds_mtls_adapter_send_no_fallback_strict_mode(
         with pytest.raises(requests.exceptions.SSLError):
             adapter.send(request)
 
+
 @mock.patch("requests.adapters.HTTPAdapter.close")
 @mock.patch("google.auth.compute_engine._mtls.ssl.create_default_context")
 def test_mds_mtls_adapter_close(
@@ -337,4 +338,3 @@ def test_mds_mtls_adapter_close(
         adapter.close()
         mock_fallback_close.assert_called_once()
         mock_super_close.assert_called_once()
-

--- a/packages/google-auth/tests/compute_engine/test__mtls.py
+++ b/packages/google-auth/tests/compute_engine/test__mtls.py
@@ -328,7 +328,7 @@ def test_mds_mtls_adapter_send_no_fallback_strict_mode(
             adapter.send(request)
 
 @mock.patch("requests.adapters.HTTPAdapter.close")
-@mock.patch("ssl.create_default_context")
+@mock.patch("google.auth.compute_engine._mtls.ssl.create_default_context")
 def test_mds_mtls_adapter_close(
     mock_ssl_context, mock_super_close, mock_mds_mtls_config
 ):

--- a/packages/google-auth/tests/test_identity_pool.py
+++ b/packages/google-auth/tests/test_identity_pool.py
@@ -1123,9 +1123,7 @@ class TestCredentials(object):
         "_get_cert_bytes",
         side_effect=Exception("Read error"),
     )
-    def test_retrieve_subject_token_leaf_cert_callback_error(
-        self, mock_get_cert_bytes
-    ):
+    def test_retrieve_subject_token_leaf_cert_callback_error(self, mock_get_cert_bytes):
         credentials = self.make_credentials(
             credential_source=self.CREDENTIAL_SOURCE_CERTIFICATE
         )
@@ -1139,9 +1137,7 @@ class TestCredentials(object):
         "_get_cert_bytes",
         return_value=b"invalid-pem-data",
     )
-    def test_retrieve_subject_token_leaf_cert_parse_error(
-        self, mock_get_cert_bytes
-    ):
+    def test_retrieve_subject_token_leaf_cert_parse_error(self, mock_get_cert_bytes):
         credentials = self.make_credentials(
             credential_source=self.CREDENTIAL_SOURCE_CERTIFICATE
         )

--- a/packages/google-auth/tests/test_identity_pool.py
+++ b/packages/google-auth/tests/test_identity_pool.py
@@ -1000,6 +1000,27 @@ class TestCredentials(object):
 
         assert subject_token == JSON_FILE_SUBJECT_TOKEN
 
+    def test_retrieve_subject_token_supplier_leaf_cert_callback_error(self):
+        def failing_callback():
+            raise RuntimeError("Read error")
+
+        supplier = identity_pool._X509Supplier(
+            trust_chain_path=None,
+            leaf_cert_callback=failing_callback,
+        )
+        with pytest.raises(exceptions.RefreshError) as excinfo:
+            supplier.get_subject_token(None, None)
+        assert "Failed to retrieve leaf certificate." in str(excinfo.value)
+
+    def test_retrieve_subject_token_supplier_leaf_cert_parse_error(self):
+        supplier = identity_pool._X509Supplier(
+            trust_chain_path=None,
+            leaf_cert_callback=lambda: b"invalid-non-pem-data",
+        )
+        with pytest.raises(exceptions.RefreshError) as excinfo:
+            supplier.get_subject_token(None, None)
+        assert "Failed to parse leaf certificate." in str(excinfo.value)
+
     @mock.patch(
         "google.auth.transport._mtls_helper._get_workload_cert_and_key_paths",
         return_value=(CERT_FILE, KEY_FILE),
@@ -1096,6 +1117,38 @@ class TestCredentials(object):
             credentials.retrieve_subject_token(None)
 
         assert excinfo.match("Trust chain file 'fake.pem' was not found.")
+
+    @mock.patch.object(
+        identity_pool.Credentials,
+        "_get_cert_bytes",
+        side_effect=Exception("Read error"),
+    )
+    def test_retrieve_subject_token_leaf_cert_callback_error(
+        self, mock_get_cert_bytes
+    ):
+        credentials = self.make_credentials(
+            credential_source=self.CREDENTIAL_SOURCE_CERTIFICATE
+        )
+        with pytest.raises(
+            exceptions.RefreshError, match="Failed to retrieve leaf certificate."
+        ):
+            credentials.retrieve_subject_token(None)
+
+    @mock.patch.object(
+        identity_pool.Credentials,
+        "_get_cert_bytes",
+        return_value=b"invalid-pem-data",
+    )
+    def test_retrieve_subject_token_leaf_cert_parse_error(
+        self, mock_get_cert_bytes
+    ):
+        credentials = self.make_credentials(
+            credential_source=self.CREDENTIAL_SOURCE_CERTIFICATE
+        )
+        with pytest.raises(
+            exceptions.RefreshError, match="Failed to parse leaf certificate."
+        ):
+            credentials.retrieve_subject_token(None)
 
     @mock.patch(
         "google.auth.transport._mtls_helper._get_workload_cert_and_key_paths",

--- a/packages/google-auth/tests/transport/test_aio_mtls_helper.py
+++ b/packages/google-auth/tests/transport/test_aio_mtls_helper.py
@@ -181,15 +181,15 @@ class TestMTLS:
 
     @pytest.mark.asyncio
     async def test_get_client_cert_and_key_callback_sync(self):
-        """Tests that a sync callback is handled via the TypeError fallback."""
+        """Tests that a sync callback is handled via inspect.isawaitable."""
         callback = mock.Mock(return_value=(CERT_DATA, KEY_DATA))
 
         success, cert, key = await mtls.get_client_cert_and_key(callback)
 
         assert success is True
         assert cert == CERT_DATA
-        # Note: In the source, the first 'await' will call the function.
-        # When it fails to await, the exception handler uses the result already obtained.
+        # When the callback is synchronous, inspect.isawaitable() is False
+        # and the result is returned directly without awaiting.
         assert callback.call_count == 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #17758

- Updated `test_get_client_cert_and_key_callback_sync` docstring and comments in `tests/transport/test_aio_mtls_helper.py` to reference `inspect.isawaitable()`.
- Added unit test coverage for `MdsMtlsAdapter.close()` in `tests/compute_engine/test__mtls.py`.
- Added test coverage for `RefreshError` exception paths in leaf certificate retrieval and parsing in `tests/test_identity_pool.py`.