### PR TITLE
fix: close previous response before retrying in AsyncAuthorizedSession

### DIFF
--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -340,7 +340,19 @@ class AsyncAuthorizedSession:
                 actual_timeout = float(timeout)
             # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
             # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
+            response = None
             async for _ in retries:  # pragma: no branch
+                if response is not None and hasattr(response, "close"):
+                    # Release the previous response before retrying so an
+                    # unread body does not keep its connection checked out
+                    # of the connector pool.
+                    try:
+                        res = response.close()
+                        if inspect.isawaitable(res):
+                            await res
+                    except Exception:
+                        pass
+
                 response = await with_timeout(
                     self._auth_request(
                         url, method, data, request_headers, actual_timeout, **kwargs

--- a/packages/google-auth/tests/transport/aio/test_sessions.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions.py
@@ -288,6 +288,41 @@ class TestAsyncAuthorizedSession(object):
             assert auth_request.call_count == DEFAULT_MAX_RETRY_ATTEMPTS
 
     @pytest.mark.asyncio
+    async def test_request_closes_previous_response_before_retry(self):
+        retry_response = MockResponse(status_code=503)
+        success_response = MockResponse(status_code=200)
+
+        class _SequenceMockRequest(MockRequest):
+            def __init__(self, responses):
+                super().__init__(response=None)
+                self._responses = responses
+
+            async def __call__(self, *args, **kwargs):
+                self.call_count += 1
+                return self._responses[self.call_count - 1]
+
+        auth_request = _SequenceMockRequest([retry_response, success_response])
+        with patch("asyncio.sleep", return_value=None):
+            authed_session = sessions.AsyncAuthorizedSession(
+                self.credentials, auth_request
+            )
+            response = await authed_session.request(
+                "GET",
+                self.TEST_URL,
+                max_allowed_time=float("inf"),
+                total_attempts=2,
+            )
+            assert response is success_response
+            assert auth_request.call_count == 2
+            # The initial retryable response must be closed before the retry
+            # so its connection is released back to the pool.
+            assert retry_response._close
+            # The final response is left open for the caller to close.
+            assert not success_response._close
+
+        await authed_session.close()
+
+    @pytest.mark.asyncio
     async def test_http_get_method_success(self):
         expected_payload = b"content is retrieved."
         authed_session = sessions.AsyncAuthorizedSession(self.credentials)


### PR DESCRIPTION
Fixes #18315

## Problem
In `AsyncAuthorizedSession.request` (`packages/google-auth/google/auth/aio/transport/sessions.py`), the retry loop reassigned `response = await with_timeout(...)` across retry attempts without closing the previous response. If the response payload had not reached EOF before the next retry fired (e.g. with chunked or streaming responses), `aiohttp` keeps the socket checked out in `connector._acquired`. Under concurrency, multiple requests retrying against a degraded endpoint can burn through the connector pool (`limit=100`) and block other outgoing requests across the session.

## Fix
Close any previous response (awaiting it if the `close()` result is awaitable) before kicking off the next retry attempt, matching the cleanup pattern already used in the 401 credential-recovery path in the same method.

## Tests
- New test `test_request_closes_previous_response_before_retry`: 503 followed by 200 with `total_attempts=2`; asserts `close()` was awaited on the 503 response before the retry and that the final 200 response is left open for the caller. Verified the test **fails before** the fix and **passes after**.
- Full `tests/transport/aio/test_sessions.py` run: 24 passed. The 6 remaining failures (`test_http_*_method_success`, `test_request_default_auth_request_success`) are pre-existing in this environment — they fail identically on unpatched `main` (aioresponses/aiohttp version interaction, unrelated to this change).
- `flake8` (repo `.flake8` config) on both touched files: clean.
