### PR TITLE
chore(tests): increase max timeout for post submit jobs

### DIFF
--- a/.kokoro/continuous/common.cfg
+++ b/.kokoro/continuous/common.cfg
@@ -1,5 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+timeout_mins: 240
+
 # Build logs will be here
 action {
   define_artifacts {

--- a/.kokoro/continuous/prerelease.cfg
+++ b/.kokoro/continuous/prerelease.cfg
@@ -5,3 +5,5 @@ env_vars: {
     key: "NOX_SESSION"
     value: "prerelease_deps"
 }
+
+timeout_mins: 240

--- a/.kokoro/continuous/prerelease.cfg
+++ b/.kokoro/continuous/prerelease.cfg
@@ -5,5 +5,3 @@ env_vars: {
     key: "NOX_SESSION"
     value: "prerelease_deps"
 }
-
-timeout_mins: 240


### PR DESCRIPTION
The pre-release Post-submit job is currently failing due to timeouts. This PR bumps the timeout value, until we can focus on improving run time