### PR TITLE
fix(auth): allow mTLS retry when credentials raise NotImplementedError on refresh

### DIFF
--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -485,7 +485,6 @@ class AsyncAuthorizedSession:
                                     _LOGGER.debug(
                                         "Credentials do not implement refresh()."
                                     )
-                                    return response
                                 except (
                                     exceptions.RefreshError,
                                     getattr(exceptions, "InvalidOperation", Exception),

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1126,3 +1126,52 @@ class TestSessionsMtls:
         assert not session._mtls_init_task.cancelled()
         assert session._is_mtls is True
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_credential_refresh_not_implemented_retries(self):
+        """Validate credentials that raise NotImplementedError on refresh()
+        still trigger a retry after mTLS reconfiguration, not return the 401."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(side_effect=NotImplementedError)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+            ) as mock_check,
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            mock_check.return_value = (b"new_cert", b"new_key", b"old_fp", b"new_fp")
+
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+
+            # Validate that the handler falls through to `return None`
+            # on NotImplementedError in order to signal retry.
+            assert resp == mock_resp_200
+            mock_conf.assert_called_once()
+            mock_creds.refresh.assert_called_once()
+            assert mock_auth_req.call_count == 2
+            mock_resp_401.close.assert_called_once()
+
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1151,27 +1151,25 @@ class TestSessionsMtls:
         session._is_mtls = True
         session._cached_cert = b"old_cert"
 
-        with (
-            mock.patch(
-                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
-                new_callable=mock.AsyncMock,
-            ) as mock_check,
-            mock.patch.object(
+        with mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check:
+            with mock.patch.object(
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
-            ) as mock_conf,
-        ):
-            mock_check.return_value = (b"new_cert", b"new_key", b"old_fp", b"new_fp")
+            ) as mock_conf:
+                mock_check.return_value = (b"new_cert", b"new_key", b"old_fp", b"new_fp")
 
-            resp = await session.request(
-                "GET", "https://pubsub.mtls.googleapis.com/test"
-            )
+                resp = await session.request(
+                    "GET", "https://pubsub.mtls.googleapis.com/test"
+                )
 
-            # Validate that the handler falls through to `return None`
-            # on NotImplementedError in order to signal retry.
-            assert resp == mock_resp_200
-            mock_conf.assert_called_once()
-            mock_creds.refresh.assert_called_once()
-            assert mock_auth_req.call_count == 2
-            mock_resp_401.close.assert_called_once()
+                # Validate that the handler falls through to `return None`
+                # on NotImplementedError in order to signal retry.
+                assert resp == mock_resp_200
+                mock_conf.assert_called_once()
+                mock_creds.refresh.assert_called_once()
+                assert mock_auth_req.call_count == 2
+                mock_resp_401.close.assert_called_once()
 
         await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1158,7 +1158,12 @@ class TestSessionsMtls:
             with mock.patch.object(
                 session, "configure_mtls_channel", new_callable=mock.AsyncMock
             ) as mock_conf:
-                mock_check.return_value = (b"new_cert", b"new_key", b"old_fp", b"new_fp")
+                mock_check.return_value = (
+                    b"new_cert",
+                    b"new_key",
+                    b"old_fp",
+                    b"new_fp",
+                )
 
                 resp = await session.request(
                     "GET", "https://pubsub.mtls.googleapis.com/test"

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1173,7 +1173,13 @@ class TestSessionsMtls:
                 # on NotImplementedError in order to signal retry.
                 assert resp == mock_resp_200
                 mock_conf.assert_called_once()
-                mock_creds.refresh.assert_called_once()
+                cb = (
+                    mock_conf.call_args.args[0]
+                    if mock_conf.call_args.args
+                    else mock_conf.call_args.kwargs["client_cert_callback"]
+                )
+                assert cb() == (b"new_cert", b"new_key")
+                mock_creds.refresh.assert_called_once_with(mock_auth_req)
                 assert mock_auth_req.call_count == 2
                 mock_resp_401.close.assert_called_once()
 


### PR DESCRIPTION
## Summary
- In `AsyncAuthorizedSession.request()`'s inner `_recover_auth_state()` function
(`google/auth/aio/transport/sessions.py`), the `except NotImplementedError` branch
incorrectly did `return response`, returning the original 401 to the caller instead of
falling through to `return None` to trigger a retry.
- This caused the first request after a client certificate rotation to fail with a 401 for
credential types that do not implement `refresh()` (e.g., Agent Identity workloads), even
though the mTLS channel was successfully reconfigured.
- The `RefreshError` branch correctly returns the 401 (a real refresh failure means
recovery failed), but `NotImplementedError` is not an error — it means the credential
simply doesn't support refresh. The mTLS reconfiguration was still successful, and the
retry should proceed.

This recovery path was introduced in #18224.

Extension of the fix for https://github.com/googleapis/google-cloud-python/issues/18227

## Test plan
- [x] Added regression test `test_cert_rotation_credential_refresh_not_implemented_retries` that verifies credentials raising `NotImplementedError` on refresh still get a retry after mTLS reconfiguration
- [x] All 28 mTLS session tests pass
- [x] All 29 general session tests pass
