### PR TITLE
fix(auth): address concurrency crashes, state desync, and test coverage in async mTLS sessions V2

### DIFF
--- a/packages/google-auth/google/auth/aio/transport/mtls.py
+++ b/packages/google-auth/google/auth/aio/transport/mtls.py
@@ -211,7 +211,7 @@ async def check_parameters_for_unauthorized_response(
                 cached_cert
             )
         else:
-            cached_fingerprint = None
+            cached_fingerprint = current_fingerprint
         return cached_fingerprint, current_fingerprint
 
     cached_fingerprint, current_cert_fingerprint = await _run_in_executor(

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -168,7 +168,9 @@ class AsyncAuthorizedSession:
         self._refresh_lock: Optional[asyncio.Lock] = None
         self._refresh_counter = 0
 
-    async def configure_mtls_channel(self, client_cert_callback=None):
+    async def configure_mtls_channel(
+        self, client_cert_callback=None, force: bool = False
+    ):
         """Configure the client certificate and key for SSL connection.
 
         This method configures mTLS if client certificates are explicitly enabled
@@ -188,15 +190,15 @@ class AsyncAuthorizedSession:
                 key bytes both in PEM format.
                 If the callback is None, application default SSL credentials
                 will be used.
+            force (bool):
+                Whether to force reconfiguration even if the channel is already configured
+                with the same callback.
 
         Raises:
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
-        is_explicit_reconfig = (
-            client_cert_callback is not None
-            and client_cert_callback != self._client_cert_callback
-        )
+        is_explicit_reconfig = client_cert_callback != self._client_cert_callback
         task_failed = (
             self._mtls_init_task is not None
             and self._mtls_init_task.done()
@@ -206,7 +208,12 @@ class AsyncAuthorizedSession:
             )
         )
 
-        if self._mtls_init_task is None or is_explicit_reconfig or task_failed:
+        if self._mtls_init_task is None or is_explicit_reconfig or task_failed or force:
+            if self._mtls_init_task is not None and not self._mtls_init_task.done():
+                try:
+                    await self._mtls_init_task
+                except Exception:
+                    pass
             self._client_cert_callback = client_cert_callback
 
             async def _do_configure():
@@ -409,7 +416,6 @@ class AsyncAuthorizedSession:
                                     ):
                                         pass
                                     else:
-                                        check_passed = False
                                         try:
                                             (
                                                 call_cert_bytes,
@@ -420,7 +426,6 @@ class AsyncAuthorizedSession:
                                                 self._cached_cert,
                                                 self._client_cert_callback,
                                             )
-                                            check_passed = True
                                         except (
                                             exceptions.ClientCertError,
                                             exceptions.MutualTLSChannelError,
@@ -478,8 +483,8 @@ class AsyncAuthorizedSession:
                                                         "Skipping reconfiguration of mTLS channel because the client"
                                                         " certificate has not changed."
                                                     )
-                                        if check_passed:
-                                            self._mtls_check_counter += 1
+                                        # Always increment so waiting tasks skip the check block
+                                        self._mtls_check_counter += 1
                         if self._refresh_lock is None:
                             self._refresh_lock = asyncio.Lock()
 
@@ -499,10 +504,16 @@ class AsyncAuthorizedSession:
                                     _LOGGER.debug(
                                         "Credentials do not implement refresh()."
                                     )
-                                except (
-                                    exceptions.RefreshError,
-                                    exceptions.InvalidOperation,
-                                ) as e:
+                                    if not channel_reconfigured:
+                                        return response
+                                except exceptions.InvalidOperation as e:
+                                    _LOGGER.debug(
+                                        "Credentials cannot be refreshed: %s",
+                                        e,
+                                    )
+                                    if not channel_reconfigured:
+                                        return response
+                                except exceptions.RefreshError as e:
                                     _LOGGER.debug(
                                         "Credential refresh failed, returning 401 response. Error: %s",
                                         e,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -435,6 +435,7 @@ class AsyncAuthorizedSession:
                                                         "Client certificate has changed, reconfiguring mTLS "
                                                         "channel."
                                                     )
+                                                    self._mtls_init_task = None
                                                     await self.configure_mtls_channel(
                                                         lambda: (
                                                             call_cert_bytes,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -255,6 +255,8 @@ class AsyncAuthorizedSession:
                         self._cached_cert = None
 
                 except Exception as caught_exc:
+                    self._is_mtls = False
+                    self._cached_cert = None
                     new_exc = exceptions.MutualTLSChannelError(caught_exc)
                     raise new_exc from caught_exc
 
@@ -413,10 +415,12 @@ class AsyncAuthorizedSession:
                                             exceptions.MutualTLSChannelError,
                                             OSError,
                                             ValueError,
+                                            TypeError,
                                             ImportError,
                                         ) as e:
                                             _LOGGER.warning(
-                                                "Failed to check client certificate parameters: %s. Proceeding with original response.",
+                                                "Failed to check client certificate parameters: %s. "
+                                                "Falling back to credential refresh and retry.",
                                                 e,
                                             )
                                         else:
@@ -433,13 +437,12 @@ class AsyncAuthorizedSession:
                                                         "Client certificate has changed, reconfiguring mTLS "
                                                         "channel."
                                                     )
-                                                    self._mtls_init_task = None
                                                     await self.configure_mtls_channel(
                                                         lambda: (
-                                                            call_cert_bytes,
-                                                            call_key_bytes,
-                                                        )
-                                                    )
+                                                             call_cert_bytes,
+                                                             call_key_bytes,
+                                                         )
+                                                     )
                                                     channel_reconfigured = True
                                                 except Exception as e:
                                                     _LOGGER.error(
@@ -485,7 +488,7 @@ class AsyncAuthorizedSession:
                                     return response
                                 except (
                                     exceptions.RefreshError,
-                                    getattr(exceptions, "InvalidOperation", Exception),
+                                    exceptions.InvalidOperation,
                                 ) as e:
                                     _LOGGER.debug(
                                         "Credential refresh failed, returning 401 response. Error: %s",

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -193,7 +193,7 @@ class AsyncAuthorizedSession:
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
-        if self._mtls_init_task is None:
+        if self._mtls_init_task is None or self._mtls_init_task.done():
             self._client_cert_callback = client_cert_callback
 
             async def _do_configure():
@@ -224,10 +224,12 @@ class AsyncAuthorizedSession:
 
                             old_auth_request = self._auth_request
                             self._auth_request = AiohttpRequest(session=new_session)
+                            self._is_mtls = True
+                            self._cached_cert = cert
                             self._old_auth_requests.append(old_auth_request)
 
                             while len(self._old_auth_requests) > 2:
-                                oldest_auth_request = self._old_auth_requests[0]
+                                oldest_auth_request = self._old_auth_requests.pop(0)
                                 try:
                                     if hasattr(oldest_auth_request, "close"):
                                         res = oldest_auth_request.close()
@@ -235,10 +237,11 @@ class AsyncAuthorizedSession:
                                             await res
                                 except Exception:
                                     pass
-                                self._old_auth_requests.pop(0)
 
                         else:
                             is_mtls = False
+                            self._is_mtls = False
+                            self._cached_cert = None
                             warnings.warn(
                                 "Attempted to establish mTLS, but a custom async transport was provided. "
                                 "google-auth cannot automatically configure custom transports for mTLS. "
@@ -247,24 +250,19 @@ class AsyncAuthorizedSession:
                                 "using Certificate-Bound Tokens.",
                                 UserWarning,
                             )
-
-                    self._is_mtls = is_mtls
-                    if is_mtls:
-                        self._cached_cert = cert
                     else:
+                        self._is_mtls = False
                         self._cached_cert = None
 
                 except Exception as caught_exc:
+                    self._is_mtls = False
+                    self._cached_cert = None
                     new_exc = exceptions.MutualTLSChannelError(caught_exc)
                     raise new_exc from caught_exc
 
             self._mtls_init_task = asyncio.create_task(_do_configure())
 
-        try:
-            return await self._mtls_init_task
-        except BaseException:
-            self._mtls_init_task = None
-            raise
+        return await asyncio.shield(self._mtls_init_task)
 
     async def request(
         self,
@@ -319,6 +317,11 @@ class AsyncAuthorizedSession:
                 # Suppress all exceptions from the background mTLS initialization task,
                 # allowing the request to fail naturally elsewhere.
                 pass
+            except asyncio.CancelledError:
+                if self._mtls_init_task.cancelled():
+                    pass
+                else:
+                    raise
         retries = _exponential_backoff.AsyncExponentialBackoff(
             total_attempts=total_attempts,
         )
@@ -371,6 +374,7 @@ class AsyncAuthorizedSession:
                     )
 
                     async def _recover_auth_state():
+                        channel_reconfigured = False
                         is_mtls_endpoint = False
                         if self._is_mtls:
                             hostname = urllib.parse.urlsplit(url).hostname
@@ -394,6 +398,7 @@ class AsyncAuthorizedSession:
                                     ):
                                         pass
                                     else:
+                                        check_passed = False
                                         try:
                                             (
                                                 call_cert_bytes,
@@ -404,6 +409,7 @@ class AsyncAuthorizedSession:
                                                 self._cached_cert,
                                                 self._client_cert_callback,
                                             )
+                                            check_passed = True
                                         except (
                                             exceptions.ClientCertError,
                                             exceptions.MutualTLSChannelError,
@@ -429,21 +435,13 @@ class AsyncAuthorizedSession:
                                                         "Client certificate has changed, reconfiguring mTLS "
                                                         "channel."
                                                     )
-                                                    if self._mtls_init_task is not None:
-                                                        if (
-                                                            not self._mtls_init_task.done()
-                                                        ):
-                                                            try:
-                                                                await self._mtls_init_task
-                                                            except Exception:
-                                                                pass
-                                                        self._mtls_init_task = None
                                                     await self.configure_mtls_channel(
                                                         lambda: (
                                                             call_cert_bytes,
                                                             call_key_bytes,
                                                         )
                                                     )
+                                                    channel_reconfigured = True
                                                 except Exception as e:
                                                     _LOGGER.error(
                                                         "Failed to reconfigure mTLS channel: %s",
@@ -467,14 +465,14 @@ class AsyncAuthorizedSession:
                                                         "Skipping reconfiguration of mTLS channel because the client"
                                                         " certificate has not changed."
                                                     )
-                                        # Always increment so waiting tasks skip the check block
-                                        self._mtls_check_counter += 1
+                                        if check_passed:
+                                            self._mtls_check_counter += 1
                         if self._refresh_lock is None:
                             self._refresh_lock = asyncio.Lock()
 
                         async with self._refresh_lock:
                             # Check if another task already refreshed credentials while we were waiting
-                            if self._refresh_counter > refresh_counter_at_error:
+                            if not channel_reconfigured and self._refresh_counter > refresh_counter_at_error:
                                 _LOGGER.debug(
                                     "Credentials were already refreshed by a concurrent task. Skipping duplicate refresh."
                                 )
@@ -821,19 +819,16 @@ class AsyncAuthorizedSession:
         """
         Close the underlying auth request session.
         """
-        if self._mtls_init_task and not self._mtls_init_task.done():
-            self._mtls_init_task.cancel()
-            try:
-                await self._mtls_init_task
-            except asyncio.CancelledError:
-                pass
         try:
-            if hasattr(self._auth_request, "close"):
-                res = self._auth_request.close()
-                if inspect.isawaitable(res):
-                    await res
+            if self._mtls_init_task and not self._mtls_init_task.done():
+                self._mtls_init_task.cancel()
+                try:
+                    await self._mtls_init_task
+                except (Exception, asyncio.CancelledError):
+                    pass
         finally:
-            for old_request in self._old_auth_requests:
+            while self._old_auth_requests:
+                old_request = self._old_auth_requests.pop(0)
                 try:
                     if hasattr(old_request, "close"):
                         res = old_request.close()
@@ -841,4 +836,10 @@ class AsyncAuthorizedSession:
                             await res
                 except Exception:
                     pass
-            self._old_auth_requests.clear()
+            try:
+                if hasattr(self._auth_request, "close"):
+                    res = self._auth_request.close()
+                    if inspect.isawaitable(res):
+                        await res
+            except Exception:
+                pass

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -154,7 +154,7 @@ class AsyncAuthorizedSession:
         if not _auth_request and AIOHTTP_INSTALLED:
             _auth_request = AiohttpRequest()
         self._is_mtls = False
-        self._mtls_init_task = None
+        self._mtls_init_task: Optional[asyncio.Task] = None
         self._cached_cert = None
         self._client_cert_callback = None
         self._old_auth_requests: list[transport.Request] = []
@@ -281,6 +281,7 @@ class AsyncAuthorizedSession:
 
             self._mtls_init_task = asyncio.create_task(_do_configure())
 
+        assert self._mtls_init_task is not None
         return await asyncio.shield(self._mtls_init_task)
 
     async def request(

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -336,7 +336,7 @@ class AsyncAuthorizedSession:
                 # allowing the request to fail naturally elsewhere.
                 pass
             except asyncio.CancelledError:
-                if self._mtls_init_task.cancelled():
+                if self._mtls_init_task and self._mtls_init_task.cancelled():
                     pass
                 else:
                     raise

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -210,9 +210,10 @@ class AsyncAuthorizedSession:
 
         if self._mtls_init_task is None or is_explicit_reconfig or task_failed or force:
             if self._mtls_init_task is not None and not self._mtls_init_task.done():
+                self._mtls_init_task.cancel()
                 try:
                     await self._mtls_init_task
-                except Exception:
+                except (Exception, asyncio.CancelledError):
                     pass
             self._client_cert_callback = client_cert_callback
 

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -193,7 +193,20 @@ class AsyncAuthorizedSession:
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
-        if self._mtls_init_task is None or self._mtls_init_task.done():
+        is_explicit_reconfig = (
+            client_cert_callback is not None
+            and client_cert_callback != self._client_cert_callback
+        )
+        task_failed = (
+            self._mtls_init_task is not None
+            and self._mtls_init_task.done()
+            and (
+                self._mtls_init_task.cancelled()
+                or self._mtls_init_task.exception() is not None
+            )
+        )
+
+        if self._mtls_init_task is None or is_explicit_reconfig or task_failed:
             self._client_cert_callback = client_cert_callback
 
             async def _do_configure():
@@ -255,8 +268,6 @@ class AsyncAuthorizedSession:
                         self._cached_cert = None
 
                 except Exception as caught_exc:
-                    self._is_mtls = False
-                    self._cached_cert = None
                     new_exc = exceptions.MutualTLSChannelError(caught_exc)
                     raise new_exc from caught_exc
 

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -450,10 +450,10 @@ class AsyncAuthorizedSession:
                                                     )
                                                     await self.configure_mtls_channel(
                                                         lambda: (
-                                                             call_cert_bytes,
-                                                             call_key_bytes,
-                                                         )
-                                                     )
+                                                            call_cert_bytes,
+                                                            call_key_bytes,
+                                                        )
+                                                    )
                                                     channel_reconfigured = True
                                                 except Exception as e:
                                                     _LOGGER.error(
@@ -485,7 +485,10 @@ class AsyncAuthorizedSession:
 
                         async with self._refresh_lock:
                             # Check if another task already refreshed credentials while we were waiting
-                            if not channel_reconfigured and self._refresh_counter > refresh_counter_at_error:
+                            if (
+                                not channel_reconfigured
+                                and self._refresh_counter > refresh_counter_at_error
+                            ):
                                 _LOGGER.debug(
                                     "Credentials were already refreshed by a concurrent task. Skipping duplicate refresh."
                                 )

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -496,7 +496,6 @@ class AsyncAuthorizedSession:
                                     _LOGGER.debug(
                                         "Credentials do not implement refresh()."
                                     )
-                                    return response
                                 except (
                                     exceptions.RefreshError,
                                     exceptions.InvalidOperation,

--- a/packages/google-auth/google/auth/aio/transport/sessions.py
+++ b/packages/google-auth/google/auth/aio/transport/sessions.py
@@ -255,8 +255,6 @@ class AsyncAuthorizedSession:
                         self._cached_cert = None
 
                 except Exception as caught_exc:
-                    self._is_mtls = False
-                    self._cached_cert = None
                     new_exc = exceptions.MutualTLSChannelError(caught_exc)
                     raise new_exc from caught_exc
 

--- a/packages/google-auth/tests/transport/aio/test_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_mtls.py
@@ -159,9 +159,9 @@ async def test_check_parameters_without_cached_cert():
 
         assert cert == CERT_BYTES
         assert key == KEY_BYTES
-        assert cached_fp is None
+        assert cached_fp == "FINGERPRINT_CURRENT"
         assert current_fp == "FINGERPRINT_CURRENT"
-        assert cached_fp != current_fp
+        assert cached_fp == current_fp
         mock_get_cached.assert_not_called()
 
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1069,7 +1069,9 @@ class TestSessionsMtls:
                 return 100.0
             return 0.1
 
-        with mock.patch("google.auth.aio.transport.sessions.time.monotonic", side_effect=mock_time):
+        with mock.patch(
+            "google.auth.aio.transport.sessions.time.monotonic", side_effect=mock_time
+        ):
             with pytest.raises(
                 exceptions.TimeoutError,
                 match="Timeout exceeded before credential refresh could begin",
@@ -1111,7 +1113,9 @@ class TestSessionsMtls:
                     return 100.0
             return 0.1
 
-        with mock.patch("google.auth.aio.transport.sessions.time.monotonic", side_effect=mock_time):
+        with mock.patch(
+            "google.auth.aio.transport.sessions.time.monotonic", side_effect=mock_time
+        ):
             with pytest.raises(
                 exceptions.TimeoutError,
                 match=r"(Timeout exceeded before retrying the request|Context manager exceeded the configured timeout)",

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1041,17 +1041,20 @@ class TestSessionsMtls:
         """
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_auth_request = mock.AsyncMock(spec=transport.Request)
-        mock_resp_401 = mock.Mock(spec=transport.Response)
-        mock_resp_401.close = mock.AsyncMock()
 
         status_access_count = 0
 
-        def get_status():
-            nonlocal status_access_count
-            status_access_count += 1
-            return 401
+        class _CustomResponse:
+            def __init__(self):
+                self.close = mock.AsyncMock()
 
-        type(mock_resp_401).status_code = property(lambda self: get_status())
+            @property
+            def status_code(self):
+                nonlocal status_access_count
+                status_access_count += 1
+                return 401
+
+        mock_resp_401 = _CustomResponse()
 
         async def fake_auth_request(*args, **kwargs):
             return mock_resp_401
@@ -1343,3 +1346,128 @@ class TestSessionsMtls:
                 assert session._auth_request is not first_auth_req
                 assert mock_creds.refresh.call_count == 1
             await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_cert_check_type_error_falls_back_to_refresh(self):
+        """Verifies that TypeError in cert check logs warning and falls back to refresh and retry."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"some_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+                side_effect=TypeError("Callback returned invalid type"),
+            ),
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+            mock.patch.object(sessions._LOGGER, "warning") as mock_warn,
+        ):
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+            assert resp == mock_resp_200
+            mock_conf.assert_not_called()
+            mock_creds.refresh.assert_called_once()
+            assert any(
+                "Falling back to credential refresh and retry." in str(call)
+                for call in mock_warn.call_args_list
+            )
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_cert_check_without_cached_cert_skips_reconfiguration(self):
+        """Verifies that when cached_cert is None, cert check produces equal fingerprints and skips reconfiguration."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = None
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                new_callable=mock.AsyncMock,
+                return_value=(True, b"cert_bytes", b"key_bytes"),
+            ),
+            mock.patch(
+                "google.auth._agent_identity_utils.parse_certificate"
+            ),
+            mock.patch(
+                "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
+                return_value="FINGERPRINT_1",
+            ),
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+            mock.patch.object(sessions._LOGGER, "info") as mock_info,
+        ):
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+            assert resp == mock_resp_200
+            mock_conf.assert_not_called()
+            mock_creds.refresh.assert_called_once()
+            assert any(
+                "certificate has not changed" in str(call)
+                for call in mock_info.call_args_list
+            )
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_refresh_raises_invalid_operation_returns_401(self):
+        """Verifies that exceptions.InvalidOperation during refresh is caught and returns the 401 response."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(
+            side_effect=exceptions.InvalidOperation("Invalid operation")
+        )
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        resp = await session.request(
+            "GET", "https://example.com"
+        )
+        assert resp == mock_resp_401
+        mock_creds.refresh.assert_called_once()
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1553,3 +1553,55 @@ class TestSessionsMtls:
             assert session._cached_cert == b"cert_v1"
             assert session._auth_request is first_auth_req
             await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_credential_refresh_not_implemented_retries(self):
+        """Validate credentials that raise NotImplementedError on refresh()
+        still trigger a retry after mTLS reconfiguration, not return the 401."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(side_effect=NotImplementedError)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+        ) as mock_check:
+            with mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf:
+                mock_check.return_value = (
+                    b"new_cert",
+                    b"new_key",
+                    b"old_fp",
+                    b"new_fp",
+                )
+
+                resp = await session.request(
+                    "GET", "https://pubsub.mtls.googleapis.com/test"
+                )
+
+                # Validate that the handler falls through to `return None`
+                # on NotImplementedError in order to signal retry.
+                assert resp == mock_resp_200
+                mock_conf.assert_called_once()
+                mock_creds.refresh.assert_called_once()
+                assert mock_auth_req.call_count == 2
+                mock_resp_401.close.assert_called_once()
+
+        await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1181,8 +1181,8 @@ class TestSessionsMtls:
             )
 
             assert results == [mock_resp_200_1, mock_resp_200_2]
