### PR TITLE
chore(ci): add twine presubmit check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,7 +88,7 @@ jobs:
         python-version: "3.14"
     - name: Install nox
       run: |
-        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install --upgrade setuptools pip wheel build twine
         python -m pip install nox uv
     - name: Run lint
       env:
@@ -106,6 +106,16 @@ jobs:
         TARGET_BRANCH: ${{ github.base_ref || github.event.merge_group.base_ref }}
         TEST_ALL_PACKAGES: ${{ steps.check-label.outputs.is_full_run }}
         TEST_TYPE: lint_setup_py
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
+        PY_VERSION: "unused"
+      run: |
+        ci/run_conditional_tests.sh
+    - name: Run twine_check
+      env:
+        BUILD_TYPE: presubmit
+        TARGET_BRANCH: ${{ github.base_ref || github.event.merge_group.base_ref }}
+        TEST_ALL_PACKAGES: ${{ steps.check-label.outputs.is_full_run }}
+        TEST_TYPE: twine_check
         # TODO(https://github.com/googleapis/google-cloud-python/issues/13775): Specify `PY_VERSION` rather than relying on the default python version of the nox session.
         PY_VERSION: "unused"
       run: |

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -222,9 +222,12 @@ case ${TEST_TYPE} in
     twine_check)
         if [ -f setup.py ] || [ -f pyproject.toml ]; then
             echo "Running twine_check for $(basename $(pwd))..."
