### PR TITLE
chore(google-auth): move to individual releases

### DIFF
--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -17,7 +17,6 @@
   "packages/google-apps-meet": "0.5.0",
   "packages/google-apps-script-type": "0.8.0",
   "packages/google-area120-tables": "0.15.0",
-  "packages/google-auth": "2.58.0",
   "packages/google-auth-httplib2": "0.4.2",
   "packages/google-auth-oauthlib": "1.4.1",
   "packages/google-backstory": "0.1.0",

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages/google-auth": "2.58.0",
   "packages/google-cloud-apptopology": "0.1.0",
   "packages/google-cloud-ftp": "0.1.0",
   "packages/google-cloud-sql": "0.1.1",

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -202,9 +202,6 @@
         }
       ]
     },
-    "packages/google-auth": {
-      "component": "google-auth"
-    },
     "packages/google-auth-httplib2": {
       "component": "google-auth-httplib2"
     },

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -3,7 +3,8 @@
   "bump-patch-for-minor-pre-major": true,
   "packages": {
     "packages/google-auth": {
-      "component": "google-auth"
+      "component": "google-auth",
+      "extra-label": "auth"
     },
     "packages/google-cloud-apptopology": {
       "component": "google-cloud-apptopology",

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -2,6 +2,9 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "packages": {
+    "packages/google-auth": {
+      "component": "google-auth"
+    },
     "packages/google-cloud-apptopology": {
       "component": "google-cloud-apptopology",
       "extra-files": [


### PR DESCRIPTION
Move `google-auth` to its own release PR for independent release management.

See http://b/539996163