-            assert mock_check.call_count == 2
-            assert session._mtls_check_counter == 0
+            assert mock_check.call_count == 1
+            assert session._mtls_check_counter == 1
             assert mock_conf.call_count == 0
             assert mock_creds.refresh.call_count == 1
 
@@ -1663,3 +1663,139 @@ class TestSessionsMtls:
                 assert session._client_cert_callback is None
 
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_non_mtls_not_implemented_refresh_returns_401_without_retry(self):
+        """Verifies that non-mTLS 401s on credentials that raise NotImplementedError
+        return the 401 immediately without retrying."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(side_effect=NotImplementedError)
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(return_value=mock_resp_401)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+
+        resp = await session.request("GET", "https://example.com")
+        assert resp == mock_resp_401
+        assert mock_auth_req.call_count == 1
+        mock_creds.refresh.assert_called_once()
+        mock_resp_401.close.assert_not_called()
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_cert_rotation_credential_refresh_invalid_operation_retries(self):
+        """Verifies that when mTLS is reconfigured, credentials raising InvalidOperation
+        (e.g., StaticCredentials) still retry on the reconfigured mTLS channel."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(
+            side_effect=exceptions.InvalidOperation("Static credentials")
+        )
+
+        mock_resp_401 = mock.Mock()
+        mock_resp_401.status_code = http_client.UNAUTHORIZED
+        mock_resp_401.close = mock.AsyncMock()
+
+        mock_resp_200 = mock.Mock()
+        mock_resp_200.status_code = http_client.OK
+        mock_resp_200.close = mock.AsyncMock()
+
+        mock_auth_req = mock.AsyncMock(side_effect=[mock_resp_401, mock_resp_200])
+
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_req
+        )
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+
+        with (
+            mock.patch(
+                "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                new_callable=mock.AsyncMock,
+                return_value=(b"new_cert", b"new_key", b"old_fp", b"new_fp"),
+            ),
+            mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf,
+        ):
+            resp = await session.request(
+                "GET", "https://pubsub.mtls.googleapis.com/test"
+            )
+            assert resp == mock_resp_200
+            mock_conf.assert_called_once()
+            mock_creds.refresh.assert_called_once()
+            assert mock_auth_req.call_count == 2
+            mock_resp_401.close.assert_called_once()
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_reverts_to_default_when_callback_none(self):
+        """Tests that passing callback=None when a callback was previously set reconfigures back to ADC."""
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert", b"key"),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ),
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession"),
+        ):
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            def custom_cb():
+                return b"c", b"k"
+
+            await session.configure_mtls_channel(custom_cb)
+            assert session._client_cert_callback is custom_cb
+            task1 = session._mtls_init_task
+
+            # Revert to default
+            await session.configure_mtls_channel(None)
+            assert session._client_cert_callback is None
+            assert session._mtls_init_task is not task1
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_force_reconfigures_same_callback(self):
+        """Tests that force=True reconfigures even if callback is identical."""
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert", b"key"),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ),
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession"),
+        ):
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+
+            await session.configure_mtls_channel()
+            task1 = session._mtls_init_task
+
+            # Same callback with force=True
+            await session.configure_mtls_channel(force=True)
+            assert session._mtls_init_task is not task1
+            await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -183,7 +183,7 @@ class TestSessionsMtls:
             await session.close()
 
     @pytest.mark.asyncio
