### PR TITLE
chore(ci): remove core-deps continuous job from Kokoro

### DIFF
--- a/.kokoro/continuous/core_deps.cfg
+++ b/.kokoro/continuous/core_deps.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "core_deps_from_source"
-}


### PR DESCRIPTION
Remove `core-deps` from Kokoro. If we want to add this as a post submit job on Github, that is tracked separately in: b/559957253.

Googlers, see: b/559955805

Related CL: cl/979630466