-            python3 -m build --sdist --no-isolation --outdir dist .
-            twine check --strict dist/*
-            retval=$?
+            rm -rf dist
+            if python3 -m build --sdist --no-isolation --outdir dist . && twine check --strict dist/*; then
+                retval=0
+            else
+                retval=1
+            fi
             rm -rf dist
         else
             echo "Skipping twine_check as this does not appear to be a Python package (no setup.py or pyproject.toml)."

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -223,7 +223,7 @@ case ${TEST_TYPE} in
         if [ -f setup.py ] || [ -f pyproject.toml ]; then
             echo "Running twine_check for $(basename $(pwd))..."
             rm -rf dist
-            # TODO(https://github.com/googleapis/google-cloud-python/issues/18211): Re-enable `--strict` once `long_description_content_type` is set in setup.py across all packages.
+            # TODO(https://github.com/googleapis/google-cloud-python/issues/18339): Re-enable `--strict` once `long_description_content_type` is set in setup.py across all packages.
             if python3 -m build --sdist --no-isolation --outdir dist . && twine check dist/*; then
                 retval=0
             else

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -224,7 +224,7 @@ case ${TEST_TYPE} in
             echo "Running twine_check for $(basename $(pwd))..."
             rm -rf dist
             # TODO(https://github.com/googleapis/google-cloud-python/issues/18339): Re-enable `--strict` once `long_description_content_type` is set in setup.py across all packages.
-            if python3 -m build --sdist --no-isolation --skip-dependency-check --outdir dist . && twine check dist/*; then
+            if python3 -m build --sdist --no-isolation --outdir dist . && twine check dist/*; then
                 retval=0
             else
                 retval=1

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -219,6 +219,18 @@ case ${TEST_TYPE} in
             retval=0
         fi
         ;;
+    twine_check)
+        if [ -f setup.py ] || [ -f pyproject.toml ]; then
+            echo "Running twine_check for $(basename $(pwd))..."
+            python3 -m build --sdist --no-isolation --outdir dist .
+            twine check --strict dist/*
+            retval=$?
+            rm -rf dist
+        else
+            echo "Skipping twine_check as this does not appear to be a Python package (no setup.py or pyproject.toml)."
+            retval=0
+        fi
+        ;;
     *)
         nox --stop-on-first-error -s ${TEST_TYPE}
         retval=$?

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -224,7 +224,7 @@ case ${TEST_TYPE} in
             echo "Running twine_check for $(basename $(pwd))..."
             rm -rf dist
             # TODO(https://github.com/googleapis/google-cloud-python/issues/18339): Re-enable `--strict` once `long_description_content_type` is set in setup.py across all packages.
-            if python3 -m build --sdist --no-isolation --outdir dist . && twine check dist/*; then
+            if python3 -m build --sdist --no-isolation --skip-dependency-check --outdir dist . && twine check dist/*; then
                 retval=0
             else
                 retval=1

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -223,7 +223,8 @@ case ${TEST_TYPE} in
         if [ -f setup.py ] || [ -f pyproject.toml ]; then
             echo "Running twine_check for $(basename $(pwd))..."
             rm -rf dist
-            if python3 -m build --sdist --no-isolation --outdir dist . && twine check --strict dist/*; then
+            # TODO(https://github.com/googleapis/google-cloud-python/issues/18211): Re-enable `--strict` once `long_description_content_type` is set in setup.py across all packages.
+            if python3 -m build --sdist --no-isolation --outdir dist . && twine check dist/*; then
                 retval=0
             else
                 retval=1

--- a/packages/gcp-sphinx-docfx-yaml/setup.py
+++ b/packages/gcp-sphinx-docfx-yaml/setup.py
@@ -38,7 +38,6 @@ dependencies = [
 packages = setuptools.find_packages(".", exclude=["tests"])
 
 extra_setup = dict(
-    setup_requires=["pytest-runner"],
     tests_require=["pytest", "mock"],
 )
 

--- a/packages/google-cloud-storage/README.rst
+++ b/packages/google-cloud-storage/README.rst
@@ -49,7 +49,7 @@ A step-by-step guide may also be found in `Get Started with Client Libraries`_.
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
 3. `Enable the Google Cloud Storage API.`_
-4. `Set up Authentication.`_
+4. `Setup Authentication.`_
 
 .. _Get Started with Client Libraries: https://cloud.google.com/storage/docs/reference/libraries#client-libraries-install-python
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project

--- a/packages/google-cloud-storage/README.rst
+++ b/packages/google-cloud-storage/README.rst
@@ -49,7 +49,7 @@ A step-by-step guide may also be found in `Get Started with Client Libraries`_.
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
 3. `Enable the Google Cloud Storage API.`_
-4. `Setup Authentication.`_
+4. `Set up Authentication.`_
 
 .. _Get Started with Client Libraries: https://cloud.google.com/storage/docs/reference/libraries#client-libraries-install-python
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project


### PR DESCRIPTION
Fixes the issue temporarily reproduced in a test commit (See the linked issue for full details):

```

removing 'google_cloud_storage-3.14.1' (and everything under it)
Successfully built google_cloud_storage-3.14.1.tar.gz
Checking dist/google_cloud_storage-3.14.1.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 52: Error: Unknown target name: "setup authentication.".          
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
❌ Tests failed in packages/google-cloud-storage/ with exit code 1

```

**Note:** `twine check --strict` treats the `WARNING: long_description_content_type missing` as a fatal error. Because most packages currently lack `long_description_content_type` in `setup.py` (tracked in [#18211](https://github.com/googleapis/google-cloud-python/issues/18339)), `--strict` would cause false-positive CI failures.
Without `--strict`, `twine check` **still catches all fatal reST syntax errors and invalid metadata (exit 1)**, while ignoring the non-fatal missing content-type warning. A `# TODO(https://github.com/googleapis/google-cloud-python/issues/18339)` is included to re-enable `--strict` once [#18211](https://github.com/googleapis/google-cloud-python/issues/18339) is resolved.

**My 2 cents:**

I think centralizing this check in our CI is a better approach than introducing separate nox sessions:
1. This is a much simpler change since the number of files affected is 2 compared to 150+ files affected if we add a new nox session.
2. Running a nox session in our CI adds a separate (setup) cost which is unnecessary and will make it slow.
3. Only occasionally will developers need to run this locally. In most cases, the error will be caught upstream. Running twine locally is as simple as running a nox session. However, if we have a strong justification to include a nox session, we can do so but we should still avoid using it in the CI.

Fixes: https://github.com/googleapis/google-cloud-python/issues/18211