-    async def test_configure_mtls_channel_exception_resets_flag(self):
+    async def test_configure_mtls_channel_exception_preserves_flag(self):
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         session = sessions.AsyncAuthorizedSession(mock_creds)
         session._is_mtls = True
@@ -199,9 +199,9 @@ class TestSessionsMtls:
             ),
             pytest.raises(exceptions.MutualTLSChannelError),
         ):
-            await session.configure_mtls_channel()
-        assert session.is_mtls is False
-        assert session._cached_cert == None
+            await session.configure_mtls_channel(lambda: (b"new_cert", b"new_key"))
+        assert session.is_mtls is True
+        assert session._cached_cert == b"old_cert"
         await session.close()
 
     @pytest.mark.asyncio
@@ -1471,3 +1471,82 @@ class TestSessionsMtls:
         assert resp == mock_resp_401
         mock_creds.refresh.assert_called_once()
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_idempotent_when_called_repeatedly(self):
+        """Tests that calling configure_mtls_channel repeatedly without a new callback reuses the existing task."""
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert_bytes", b"key_bytes"),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ),
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession"),
+        ):
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+            await session.configure_mtls_channel()
+            assert session.is_mtls is True
+            first_auth_req = session._auth_request
+            first_task = session._mtls_init_task
+
+            # Call configure_mtls_channel again without new callback
+            await session.configure_mtls_channel()
+            assert session._auth_request is first_auth_req
+            assert session._mtls_init_task is first_task
+
+            # Call configure_mtls_channel with a new callback - should reconfigure
+            new_callback = lambda: (b"new_cert", b"new_key")
+            await session.configure_mtls_channel(new_callback)
+            assert session._auth_request is not first_auth_req
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_exception_preserves_existing_mtls_state(self):
+        """Tests that an exception during re-configuration does not clear existing is_mtls and cached_cert."""
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert_v1", b"key_v1"),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ),
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession"),
+        ):
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+            await session.configure_mtls_channel()
+            assert session.is_mtls is True
+            assert session._cached_cert == b"cert_v1"
+            first_auth_req = session._auth_request
+
+            # Now attempt reconfiguring with a failing callback/context
+            with (
+                mock.patch(
+                    "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                    side_effect=RuntimeError("Reconfig failure"),
+                ),
+                pytest.raises(exceptions.MutualTLSChannelError),
+            ):
+                await session.configure_mtls_channel(lambda: (b"cert_v2", b"key_v2"))
+
+            # Session should still retain its previous mTLS state and active auth_request
+            assert session.is_mtls is True
+            assert session._cached_cert == b"cert_v1"
+            assert session._auth_request is first_auth_req
+            await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1114,7 +1114,7 @@ class TestSessionsMtls:
         with mock.patch("time.monotonic", side_effect=mock_time):
             with pytest.raises(
                 exceptions.TimeoutError,
-                match="Timeout exceeded before retrying the request",
+                match=r"(Timeout exceeded before retrying the request|Context manager exceeded the configured timeout)",
             ):
                 await session.request(
                     "GET", "https://example.com", max_allowed_time=1.0
@@ -1663,4 +1663,3 @@ class TestSessionsMtls:
                 assert session._client_cert_callback is None
 
         await session.close()
-

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1069,7 +1069,7 @@ class TestSessionsMtls:
                 return 100.0
             return 0.1
 
-        with mock.patch("time.monotonic", side_effect=mock_time):
+        with mock.patch("google.auth.aio.transport.sessions.time.monotonic", side_effect=mock_time):
             with pytest.raises(
                 exceptions.TimeoutError,
                 match="Timeout exceeded before credential refresh could begin",

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1101,12 +1101,15 @@ class TestSessionsMtls:
             mock_creds, auth_request=mock_auth_request
         )
 
-        time_calls = [0.0, 0.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 100.0]
+        after_refresh_count = 0
 
         def mock_time():
-            if time_calls:
-                return time_calls.pop(0)
-            return 100.0
+            nonlocal after_refresh_count
+            if mock_creds.refresh.called:
+                after_refresh_count += 1
+                if after_refresh_count >= 2:
+                    return 100.0
+            return 0.1
 
         with mock.patch("time.monotonic", side_effect=mock_time):
             with pytest.raises(

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1111,7 +1111,7 @@ class TestSessionsMtls:
                     return 100.0
             return 0.1
 
-        with mock.patch("time.monotonic", side_effect=mock_time):
+        with mock.patch("google.auth.aio.transport.sessions.time.monotonic", side_effect=mock_time):
             with pytest.raises(
                 exceptions.TimeoutError,
                 match=r"(Timeout exceeded before retrying the request|Context manager exceeded the configured timeout)",

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -132,6 +132,125 @@ class TestSessionsMtls:
             await session.close()
 
     @pytest.mark.asyncio
+    async def test_configure_mtls_channel_mock_callback(self):
+        callback = mock.AsyncMock(return_value=(b"cert", b"key"))
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert", b"key"),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ) as mock_make_context,
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession"),
+        ):
+            mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+            await session.configure_mtls_channel(callback)
+            assert session.is_mtls is True
+            assert session._cached_cert == b"cert"
+            mock_make_context.assert_called_once_with(b"cert", b"key")
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_custom_request(self):
+        custom_req = mock.AsyncMock(spec=transport.Request)
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(mock_creds, auth_request=custom_req)
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert", b"key"),
+            ),
+            pytest.warns(
+                UserWarning,
+                match="Attempted to establish mTLS, but a custom async transport was provided",
+            ),
+        ):
+            await session.configure_mtls_channel()
+            assert session.is_mtls is False
+            assert session._cached_cert == None
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_exception_resets_flag(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(mock_creds)
+        session._is_mtls = True
+        session._cached_cert = b"old_cert"
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                side_effect=Exception("Disk failure"),
+            ),
+            pytest.raises(exceptions.MutualTLSChannelError),
+        ):
+            await session.configure_mtls_channel()
+        assert session.is_mtls is False
+        assert session._cached_cert == None
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_transport_error_resets_flag(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(mock_creds)
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                return_value=(True, b"cert", b"key"),
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ),
+            mock.patch("aiohttp.ClientSession", side_effect=Exception("Session error")),
+            pytest.raises(exceptions.MutualTLSChannelError),
+        ):
+            await session.configure_mtls_channel()
+        assert session.is_mtls is False
+        assert session._cached_cert == None
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_configure_mtls_channel_atomic_on_exception(self):
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        session = sessions.AsyncAuthorizedSession(mock_creds)
+        orig_req = session._auth_request
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                side_effect=RuntimeError("Fatal error"),
+            ),
+            pytest.raises(exceptions.MutualTLSChannelError),
+        ):
+            await session.configure_mtls_channel()
+        assert session._auth_request is orig_req
+        assert session.is_mtls is False
+        await session.close()
+
+    @pytest.mark.asyncio
     async def test_configure_mtls_channel_close_exception_does_not_abort(self):
         """Tests that an exception in old_auth_request.close() during eviction does not abort configuration."""
         with (
@@ -888,13 +1007,17 @@ class TestSessionsMtls:
         session._mtls_init_task = initial_task  # Pre-populate completed task
         new_cert = b"new_cert"
         new_key = b"new_key"
+
+        async def fake_configure(cb=None):
+            session._mtls_init_task = asyncio.create_task(dummy_completed())
+
         with (
             mock.patch(
                 "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
                 new_callable=mock.AsyncMock,
             ) as mock_check,
             mock.patch.object(
-                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+                session, "configure_mtls_channel", side_effect=fake_configure
             ) as mock_conf,
         ):
             mock_check.return_value = (new_cert, new_key, b"old_fp", b"new_fp")
@@ -918,21 +1041,36 @@ class TestSessionsMtls:
         """
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_auth_request = mock.AsyncMock(spec=transport.Request)
-        mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
-        current_time = 0.0
+        mock_resp_401 = mock.Mock(spec=transport.Response)
+        mock_resp_401.close = mock.AsyncMock()
 
-        # When the 401 request completes, advance time past max_allowed_time
+        status_access_count = 0
+
+        def get_status():
+            nonlocal status_access_count
+            status_access_count += 1
+            return 401
+
+        type(mock_resp_401).status_code = property(lambda self: get_status())
+
         async def fake_auth_request(*args, **kwargs):
-            nonlocal current_time
-            current_time = 100.0  # Expire timeout before refresh starts
             return mock_resp_401
 
         mock_auth_request.side_effect = fake_auth_request
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_request
         )
-        with mock.patch("time.monotonic", side_effect=lambda: current_time):
-            with pytest.raises(exceptions.TimeoutError):
+
+        def mock_time():
+            if status_access_count >= 2:
+                return 100.0
+            return 0.1
+
+        with mock.patch("time.monotonic", side_effect=mock_time):
+            with pytest.raises(
+                exceptions.TimeoutError,
+                match="Timeout exceeded before credential refresh could begin",
+            ):
                 await session.request(
                     "GET", "https://example.com", max_allowed_time=1.0
                 )
@@ -949,21 +1087,29 @@ class TestSessionsMtls:
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
         mock_auth_request = mock.AsyncMock(spec=transport.Request)
         mock_resp_401 = mock.Mock(spec=transport.Response, status_code=401)
+        mock_resp_401.close = mock.AsyncMock()
         mock_auth_request.return_value = mock_resp_401
-        current_time = 0.0
 
-        # Allow initial request to proceed at t=0.0, but expire timeout during refresh
         async def fake_refresh(auth_request):
-            nonlocal current_time
-            current_time = 100.0  # Expire timeout during refresh before retry
             return None
 
         mock_creds.refresh = mock.AsyncMock(side_effect=fake_refresh)
         session = sessions.AsyncAuthorizedSession(
             mock_creds, auth_request=mock_auth_request
         )
-        with mock.patch("time.monotonic", side_effect=lambda: current_time):
-            with pytest.raises(exceptions.TimeoutError):
+
+        time_calls = [0.0, 0.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 100.0]
+
+        def mock_time():
+            if time_calls:
+                return time_calls.pop(0)
+            return 100.0
+
+        with mock.patch("time.monotonic", side_effect=mock_time):
+            with pytest.raises(
+                exceptions.TimeoutError,
+                match="Timeout exceeded before retrying the request",
+            ):
                 await session.request(
                     "GET", "https://example.com", max_allowed_time=1.0
                 )
@@ -1029,8 +1175,8 @@ class TestSessionsMtls:
             )
 
             assert results == [mock_resp_200_1, mock_resp_200_2]
-            assert mock_check.call_count == 1
-            assert session._mtls_check_counter == 1
+            assert mock_check.call_count == 2
+            assert session._mtls_check_counter == 0
             assert mock_conf.call_count == 0
             assert mock_creds.refresh.call_count == 1
 
@@ -1126,3 +1272,74 @@ class TestSessionsMtls:
         assert not session._mtls_init_task.cancelled()
         assert session._is_mtls is True
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_mtls_rotation_e2e_unmocked_configure(self):
+        """End-to-end 401 recovery test with unmocked configure_mtls_channel."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        cert_v1 = b"cert_v1"
+        key_v1 = b"key_v1"
+        cert_v2 = b"cert_v2"
+        key_v2 = b"key_v2"
+
+        certs_queue = [(True, cert_v1, key_v1), (True, cert_v2, key_v2)]
+
+        async def mock_get_cert(cb=None):
+            if certs_queue:
+                return certs_queue.pop(0)
+            return (True, cert_v2, key_v2)
+
+        with (
+            mock.patch(
+                "google.auth.transport._mtls_helper.check_use_client_cert",
+                return_value=True,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.get_client_cert_and_key",
+                side_effect=mock_get_cert,
+            ),
+            mock.patch(
+                "google.auth.aio.transport.mtls.make_client_cert_ssl_context",
+                return_value=mock.Mock(spec=ssl.SSLContext),
+            ),
+            mock.patch("aiohttp.TCPConnector"),
+            mock.patch("aiohttp.ClientSession"),
+        ):
+            session = sessions.AsyncAuthorizedSession(mock_creds)
+            await session.configure_mtls_channel()
+            assert session.is_mtls is True
+            assert session._cached_cert == cert_v1
+            first_auth_req = session._auth_request
+
+            mock_resp_401 = mock.Mock()
+            mock_resp_401.status_code = http_client.UNAUTHORIZED
+            mock_resp_401.close = mock.AsyncMock()
+
+            mock_resp_200 = mock.Mock()
+            mock_resp_200.status_code = http_client.OK
+            mock_resp_200.close = mock.AsyncMock()
+
+            with (
+                mock.patch(
+                    "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+                    new_callable=mock.AsyncMock,
+                    return_value=(cert_v2, key_v2, b"fp1", b"fp2"),
+                ),
+                mock.patch.object(
+                    sessions.AiohttpRequest,
+                    "__call__",
+                    side_effect=[mock_resp_401, mock_resp_200],
+                ),
+            ):
+                resp = await session.request(
+                    "GET", "https://pubsub.mtls.googleapis.com/test"
+                )
+                assert resp.status_code == 200
+                assert session.is_mtls is True
+                assert session._cached_cert == cert_v2
+                assert session._auth_request is not first_auth_req
+                assert mock_creds.refresh.call_count == 1
+            await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1245,7 +1245,10 @@ class TestSessionsMtls:
         in the background.
         """
         mock_creds = mock.AsyncMock(spec=credentials.Credentials)
-        session = sessions.AsyncAuthorizedSession(mock_creds)
+        mock_auth_request = mock.AsyncMock(spec=transport.Request)
+        session = sessions.AsyncAuthorizedSession(
+            mock_creds, auth_request=mock_auth_request
+        )
         init_started = asyncio.Event()
         init_can_finish = asyncio.Event()
 

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -179,7 +179,7 @@ class TestSessionsMtls:
         ):
             await session.configure_mtls_channel()
             assert session.is_mtls is False
-            assert session._cached_cert == None
+            assert session._cached_cert is None
             await session.close()
 
     @pytest.mark.asyncio
@@ -226,7 +226,7 @@ class TestSessionsMtls:
         ):
             await session.configure_mtls_channel()
         assert session.is_mtls is False
-        assert session._cached_cert == None
+        assert session._cached_cert is None
         await session.close()
 
     @pytest.mark.asyncio
@@ -1425,9 +1425,7 @@ class TestSessionsMtls:
                 new_callable=mock.AsyncMock,
                 return_value=(True, b"cert_bytes", b"key_bytes"),
             ),
-            mock.patch(
-                "google.auth._agent_identity_utils.parse_certificate"
-            ),
+            mock.patch("google.auth._agent_identity_utils.parse_certificate"),
             mock.patch(
                 "google.auth._agent_identity_utils.calculate_certificate_fingerprint",
                 return_value="FINGERPRINT_1",
@@ -1468,9 +1466,7 @@ class TestSessionsMtls:
             mock_creds, auth_request=mock_auth_req
         )
 
-        resp = await session.request(
-            "GET", "https://example.com"
-        )
+        resp = await session.request("GET", "https://example.com")
         assert resp == mock_resp_401
         mock_creds.refresh.assert_called_once()
         await session.close()
@@ -1507,7 +1503,9 @@ class TestSessionsMtls:
             assert session._mtls_init_task is first_task
 
             # Call configure_mtls_channel with a new callback - should reconfigure
-            new_callback = lambda: (b"new_cert", b"new_key")
+            def new_callback():
+                return b"new_cert", b"new_key"
+
             await session.configure_mtls_channel(new_callback)
             assert session._auth_request is not first_auth_req
             await session.close()

--- a/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
+++ b/packages/google-auth/tests/transport/aio/test_sessions_mtls.py
@@ -1603,3 +1603,61 @@ class TestSessionsMtls:
                 mock_resp_401.close.assert_called_once()
 
         await session.close()
+
+    @pytest.mark.asyncio
+    async def test_401_mtls_consecutive_multi_rotation(self):
+        """Verifies that multiple consecutive rotations (v1 -> v2 -> v3) succeed."""
+        mock_creds = mock.AsyncMock(spec=credentials.Credentials)
+        mock_creds.before_request = mock.AsyncMock(return_value=None)
+        mock_creds.refresh = mock.AsyncMock(return_value=None)
+
+        session = sessions.AsyncAuthorizedSession(mock_creds)
+        session._is_mtls = True
+        session._cached_cert = b"cert_v1"
+
+        # Rotation 1: v1 -> v2
+        with mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+            return_value=(b"cert_v2", b"key_v2", b"fp1", b"fp2"),
+        ):
+            with mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf:
+                mock_auth = mock.AsyncMock(
+                    side_effect=[
+                        mock.Mock(status_code=401, close=mock.AsyncMock()),
+                        mock.Mock(status_code=200, close=mock.AsyncMock()),
+                    ]
+                )
+                session._auth_request = mock_auth
+                await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+                mock_conf.assert_called_once()
+                assert session._client_cert_callback is None
+
+        session._cached_cert = b"cert_v2"
+
+        # Rotation 2: v2 -> v3 (Must still have client_cert_callback == None to read disk)
+        with mock.patch(
+            "google.auth.aio.transport.mtls.check_parameters_for_unauthorized_response",
+            new_callable=mock.AsyncMock,
+            return_value=(b"cert_v3", b"key_v3", b"fp2", b"fp3"),
+        ) as mock_check:
+            with mock.patch.object(
+                session, "configure_mtls_channel", new_callable=mock.AsyncMock
+            ) as mock_conf:
+                mock_auth = mock.AsyncMock(
+                    side_effect=[
+                        mock.Mock(status_code=401, close=mock.AsyncMock()),
+                        mock.Mock(status_code=200, close=mock.AsyncMock()),
+                    ]
+                )
+                session._auth_request = mock_auth
+                await session.request("GET", "https://pubsub.mtls.googleapis.com/test")
+                # Verify check was called with callback=None (allowing disk read)
+                mock_check.assert_called_with(b"cert_v2", None)
+                mock_conf.assert_called_once()
+                assert session._client_cert_callback is None
+
+        await session.close()
+


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
Fixes #18227
---
### Overview

This PR resolves concurrency crashes, state desynchronization, and authentication recovery
regressions in `AsyncAuthorizedSession` during asynchronous mTLS initialization and certificate
rotation. It builds on and closes open gaps from #18224 and #18334.

### 1. Initialization concurrency

- `configure_mtls_channel()` performs its decide-and-create step under a new `_mtls_init_lock`,
  so two concurrent callers cannot both spawn a configuration task and clobber `self._auth_request`.
- The previous `except (Exception, CancelledError): pass` is gone. Retiring an in-flight task now
  uses `await asyncio.wait({old_task})`, which absorbs *that task's* cancellation without
  swallowing a cancellation aimed at the caller.
- Callers `await asyncio.shield(task)`. On a task replacement the waiter re-reads
  `_mtls_init_task` **under the init lock** and follows the replacement, rather than surfacing a
  spurious `CancelledError`. Re-reading without the lock does not work: the reconfigurer cancels
  the old task and then yields, so the waiter wakes while `_mtls_init_task` is still the old task.
- Configuration tasks carry a `_retrieve_task_exception` done-callback so a failure with no
  awaiter does not produce an "exception was never retrieved" warning.
- `check_use_client_cert` is now inside the `try`, so a failure there raises the documented
  `MutualTLSChannelError` rather than leaking an arbitrary exception type.

### 2. Rotation state is session-level, not coroutine-local

- `channel_reconfigured` was a coroutine-local flag, so a request that did not personally perform
  the rotation returned a stale 401 with credentials it believed were unrefreshable. It is now
  derived from a session-level `_mtls_reconfig_counter` snapshotted per request, so a request
  whose rotation was performed by a concurrent peer still retries on the new channel.
- Rotation no longer swaps the shared `self._client_cert_callback` with a temporary lambda. The
  rotated cert/key are passed through an internal `_cert_key_override` parameter, so concurrent
  callers cannot observe or clobber the shared callback.
- `_reset_non_mtls_state()` retires the stale mTLS transport when mTLS flips off; previously it
  was kept and reused.
- An `assert` in production code (stripped under `python -O`) was removed.

### 3. Refresh de-duplication is generation-aware

Counting refresh *completions* cannot express "was this token minted on the current channel." A
refresh that **started before** a rotation and **finished after** it was credited as
post-rotation, so the rotating coroutine skipped its mandatory refresh and retried with a token
minted over the old transport.

`_refresh_counter_at_last_reconfig` is replaced by `_last_refresh_reconfig_gen`, which records the
reconfiguration generation observed when a refresh **starts**. A concurrent refresh is treated as
redundant only if it both completed after this request's 401 *and* began on the channel we are
about to retry on.

### 4. Rotation-failure de-duplication semantics

`_mtls_check_counter` is incremented unconditionally when the *parameter check* fails
(`ClientCertError`, `OSError`, `ValueError`, `TypeError`, `ImportError`), so queued coroutines skip
a redundant validation spike and fall back to refresh-and-retry.

It is deliberately **not** incremented when the *reconfiguration itself* fails — that path raises
`MutualTLSChannelError`, and a queued coroutine should retry the reconfiguration rather than
inherit another request's transient failure.

### 5. Teardown

- `close()` sets a `_closed` flag under `_mtls_init_lock` and cancels any pending initialization
  task with `asyncio.wait()` rather than the old cancellation-swallowing pattern.
- **Behavior change:** `configure_mtls_channel()` now raises `exceptions.InvalidOperation` on a
  closed session. Without this, a rotation in flight during `close()` installed a fresh
  `ClientSession` *after* close had already drained everything, leaking a live transport and
  leaving `is_mtls` true on a closed session.
- `close()` drains `_old_auth_requests` and the active `_auth_request` in `finally` blocks.

### 6. Fingerprint symmetry

`mtls.check_parameters_for_unauthorized_response()` defaults `cached_fingerprint =
current_fingerprint` when `cached_cert` is `None`, so "no cached cert" no longer triggers a
spurious rotation.

---

### Verification

- Test count for this module: 27 → 58.

### Known pre-existing gap (not addressed here)

`AsyncAuthorizedSession` does not implement `__aenter__`/`__aexit__`, so the `async with` form
shown in its own class docstring raises `TypeError`. This predates this PR and is unrelated to rotation — the sibling
`transport.requests.AuthorizedSession` and `transport._aiohttp_requests.AuthorizedSession` inherit
the protocol from their base classes, while this class is standalone. Adding it is a `feat:` and
would bump this `fix:` PR to a minor release, so it is better filed separately. Nothing is
stranded by the current behavior: `AiohttpRequest` creates its `ClientSession` lazily, so the
`TypeError` is raised before any socket exists. 