### PR TITLE
chore(spanner): move to individual releases

### DIFF
--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -209,7 +209,6 @@
   "packages/google-cloud-servicehealth": "0.5.0",
   "packages/google-cloud-shell": "1.16.0",
   "packages/google-cloud-source-context": "1.11.0",
-  "packages/google-cloud-spanner": "3.71.0",
   "packages/google-cloud-speech": "2.40.0",
   "packages/google-cloud-storage": "3.14.1",
   "packages/google-cloud-storage-control": "1.15.0",

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -2,6 +2,7 @@
   "packages/google-auth": "2.58.0",
   "packages/google-cloud-apptopology": "0.1.0",
   "packages/google-cloud-ftp": "0.1.0",
+  "packages/google-cloud-spanner": "3.71.0",
   "packages/google-cloud-sql": "0.1.1",
   "packages/google-cloud-workloadidentity": "0.1.0",
   "packages/google-crc32c": "1.8.0",

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -2896,32 +2896,6 @@
         "google/cloud/source_context_v1/gapic_version.py"
       ]
     },
-    "packages/google-cloud-spanner": {
-      "component": "google-cloud-spanner",
-      "extra-files": [
-        "google/cloud/spanner/gapic_version.py",
-        "google/cloud/spanner_admin_database/gapic_version.py",
-        "google/cloud/spanner_admin_database_v1/gapic_version.py",
-        "google/cloud/spanner_admin_instance/gapic_version.py",
-        "google/cloud/spanner_admin_instance_v1/gapic_version.py",
-        "google/cloud/spanner_v1/gapic_version.py",
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json",
-          "type": "json"
-        },
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json",
-          "type": "json"
-        },
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.spanner.v1.json",
-          "type": "json"
-        }
-      ]
-    },
     "packages/google-cloud-speech": {
       "component": "google-cloud-speech",
       "extra-files": [

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -30,6 +30,32 @@
         }
       ]
     },
+    "packages/google-cloud-spanner": {
+      "component": "google-cloud-spanner",
+      "extra-files": [
+        "google/cloud/spanner/gapic_version.py",
+        "google/cloud/spanner_admin_database/gapic_version.py",
+        "google/cloud/spanner_admin_database_v1/gapic_version.py",
+        "google/cloud/spanner_admin_instance/gapic_version.py",
+        "google/cloud/spanner_admin_instance_v1/gapic_version.py",
+        "google/cloud/spanner_v1/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.spanner.v1.json",
+          "type": "json"
+        }
+      ]
+    },
     "packages/google-cloud-sql": {
       "component": "google-cloud-sql",
       "extra-files": [


### PR DESCRIPTION
Move `google-cloud-spanner` to its own release PR for independent release management.